### PR TITLE
Resolve -ve response time

### DIFF
--- a/cluster-health.go
+++ b/cluster-health.go
@@ -193,7 +193,11 @@ func (an *AnonymousClient) alive(ctx context.Context, u *url.URL, resource strin
 			dnsDoneTime = time.Now()
 		},
 		GetConn: func(_ string) {
-			reqStartTime = time.Now()
+			// GetConn is called again when trace is ON
+			// https://github.com/golang/go/issues/44281
+			if reqStartTime.IsZero() {
+				reqStartTime = time.Now()
+			}
 		},
 		GotFirstResponseByte: func() {
 			firstByteTime = time.Now()


### PR DESCRIPTION
When ever call the alive  function of madmin-go . It gives a correct result as shown below
`{Endpoint:https://play.min.io/ ResponseTime:4.479420576s DNSResolveTime:77.272122ms Online:true Error:<nil>}`
But when i enable the trace , the response time is -ve .
`{Endpoint:https://play.min.io/ ResponseTime:-67.21957ms DNSResolveTime:67.652491ms Online:true Error:<nil>}`
I figured out the root cause of it ,
When the debug flag is on the request start time and the firstByteTime are recalculated,
 https://github.com/minio/madmin-go/blob/6fe32b2922012f7dc795e175ef29c790f351d737/cluster-health.go#L195 , 

which leads to -ve response time  as it is calculated as shown below
`respTime = firstByteTime.Sub(reqStartTime) - dnsDoneTime.Sub(dnsStartTime)`
```
ashish@ashish:~/code/go/src/github/minio/madmin-go$ go run examples/alive.go 
 reqStartTime :  2022-09-05 10:09:44.507405981 +0530 IST m=+1.128982975
 dnsStartTime :  2022-09-05 10:09:44.507680283 +0530 IST m=+1.129257277
 dnsDoneTime :  2022-09-05 10:09:44.575332773 +0530 IST m=+1.196909768
 firstByteTime :  2022-09-05 10:09:45.401082532 +0530 IST m=+2.022659526
 an.isTraceEnabled true
---------START-HTTP---------
 reqStartTime :  2022-09-05 10:09:45.401461381 +0530 IST m=+2.023038390
 firstByteTime :  2022-09-05 10:09:45.401894316 +0530 IST m=+2.023471311
GET /minio/health/live HTTP/1.1
Host: play.min.io
User-Agent: Go-http-client/1.1
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
Accept-Encoding: gzip

Accept-Ranges: bytes
Connection: keep-alive
Content-Length: 0
Content-Security-Policy: block-all-mixed-content
Date: Mon, 05 Sep 2022 04:39:45 GMT
Server: nginx/1.18.0 (Ubuntu)
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
X-Amz-Bucket-Region: us-east-1
X-Amz-Request-Id: 1711DD0CF9FDC12F
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block
---------END-HTTP---------
2022/09/05 10:09:45 {Endpoint:https://play.min.io/ ResponseTime:-67.21957ms DNSResolveTime:67.652491ms Online:true Error:<nil>}
```
The second call for getting the request start time and first Byte time is done by httputil package. Here :
 https://github.com/minio/madmin-go/blob/6fe32b2922012f7dc795e175ef29c790f351d737/anonymous-api.go#L265