### PR TITLE
procinfo: Do not treat username issue as an error

### DIFF
--- a/health.go
+++ b/health.go
@@ -667,11 +667,9 @@ func GetProcInfo(ctx context.Context, addr string) ProcInfo {
 		return procInfo
 	}
 
-	procInfo.Username, err = proc.UsernameWithContext(ctx)
-	if err != nil {
-		procInfo.Error = err.Error()
-		return procInfo
-	}
+	// In certain environments, it is not possible to get username e.g. minio-operator
+	// Plus it's not a serious error. So ignore error if any.
+	procInfo.Username, _ = proc.UsernameWithContext(ctx)
 
 	return procInfo
 }

--- a/health.go
+++ b/health.go
@@ -669,7 +669,10 @@ func GetProcInfo(ctx context.Context, addr string) ProcInfo {
 
 	// In certain environments, it is not possible to get username e.g. minio-operator
 	// Plus it's not a serious error. So ignore error if any.
-	procInfo.Username, _ = proc.UsernameWithContext(ctx)
+	procInfo.Username, err = proc.UsernameWithContext(ctx)
+	if err != nil {
+		procInfo.Username = "<non-root>"
+	}
 
 	return procInfo
 }


### PR DESCRIPTION
If the system cannot fetch username of the minio process owner, it gets
reported as an error in the health report. However, this can happen for
legitimate reasons (e.g. in minio-operator based environments) and is
not something that needs to be flagged as an error.

Fixed by ignoring error when trying to get the username