### PR TITLE
Add userType to IAM policy mapping hook data structure

### DIFF
--- a/cluster-commands.go
+++ b/cluster-commands.go
@@ -261,6 +261,7 @@ type SRSvcAccChange struct {
 // SRPolicyMapping - represents mapping of a policy to a user or group.
 type SRPolicyMapping struct {
 	UserOrGroup string    `json:"userOrGroup"`
+	UserType    int       `json:"userType"`
 	IsGroup     bool      `json:"isGroup"`
 	Policy      string    `json:"policy"`
 	CreatedAt   time.Time `json:"createdAt,omitempty"`


### PR DESCRIPTION
When replicating a policy mapping, we need to know if we are creating
the policy mapping for a virtual user, otherwise, the target site would
fail, complaining that the user to who we are associating the policy does
not exist.