### PR TITLE
Add option to skip tls verification

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -21,10 +21,24 @@ import (
 	"testing"
 
 	"github.com/minio/madmin-go"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func TestMinioAdminClient(t *testing.T) {
 	_, err := madmin.New("localhost:9000", "food", "food123", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMinioAdminClientWithOpts(t *testing.T) {
+	creds := credentials.NewStaticV4("food", "food123", "")
+	opts := madmin.Options{
+		Creds:              creds,
+		Secure:             true,
+		InsecureSkipVerify: true,
+	}
+	_, err := madmin.NewWithOptions("localhost:9000", &opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport.go
+++ b/transport.go
@@ -26,7 +26,7 @@ import (
 // DefaultTransport - this default transport is similar to
 // http.DefaultTransport but with additional param  DisableCompression
 // is set to true to avoid decompressing content with 'gzip' encoding.
-var DefaultTransport = func(secure bool) http.RoundTripper {
+var DefaultTransport = func(secure, skip bool) http.RoundTripper {
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -54,7 +54,8 @@ var DefaultTransport = func(secure bool) http.RoundTripper {
 			// Can't use SSLv3 because of POODLE and BEAST
 			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
 			// Can't use TLSv1.1 because of RC4 cipher usage
-			MinVersion: tls.VersionTLS12,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: skip,
 		}
 	}
 	return tr


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>

madmin-go does not support skipping insecure verification.

This PR adds support for skipping the tls verification when using madmin-go client.