### PR TITLE
Add Error field to SpeedTestResults

### DIFF
--- a/health.go
+++ b/health.go
@@ -713,6 +713,7 @@ type SpeedTestResults struct {
 	DrivePerf []DriveSpeedTestResult `json:"drive,omitempty"`
 	ObjPerf   []SpeedTestResult      `json:"obj,omitempty"`
 	NetPerf   []NetperfNodeResult    `json:"net,omitempty"`
+	Error     string                 `json:"error,omitempty"`
 }
 
 // MinioConfig contains minio configuration of a node.


### PR DESCRIPTION
Can be populated if there are any errors when running speedtest
e.g. if lock can't be acquired before netperf