### PR TITLE
check response time when network offline

### DIFF
--- a/cluster-health.go
+++ b/cluster-health.go
@@ -205,10 +205,16 @@ func (an *AnonymousClient) alive(ctx context.Context, u *url.URL, resource strin
 		endpointOverride: u,
 	}, trace)
 	closeResponse(resp)
+	var respTime time.Duration
+	if firstByteTime.IsZero() {
+		respTime = time.Since(reqStartTime)
+	} else {
+		respTime = firstByteTime.Sub(reqStartTime) - dnsDoneTime.Sub(dnsStartTime)
+	}
 
 	result := AliveResult{
 		Endpoint:       u,
-		ResponseTime:   firstByteTime.Sub(reqStartTime) - dnsDoneTime.Sub(dnsStartTime),
+		ResponseTime:   respTime,
 		DNSResolveTime: dnsDoneTime.Sub(dnsStartTime),
 	}
 	if err != nil {


### PR DESCRIPTION
**BUG:** mc ping showed  roundtrip=2562047h47m6.852034s when the network was down .
```
mc ping play
1: https://play.minio.io:9000/   min=0s   max=0s   average=0s   errors=1   roundtrip=2562047h47m6.852034s
2: https://play.minio.io:9000/   min=0s   max=0s   average=0s   errors=2   roundtrip=2562047h47m6.852184s
```

This PR rectifies this as below
```
./mc ping play
1: https://play.min.io:443   min=0s   max=0s   average=0s   errors=1   roundtrip=1.087ms
2: https://play.min.io:443   min=0s   max=0s   average=0s   errors=2   roundtrip=1.414ms
```