### PR TITLE
Add subnet registration structs

### DIFF
--- a/register.go
+++ b/register.go
@@ -1,0 +1,57 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package madmin
+
+// ClusterRegistrationReq - JSON payload of the subnet api for cluster registration
+// Contains a registration token created by base64 encoding  of the registration info
+type ClusterRegistrationReq struct {
+	Token string `json:"token"`
+}
+
+// ClusterRegistrationInfo - Information stored in the cluster registration token
+type ClusterRegistrationInfo struct {
+	DeploymentID string      `json:"deployment_id"`
+	ClusterName  string      `json:"cluster_name"`
+	UsedCapacity uint64      `json:"used_capacity"`
+	Info         ClusterInfo `json:"info"`
+}
+
+// ClusterInfo - The "info" sub-node of the cluster registration information struct
+// Intended to be extensible i.e. more fields will be added as and when required
+type ClusterInfo struct {
+	MinioVersion    string `json:"minio_version"`
+	NoOfServerPools int    `json:"no_of_server_pools"`
+	NoOfServers     int    `json:"no_of_servers"`
+	NoOfDrives      int    `json:"no_of_drives"`
+	NoOfBuckets     uint64 `json:"no_of_buckets"`
+	NoOfObjects     uint64 `json:"no_of_objects"`
+	TotalDriveSpace uint64 `json:"total_drive_space"`
+	UsedDriveSpace  uint64 `json:"used_drive_space"`
+}
+
+// SubnetLoginReq - JSON payload of the SUBNET login api
+type SubnetLoginReq struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// SubnetMFAReq - JSON payload of the SUBNET mfa api
+type SubnetMFAReq struct {
+	Username string `json:"username"`
+	OTP      string `json:"otp"`
+	Token    string `json:"token"`
+}


### PR DESCRIPTION
These belong here, so they can be accessed without importing `mc/cmd`, by for example console.

Followup with `mc`+`console` removal once added.