### PR TITLE
Add TimeInfo struct

### DIFF
--- a/health.go
+++ b/health.go
@@ -263,6 +263,13 @@ type OSInfo struct {
 	Sensors []host.TemperatureStat `json:"sensors,omitempty"`
 }
 
+// TimeInfo contains current time in UTC
+type TimeInfo struct {
+	NodeCommon
+
+	CurrentTime time.Time `json:"current_time"`
+}
+
 // GetOSInfo returns linux only operating system's information.
 func GetOSInfo(ctx context.Context, addr string) OSInfo {
 	if runtime.GOOS != "linux" {
@@ -495,6 +502,15 @@ type ProcInfo struct {
 	Times          cpu.TimesStat              `json:"times,omitempty"`
 	UIDs           []int32                    `json:"uids,omitempty"`
 	Username       string                     `json:"username,omitempty"`
+}
+
+// GetTimeInfo returns the current time on the host
+func GetTimeInfo(ctx context.Context, addr string) TimeInfo {
+	timeInfo := TimeInfo{
+		NodeCommon:  NodeCommon{Addr: addr},
+		CurrentTime: time.Now().UTC(),
+	}
+	return timeInfo
 }
 
 // GetProcInfo returns current MinIO process information.


### PR DESCRIPTION
Will be used to return the current time from a given host.

This will be used to collect the current time from all nodes and compare
them to verify if NTP has not been configured resulting in unreasonable
differences.