### PR TITLE
Return the status of node configured for anonymous client in Alive

### DIFF
--- a/cluster-health.go
+++ b/cluster-health.go
@@ -142,17 +142,17 @@ func (an *AnonymousClient) Alive(ctx context.Context, opts AliveOpts, servers ..
 	go func() {
 		defer close(resultsCh)
 		if len(servers) == 0 {
-			an.fetchData(ctx, an.endpointURL, resource, resultsCh)
+			an.alive(ctx, an.endpointURL, resource, resultsCh)
 		} else {
 			for _, server := range servers {
 				u, err := url.Parse(an.endpointURL.Scheme + "://" + server.Endpoint)
-				an.fetchData(ctx, u, resource, resultsCh)
 				if err != nil {
 					resultsCh <- AliveResult{
 						Error: err,
 					}
 					return
 				}
+				an.alive(ctx, u, resource, resultsCh)
 
 			}
 		}
@@ -161,7 +161,7 @@ func (an *AnonymousClient) Alive(ctx context.Context, opts AliveOpts, servers ..
 	return resultsCh
 }
 
-func (an *AnonymousClient) fetchData(ctx context.Context, u *url.URL, resource string, resultsCh chan AliveResult) {
+func (an *AnonymousClient) alive(ctx context.Context, u *url.URL, resource string, resultsCh chan AliveResult) {
 	t := time.Now()
 	resp, err := an.executeMethod(ctx, http.MethodGet, requestData{
 		relPath:          resource,

--- a/cluster-health.go
+++ b/cluster-health.go
@@ -150,7 +150,7 @@ func (an *AnonymousClient) Alive(ctx context.Context, opts AliveOpts, servers ..
 					resultsCh <- AliveResult{
 						Error: err,
 					}
-					return
+					continue
 				}
 				an.alive(ctx, u, resource, resultsCh)
 

--- a/examples/alive.go
+++ b/examples/alive.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/minio/madmin-go"
 )

--- a/user-commands.go
+++ b/user-commands.go
@@ -351,7 +351,7 @@ func (adm *AdminClient) AddServiceAccount(ctx context.Context, opts AddServiceAc
 type UpdateServiceAccountReq struct {
 	NewPolicy    json.RawMessage `json:"newPolicy,omitempty"` // Parsed policy from iam/policy.Parse
 	NewSecretKey string          `json:"newSecretKey,omitempty"`
-	NewStatus    string          `json:"newStatus,omityempty"`
+	NewStatus    string          `json:"newStatus,omitempty"`
 }
 
 // UpdateServiceAccount - edit an existing service account


### PR DESCRIPTION
Return the status of the node that receives the request if there is no specified servers list.
This change is done for `mc ping ` command to return the status of the node which is configured as alias , when an empty list is passed to Alive() function.

Refer https://github.com/minio/mc/pull/4163#discussion_r934289349
