### PR TITLE
usage: Add per bucket versions count

### DIFF
--- a/info-commands.go
+++ b/info-commands.go
@@ -142,6 +142,7 @@ type BucketUsageInfo struct {
 	ReplicationPendingCount uint64 `json:"objectsPendingReplicationCount"`
 	ReplicationFailedCount  uint64 `json:"objectsFailedReplicationCount"`
 
+	VersionsCount        uint64            `json:"versionsCount"`
 	ObjectsCount         uint64            `json:"objectsCount"`
 	ObjectSizesHistogram map[string]uint64 `json:"objectsSizesHistogram"`
 }


### PR DESCRIPTION
The server provides per bucket versions count but this library is
ignoring it. This commit makes sure to unmarshal it.