### PR TITLE
Add IsKubernetes and IsDocker to MinioInfo

### DIFF
--- a/health.go
+++ b/health.go
@@ -791,6 +791,8 @@ type MinioInfo struct {
 	Backend      interface{}  `json:"backend,omitempty"`
 	Servers      []ServerInfo `json:"servers,omitempty"`
 	TLS          *TLSInfo     `json:"tls"`
+	IsKubernetes bool         `json:"is_kubernetes"`
+	IsDocker     bool         `json:"is_docker"`
 }
 
 type TLSInfo struct {

--- a/health.go
+++ b/health.go
@@ -791,8 +791,8 @@ type MinioInfo struct {
 	Backend      interface{}  `json:"backend,omitempty"`
 	Servers      []ServerInfo `json:"servers,omitempty"`
 	TLS          *TLSInfo     `json:"tls"`
-	IsKubernetes bool         `json:"is_kubernetes"`
-	IsDocker     bool         `json:"is_docker"`
+	IsKubernetes *bool        `json:"is_kubernetes"`
+	IsDocker     *bool        `json:"is_docker"`
 }
 
 type TLSInfo struct {


### PR DESCRIPTION
So that this info can be added in the health info and health-analyzer
can use it to perform or skip certain checks.