### PR TITLE
reply from all the servers in the cluster

### DIFF
--- a/cluster-health.go
+++ b/cluster-health.go
@@ -156,19 +156,22 @@ func (an *AnonymousClient) Alive(ctx context.Context, opts AliveOpts, servers ..
 			})
 			responseTime := time.Since(t)
 			closeResponse(resp)
+
+			var result AliveResult
 			if err != nil {
-				resultsCh <- AliveResult{
+				result = AliveResult{
 					Endpoint:     u,
 					Error:        err,
 					ResponseTime: responseTime,
 				}
-				return
+			} else {
+				result = AliveResult{
+					Endpoint:     u,
+					ResponseTime: responseTime,
+					Online:       resp.StatusCode == http.StatusOK && resp.Header.Get("x-minio-server-status") != "offline",
+				}
 			}
-			result := AliveResult{
-				Endpoint:     u,
-				ResponseTime: responseTime,
-				Online:       resp.StatusCode == http.StatusOK && resp.Header.Get("x-minio-server-status") != "offline",
-			}
+
 			select {
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
mc ping command used `Alive()` method . 
The present implementation returns in case of error. 
Ideally it should check the status of all the server and send it to channel.

The output format  of mc ping is as shown below 
```
1: 127.0.0.1:9000   min=4.2 ms   max=41.2 ms   average=41.2 ms  errors=0 roundtrip=41.2 ms 
1: 127.0.0.1:9001   min=4.2 ms   max=41.2 ms   average=41.2 ms  errors=0 roundtrip=41.2 ms 
1: 127.0.0.1:9002   min=4.2 ms   max=41.2 ms   average=41.2 ms  errors=1 
1: 127.0.0.1:9003   min=4.2 ms   max=41.2 ms   average=41.2 ms  errors=0 roundtrip=41.2 ms 
```
With the present implementation of Alive method , if any server has error , the  result is returned , other servers are not even checked even though they are up and running .

But for mc ping we need the output of all the servers .