### PR TITLE
Get accurate kernel version number

### DIFF
--- a/health.go
+++ b/health.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/minio/madmin-go/cgroup"
+	"github.com/minio/madmin-go/kernel"
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
@@ -292,6 +293,16 @@ func GetOSInfo(ctx context.Context, addr string) OSInfo {
 		}
 	}
 
+	kr, err := kernel.CurrentRelease()
+	if err != nil {
+		return OSInfo{
+			NodeCommon: NodeCommon{
+				Addr:  addr,
+				Error: err.Error(),
+			},
+		}
+	}
+
 	info, err := host.InfoWithContext(ctx)
 	if err != nil {
 		return OSInfo{
@@ -306,6 +317,7 @@ func GetOSInfo(ctx context.Context, addr string) OSInfo {
 		NodeCommon: NodeCommon{Addr: addr},
 		Info:       *info,
 	}
+	osInfo.Info.KernelVersion = kr
 
 	osInfo.Sensors, err = host.SensorsTemperaturesWithContext(ctx)
 	if err != nil {

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -1,0 +1,139 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build linux
+// +build linux
+
+package kernel
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+var versionRegex = regexp.MustCompile(`^(\d+)\.(\d+).(\d+).*$`)
+
+// VersionFromRelease converts a release string with format
+// 4.4.2[-1] to a kernel version number in LINUX_VERSION_CODE format.
+// That is, for kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
+func VersionFromRelease(releaseString string) (uint32, error) {
+	versionParts := versionRegex.FindStringSubmatch(releaseString)
+	if len(versionParts) != 4 {
+		return 0, fmt.Errorf("got invalid release version %q (expected format '4.3.2-1')", releaseString)
+	}
+	major, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return 0, err
+	}
+
+	minor, err := strconv.Atoi(versionParts[2])
+	if err != nil {
+		return 0, err
+	}
+
+	patch, err := strconv.Atoi(versionParts[3])
+	if err != nil {
+		return 0, err
+	}
+	return Version(major, minor, patch), nil
+}
+
+// Version implements KERNEL_VERSION equivalent macro
+// #define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
+func Version(major, minor, patch int) uint32 {
+	if patch > 255 {
+		patch = 255
+	}
+	out := major<<16 + minor<<8 + patch
+	return uint32(out)
+}
+
+func currentReleaseUname() (string, error) {
+	var buf syscall.Utsname
+	if err := syscall.Uname(&buf); err != nil {
+		return "", err
+	}
+	releaseString := strings.Trim(utsnameStr(buf.Release[:]), "\x00")
+	return releaseString, nil
+}
+
+func currentReleaseUbuntu() (string, error) {
+	procVersion, err := ioutil.ReadFile("/proc/version_signature")
+	if err != nil {
+		return "", err
+	}
+	var u1, u2, releaseString string
+	_, err = fmt.Sscanf(string(procVersion), "%s %s %s", &u1, &u2, &releaseString)
+	if err != nil {
+		return "", err
+	}
+	return releaseString, nil
+}
+
+var debianVersionRegex = regexp.MustCompile(`.* SMP Debian (\d+\.\d+.\d+-\d+)(?:\+[[:alnum:]]*)?.*`)
+
+func parseDebianRelease(str string) (string, error) {
+	match := debianVersionRegex.FindStringSubmatch(str)
+	if len(match) != 2 {
+		return "", fmt.Errorf("failed to parse kernel version from /proc/version: %s", str)
+	}
+	return match[1], nil
+}
+
+func currentReleaseDebian() (string, error) {
+	procVersion, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return "", fmt.Errorf("error reading /proc/version: %s", err)
+	}
+
+	return parseDebianRelease(string(procVersion))
+}
+
+// CurrentRelease returns the current kernel release ensuring that
+// ubuntu and debian release numbers are accurate.
+func CurrentRelease() (string, error) {
+	// We need extra checks for Debian and Ubuntu as they modify
+	// the kernel version patch number for compatibility with
+	// out-of-tree modules. Linux perf tools do the same for Ubuntu
+	// systems: https://github.com/torvalds/linux/commit/d18acd15c
+	//
+	// See also:
+	// https://kernel-team.pages.debian.net/kernel-handbook/ch-versions.html
+	// https://wiki.ubuntu.com/Kernel/FAQ
+	version, err := currentReleaseUbuntu()
+	if err == nil {
+		return version, nil
+	}
+	version, err = currentReleaseDebian()
+	if err == nil {
+		return version, nil
+	}
+	return currentReleaseUname()
+}
+
+// CurrentVersion returns the current kernel version in
+// LINUX_VERSION_CODE format (see VersionFromRelease())
+func CurrentVersion() (uint32, error) {
+	release, err := CurrentRelease()
+	if err == nil {
+		return VersionFromRelease(release)
+	}
+	return 0, err
+}

--- a/kernel/kernel_other.go
+++ b/kernel/kernel_other.go
@@ -1,0 +1,40 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build !linux
+// +build !linux
+
+package kernel
+
+// VersionFromRelease only implemented on Linux.
+func VersionFromRelease(_ string) (uint32, error) {
+	return 0, nil
+}
+
+// Version only implemented on Linux.
+func Version(_, _, _ int) uint32 {
+	return 0
+}
+
+// CurrentRelease only implemented on Linux.
+func CurrentRelease() (string, error) {
+	return "", nil
+}
+
+// CurrentVersion only implemented on Linux.
+func CurrentVersion() (uint32, error) {
+	return 0, nil
+}

--- a/kernel/kernel_test.go
+++ b/kernel/kernel_test.go
@@ -1,0 +1,91 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build linux
+// +build linux
+
+package kernel
+
+import "testing"
+
+var testData = []struct {
+	success       bool
+	releaseString string
+	kernelVersion uint32
+}{
+	{true, "4.1.2-3", 262402},
+	{true, "4.8.14-200.fc24.x86_64", 264206},
+	{true, "4.1.2-3foo", 262402},
+	{true, "4.1.2foo-1", 262402},
+	{true, "4.1.2-rkt-v1", 262402},
+	{true, "4.1.2rkt-v1", 262402},
+	{true, "4.1.2-3 foo", 262402},
+	{true, "3.10.0-1062.el7.x86_64", 199168},
+	{true, "3.0.0", 196608},
+	{true, "2.6.32", 132640},
+	{true, "5.13.0-30-generic", 331008},
+	{true, "5.10.0-1052-oem", 330240},
+	{false, "foo 4.1.2-3", 0},
+	{true, "4.1.2", 262402},
+	{false, ".4.1.2", 0},
+	{false, "4.1.", 0},
+	{false, "4.1", 0},
+}
+
+func TestVersionFromRelease(t *testing.T) {
+	for _, test := range testData {
+		version, err := VersionFromRelease(test.releaseString)
+		if err != nil && test.success {
+			t.Errorf("expected %q to success: %s", test.releaseString, err)
+		} else if err == nil && !test.success {
+			t.Errorf("expected %q to fail", test.releaseString)
+		}
+		if version != test.kernelVersion {
+			t.Errorf("expected kernel version %d, got %d", test.kernelVersion, version)
+		}
+	}
+}
+
+func TestParseDebianVersion(t *testing.T) {
+	for _, tc := range []struct {
+		success       bool
+		releaseString string
+		kernelVersion uint32
+	}{
+		// 4.9.168
+		{true, "Linux version 4.9.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.168-1+deb9u3 (2019-06-16)", 264616},
+		// 4.9.88
+		{true, "Linux ip-10-0-75-49 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux", 264536},
+		// 3.0.4
+		{true, "Linux version 3.16.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u2) ) #1 SMP Debian 3.16.68-1 (2019-05-22)", 200772},
+		// Invalid
+		{false, "Linux version 4.9.125-linuxkit (root@659b6d51c354) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Sep 7 08:20:28 UTC 2018", 0},
+	} {
+		var version uint32
+		release, err := parseDebianRelease(tc.releaseString)
+		if err == nil {
+			version, err = VersionFromRelease(release)
+		}
+		if err != nil && tc.success {
+			t.Errorf("expected %q to success: %s", tc.releaseString, err)
+		} else if err == nil && !tc.success {
+			t.Errorf("expected %q to fail", tc.releaseString)
+		}
+		if version != tc.kernelVersion {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}

--- a/kernel/kernel_utsname_int8.go
+++ b/kernel/kernel_utsname_int8.go
@@ -1,0 +1,31 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build (linux && 386) || (linux && amd64) || (linux && arm64) || (linux && mips64) || (linux && mips)
+// +build linux,386 linux,amd64 linux,arm64 linux,mips64 linux,mips
+
+package kernel
+
+func utsnameStr(in []int8) string {
+	out := make([]byte, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		if in[i] == 0x00 {
+			break
+		}
+		out = append(out, byte(in[i]))
+	}
+	return string(out)
+}

--- a/kernel/kernel_utsname_uint8.go
+++ b/kernel/kernel_utsname_uint8.go
@@ -1,0 +1,31 @@
+//
+// MinIO Object Storage (c) 2022 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build (linux && arm) || (linux && ppc64) || (linux && ppc64le) || (linux && s390x) || (linux && riscv64)
+// +build linux,arm linux,ppc64 linux,ppc64le linux,s390x linux,riscv64
+
+package kernel
+
+func utsnameStr(in []uint8) string {
+	out := make([]byte, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		if in[i] == 0x00 {
+			break
+		}
+		out = append(out, byte(in[i]))
+	}
+	return string(out)
+}


### PR DESCRIPTION
Ubuntu and debian modify kernel version patch number, so the kernel
version returned by gopsutil can be inaccurate.

This PR adds code to extract the correct kernel version number in case
of ubuntu and debian, so that the health report contains accurate version.

The code has been taken from minio/internal/kernel/kernel.go