### PR TITLE
Add a humanized time elapsed field to LockEntry

### DIFF
--- a/top-commands.go
+++ b/top-commands.go
@@ -31,13 +31,14 @@ import (
 // servers holding the lock, source on the client machine,
 // ID, type(read or write) and time stamp.
 type LockEntry struct {
-	Timestamp  time.Time `json:"time"`       // When the lock was first granted
-	Resource   string    `json:"resource"`   // Resource contains info like bucket+object
-	Type       string    `json:"type"`       // Type indicates if 'Write' or 'Read' lock
-	Source     string    `json:"source"`     // Source at which lock was granted
-	ServerList []string  `json:"serverlist"` // List of servers participating in the lock.
-	Owner      string    `json:"owner"`      // Owner UUID indicates server owns the lock.
-	ID         string    `json:"id"`         // UID to uniquely identify request of client.
+	Timestamp  time.Time     `json:"time"`       // When the lock was first granted
+	Elapsed    time.Duration `json:"elapsed"`    // Duration for which lock has been held
+	Resource   string        `json:"resource"`   // Resource contains info like bucket+object
+	Type       string        `json:"type"`       // Type indicates if 'Write' or 'Read' lock
+	Source     string        `json:"source"`     // Source at which lock was granted
+	ServerList []string      `json:"serverlist"` // List of servers participating in the lock.
+	Owner      string        `json:"owner"`      // Owner UUID indicates server owns the lock.
+	ID         string        `json:"id"`         // UID to uniquely identify request of client.
 	// Represents quorum number of servers required to hold this lock, used to look for stale locks.
 	Quorum int `json:"quorum"`
 }


### PR DESCRIPTION
This would allow consumers of `mc support top locks --json` subcommand to know the time for which the lock was held at the time of receving the json output.