### PR TITLE
Implement cluster health API to check the cluster health

### DIFF
--- a/anonymous-api.go
+++ b/anonymous-api.go
@@ -1,0 +1,258 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package madmin
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+	"golang.org/x/net/publicsuffix"
+)
+
+// anonymousClient implements a simple HTTP client
+type anonymousClient struct {
+	// Parsed endpoint url provided by the caller
+	endpointURL *url.URL
+	// Indicate whether we are using https or not
+	secure bool
+	// Needs allocation.
+	httpClient *http.Client
+	// Advanced functionality.
+	isTraceEnabled bool
+	traceOutput    io.Writer
+}
+
+// newAnonymousClient can be used for anonymous APIs without credentials set
+func newAnonymousClient(endpoint string, secure bool, enableTrace bool) (*anonymousClient, error) {
+	// Initialize cookies to preserve server sent cookies if any and replay
+	// them upon each request.
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, err
+	}
+
+	// construct endpoint.
+	endpointURL, err := getEndpointURL(endpoint, secure)
+	if err != nil {
+		return nil, err
+	}
+
+	clnt := new(anonymousClient)
+
+	// Remember whether we are using https or not
+	clnt.secure = secure
+
+	// Save endpoint URL, user agent for future uses.
+	clnt.endpointURL = endpointURL
+
+	if enableTrace {
+		// Sets a new output stream.
+		clnt.traceOutput = os.Stdout
+		// Enable tracing.
+		clnt.isTraceEnabled = true
+	}
+
+	// Instantiate http client and bucket location cache.
+	clnt.httpClient = &http.Client{
+		Jar:       jar,
+		Transport: DefaultTransport(secure),
+	}
+
+	return clnt, nil
+}
+
+// executeMethod - does a simple http request to the target with parameters provided in the request
+func (an anonymousClient) executeMethod(ctx context.Context, method string, reqData requestData) (res *http.Response, err error) {
+	defer func() {
+		if err != nil {
+			// close idle connections before returning, upon error.
+			an.httpClient.CloseIdleConnections()
+		}
+	}()
+
+	// Instantiate a new request.
+	var req *http.Request
+	req, err = an.newRequest(ctx, method, reqData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initiate the request.
+	res, err = an.do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, err
+}
+
+// newRequest - instantiate a new HTTP request for a given method.
+func (an anonymousClient) newRequest(ctx context.Context, method string, reqData requestData) (req *http.Request, err error) {
+	// If no method is supplied default to 'POST'.
+	if method == "" {
+		method = "POST"
+	}
+
+	// Construct a new target URL.
+	targetURL, err := an.makeTargetURL(reqData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize a new HTTP request for the method.
+	req, err = http.NewRequestWithContext(ctx, method, targetURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range reqData.customHeaders {
+		req.Header.Set(k, v[0])
+	}
+	if length := len(reqData.content); length > 0 {
+		req.ContentLength = int64(length)
+	}
+	sum := sha256.Sum256(reqData.content)
+	req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sum[:]))
+	req.Body = ioutil.NopCloser(bytes.NewReader(reqData.content))
+
+	return req, nil
+}
+
+// makeTargetURL make a new target url.
+func (an anonymousClient) makeTargetURL(r requestData) (*url.URL, error) {
+	host := an.endpointURL.Host
+	scheme := an.endpointURL.Scheme
+
+	urlStr := scheme + "://" + host + r.relPath
+
+	// If there are any query values, add them to the end.
+	if len(r.queryValues) > 0 {
+		urlStr = urlStr + "?" + s3utils.QueryEncode(r.queryValues)
+	}
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// do - execute http request.
+func (an anonymousClient) do(req *http.Request) (*http.Response, error) {
+	resp, err := an.httpClient.Do(req)
+	if err != nil {
+		// Handle this specifically for now until future Golang versions fix this issue properly.
+		if urlErr, ok := err.(*url.Error); ok {
+			if strings.Contains(urlErr.Err.Error(), "EOF") {
+				return nil, &url.Error{
+					Op:  urlErr.Op,
+					URL: urlErr.URL,
+					Err: errors.New("Connection closed by foreign host " + urlErr.URL + ". Retry again."),
+				}
+			}
+		}
+		return nil, err
+	}
+
+	// Response cannot be non-nil, report if its the case.
+	if resp == nil {
+		msg := "Response is empty. " // + reportIssue
+		return nil, ErrInvalidArgument(msg)
+	}
+
+	// If trace is enabled, dump http request and response.
+	if an.isTraceEnabled {
+		err = an.dumpHTTP(req, resp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}
+
+// dumpHTTP - dump HTTP request and response.
+func (an anonymousClient) dumpHTTP(req *http.Request, resp *http.Response) error {
+	// Starts http dump.
+	_, err := fmt.Fprintln(an.traceOutput, "---------START-HTTP---------")
+	if err != nil {
+		return err
+	}
+
+	// Only display request header.
+	reqTrace, err := httputil.DumpRequestOut(req, false)
+	if err != nil {
+		return err
+	}
+
+	// Write request to trace output.
+	_, err = fmt.Fprint(an.traceOutput, string(reqTrace))
+	if err != nil {
+		return err
+	}
+
+	// Only display response header.
+	var respTrace []byte
+
+	// For errors we make sure to dump response body as well.
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusPartialContent &&
+		resp.StatusCode != http.StatusNoContent {
+		respTrace, err = httputil.DumpResponse(resp, true)
+		if err != nil {
+			return err
+		}
+	} else {
+		// WORKAROUND for https://github.com/golang/go/issues/13942.
+		// httputil.DumpResponse does not print response headers for
+		// all successful calls which have response ContentLength set
+		// to zero. Keep this workaround until the above bug is fixed.
+		if resp.ContentLength == 0 {
+			var buffer bytes.Buffer
+			if err = resp.Header.Write(&buffer); err != nil {
+				return err
+			}
+			respTrace = buffer.Bytes()
+			respTrace = append(respTrace, []byte("\r\n")...)
+		} else {
+			respTrace, err = httputil.DumpResponse(resp, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	// Write response to trace output.
+	_, err = fmt.Fprint(an.traceOutput, strings.TrimSuffix(string(respTrace), "\r\n"))
+	if err != nil {
+		return err
+	}
+
+	// Ends the http dump.
+	_, err = fmt.Fprintln(an.traceOutput, "---------END-HTTP---------")
+	return err
+}

--- a/cluster-health.go
+++ b/cluster-health.go
@@ -1,0 +1,129 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package madmin
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	minioWriteQuorumHeader     = "x-minio-write-quorum"
+	minIOHealingDrives         = "x-minio-healing-drives"
+	clusterCheckEndpoint       = "/minio/health/cluster"
+	clusterReadCheckEndpoint   = "/minio/health/cluster/read"
+	maintanenceURLParameterKey = "maintenance"
+)
+
+// HealthResult represents the cluster health result
+type HealthResult struct {
+	Healthy         bool
+	MaintenanceMode bool
+	WriteQuorum     int
+	HealingDrives   int
+}
+
+// HealthOpts represents the input options for the health check
+type HealthOpts struct {
+	ClusterRead bool
+	Maintenance bool
+	Trace       bool
+}
+
+// Healthy will hit `/minio/health/cluster` and `/minio/health/cluster/ready` anonymous APIs to check the cluster health
+func Healthy(ctx context.Context, endpoint string, opts HealthOpts) (result HealthResult, err error) {
+	var targetURL *url.URL
+	targetURL, err = url.Parse(endpoint)
+	if err != nil {
+		return HealthResult{}, err
+	}
+
+	secure := targetURL.Scheme == "https"
+	anonymousClient, err := newAnonymousClient(targetURL.Host, secure, opts.Trace)
+	if err != nil {
+		return HealthResult{}, err
+	}
+
+	if opts.ClusterRead {
+		return anonymousClient.clusterReadCheck(ctx)
+	}
+	return anonymousClient.clusterCheck(ctx, opts.Maintenance)
+}
+
+func (an *anonymousClient) clusterCheck(ctx context.Context, maintenance bool) (result HealthResult, err error) {
+	urlValues := make(url.Values)
+	if maintenance {
+		urlValues.Set(maintanenceURLParameterKey, "true")
+	}
+
+	resp, err := an.executeMethod(ctx, http.MethodGet, requestData{
+		relPath:     clusterCheckEndpoint,
+		queryValues: urlValues,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return result, err
+	}
+
+	if resp != nil {
+		writeQuorumStr := resp.Header.Get(minioWriteQuorumHeader)
+		if writeQuorumStr != "" {
+			result.WriteQuorum, err = strconv.Atoi(writeQuorumStr)
+			if err != nil {
+				return result, err
+			}
+		}
+		healingDrivesStr := resp.Header.Get(minIOHealingDrives)
+		if healingDrivesStr != "" {
+			result.HealingDrives, err = strconv.Atoi(healingDrivesStr)
+			if err != nil {
+				return result, err
+			}
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			result.Healthy = true
+		case http.StatusPreconditionFailed:
+			result.MaintenanceMode = true
+		default:
+			// Not Healthy
+		}
+	}
+	return result, nil
+}
+
+func (an *anonymousClient) clusterReadCheck(ctx context.Context) (result HealthResult, err error) {
+	resp, err := an.executeMethod(ctx, http.MethodGet, requestData{
+		relPath: clusterReadCheckEndpoint,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return result, err
+	}
+
+	if resp != nil {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			result.Healthy = true
+		default:
+			// Not Healthy
+		}
+	}
+	return result, nil
+}

--- a/examples/cluster-health.go
+++ b/examples/cluster-health.go
@@ -1,0 +1,41 @@
+//go:build ignore
+// +build ignore
+
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/minio/madmin-go"
+)
+
+// Note: This is an anonymous API which doesn't require any credentials
+func main() {
+	opts := madmin.HealthOpts{
+		ClusterRead: false, // set to "true" to check if the cluster has read quorum
+		Maintenance: false, // set to "true" to check if the cluster is taken down for maintenance
+		Trace:       false, // set to "true" to enable trace
+	}
+	healthResult, err := madmin.Healthy(context.Background(), "https://your-minio.example.com:9000", opts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(healthResult)
+}


### PR DESCRIPTION
Introduces a function `Healthy(ctx context.Context, endpoint string, opts HealthOpts) (result HealthResult, err error)` which makes an anonymous request to the following cluster readiness endpoints

 (*) /minio/health/cluster
 (*) /minio/health/cluster/read