### PR TITLE
add Transport in api.Options

### DIFF
--- a/api.go
+++ b/api.go
@@ -175,6 +175,8 @@ func (adm *AdminClient) SetAppInfo(appName string, appVersion string) {
 }
 
 // SetCustomTransport - set new custom transport.
+//
+// Deprecated: use Options.Transport.
 func (adm *AdminClient) SetCustomTransport(customHTTPTransport http.RoundTripper) {
 	// Set this to override default transport
 	// ``http.DefaultTransport``.


### PR DESCRIPTION
[minio-go](https://github.com/minio/minio-go) supports the option Transport (see [here](https://github.com/minio/minio-go/blob/f5f1604f764e0543943961efefac0e6dc56ee4b2/api.go#L105)).

It would be nice if madmin-go also supported it :)