### PR TITLE
Change XL Disk API latency to integer

### DIFF
--- a/info-commands.go
+++ b/info-commands.go
@@ -331,9 +331,9 @@ type ServerProperties struct {
 
 // DiskMetrics has the information about XL Storage APIs
 // the number of calls of each API and the moving average of
-// the duration of each API.
+// the duration, in nanosecond, of each API.
 type DiskMetrics struct {
-	APILatencies map[string]string `json:"apiLatencies,omitempty"`
+	APILatencies map[string]uint64 `json:"apiLatencies,omitempty"`
 	APICalls     map[string]uint64 `json:"apiCalls,omitempty"`
 }
 

--- a/info-commands.go
+++ b/info-commands.go
@@ -333,8 +333,8 @@ type ServerProperties struct {
 // the number of calls of each API and the moving average of
 // the duration, in nanosecond, of each API.
 type DiskMetrics struct {
-	APILatencies map[string]uint64 `json:"apiLatencies,omitempty"`
-	APICalls     map[string]uint64 `json:"apiCalls,omitempty"`
+	APILatencies map[string]interface{} `json:"apiLatencies,omitempty"`
+	APICalls     map[string]uint64      `json:"apiCalls,omitempty"`
 }
 
 // Disk holds Disk information


### PR DESCRIPTION
Having the latency in string does not help consuming by another code.
Modify it to integer, duration in nanosecond.


We need to release minio then release mc with madmin-go after this is getting merged.