### PR TITLE
Inspect to return a new format

### DIFF
--- a/api.go
+++ b/api.go
@@ -496,7 +496,7 @@ func (adm AdminClient) newRequest(ctx context.Context, method string, reqData re
 	}
 
 	// Initialize a new HTTP request for the method.
-	req, err = http.NewRequestWithContext(ctx, method, targetURL.String(), nil)
+	req, err = http.NewRequestWithContext(ctx, method, targetURL.String(), bytes.NewReader(reqData.content))
 	if err != nil {
 		return nil, err
 	}

--- a/inspect.go
+++ b/inspect.go
@@ -18,6 +18,7 @@ package madmin
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -28,43 +29,68 @@ import (
 // InspectOptions provides options to Inspect.
 type InspectOptions struct {
 	Volume, File string
+	PublicKey    []byte
 }
 
 // Inspect makes an admin call to download a raw files from disk.
-func (adm *AdminClient) Inspect(ctx context.Context, d InspectOptions) (key [32]byte, c io.ReadCloser, err error) {
-	path := fmt.Sprintf(adminAPIPrefix + "/inspect-data")
-	q := make(url.Values)
-	q.Set("volume", d.Volume)
-	q.Set("file", d.File)
-	resp, err := adm.executeMethod(ctx,
-		http.MethodGet, requestData{
-			relPath:     path,
-			queryValues: q,
-		},
-	)
+func (adm *AdminClient) Inspect(ctx context.Context, d InspectOptions) (key []byte, c io.ReadCloser, err error) {
+	// Add form key/values in the body
+	form := make(url.Values)
+	form.Set("volume", d.Volume)
+	form.Set("file", d.File)
+	if d.PublicKey != nil {
+		form.Set("public-key", base64.StdEncoding.EncodeToString(d.PublicKey))
+	}
+
+	method := ""
+	reqData := requestData{
+		relPath: fmt.Sprintf(adminAPIPrefix + "/inspect-data"),
+	}
+
+	// If the public-key is specified, create a POST request and send
+	// parameters as multipart-form instead of query values
+	if d.PublicKey != nil {
+		method = http.MethodPost
+		reqData.customHeaders = make(http.Header)
+		reqData.customHeaders.Set("Content-Type", "application/x-www-form-urlencoded")
+		reqData.content = []byte(form.Encode())
+	} else {
+		method = http.MethodGet
+		reqData.queryValues = form
+	}
+
+	resp, err := adm.executeMethod(ctx, method, reqData)
 	if err != nil {
-		return key, nil, err
+		return nil, nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		closeResponse(resp)
-		return key, nil, httpRespToErrorResponse(resp)
+		return nil, nil, httpRespToErrorResponse(resp)
 	}
-	_, err = io.ReadFull(resp.Body, key[:1])
+
+	var p [1]byte
+	_, err = io.ReadFull(resp.Body, p[:])
 	if err != nil {
 		closeResponse(resp)
-		return key, nil, err
+		return nil, nil, err
 	}
-	// This is the only version we know.
-	if key[0] != 1 {
+
+	format := p[0]
+	switch format {
+	case 1:
+		key = make([]byte, 32)
+		// Read key...
+		_, err = io.ReadFull(resp.Body, key[:])
+		if err != nil {
+			closeResponse(resp)
+			return nil, nil, err
+		}
+	case 2:
+	default:
 		closeResponse(resp)
-		return key, nil, errors.New("unknown data version")
-	}
-	// Read key...
-	_, err = io.ReadFull(resp.Body, key[:])
-	if err != nil {
-		closeResponse(resp)
-		return key, nil, err
+		return nil, nil, errors.New("unknown data version")
+
 	}
 
 	// Return body


### PR DESCRIPTION
Return format version in addition to the existing API to
interpret the inspect data correctly.