### PR TITLE
Change key names in health data type map

### DIFF
--- a/health.go
+++ b/health.go
@@ -868,9 +868,9 @@ const (
 
 // HealthDataTypesMap - Map of Health datatypes
 var HealthDataTypesMap = map[string]HealthDataType{
-	"perfdrive":   HealthDataTypePerfDrive,
-	"perfnet":     HealthDataTypePerfNet,
-	"perfobj":     HealthDataTypePerfObj,
+	"driveperf":   HealthDataTypePerfDrive,
+	"netperf":     HealthDataTypePerfNet,
+	"objperf":     HealthDataTypePerfObj,
 	"minioinfo":   HealthDataTypeMinioInfo,
 	"minioconfig": HealthDataTypeMinioConfig,
 	"syscpu":      HealthDataTypeSysCPU,


### PR DESCRIPTION
The names for perf related tests were changed from perfdrive to
driveperf and perfnet to netperf, but corresponding entries were not
updated in HealthDataTypesMap.
  
Because of this, the `--test` flag of the `mc support diag` command
continues to expect old values. (This is a hidden flag)
  
Fixed by updating the required entries.