### PR TITLE
Add HealID to healing information

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -346,6 +346,7 @@ type HealingDisk struct {
 	// When adding new field, update (*healingTracker).toHealingDisk
 
 	ID         string    `json:"id"`
+	HealID     string    `json:"heal_id"`
 	PoolIndex  int       `json:"pool_index"`
 	SetIndex   int       `json:"set_index"`
 	DiskIndex  int       `json:"disk_index"`


### PR DESCRIPTION
The heal ID is an uuid that is generated after new disks are formatted, 
the heal ID represents a healing task to heal new disks belonging to 
the same erasure set.