### PR TITLE
Return malicious data error with unexpected stream header

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -113,7 +113,7 @@ var ErrMaliciousData = sio.NotAuthentic
 // EncryptData. Otherwise, the decryption will fail.
 func DecryptData(password string, data io.Reader) ([]byte, error) {
 	// Parse the stream header
-	var hdr [41]byte
+	var hdr [32 + 1 + 8]byte
 	if _, err := io.ReadFull(data, hdr[:]); err != nil {
 		if err == io.EOF {
 			// Incomplete header, return malicious data

--- a/encrypt.go
+++ b/encrypt.go
@@ -104,6 +104,9 @@ func EncryptData(password string, data []byte) ([]byte, error) {
 // decrypted by provided credentials.
 var ErrMaliciousData = sio.NotAuthentic
 
+// ErrUnexpectedHeader indicates that the data stream returned unexpected header
+var ErrUnexpectedHeader = errors.New("unexpected header")
+
 // DecryptData decrypts the data with the key derived
 // from the salt (part of data) and the password using
 // the PBKDF used in EncryptData. DecryptData returns
@@ -115,9 +118,9 @@ func DecryptData(password string, data io.Reader) ([]byte, error) {
 	// Parse the stream header
 	var hdr [32 + 1 + 8]byte
 	if _, err := io.ReadFull(data, hdr[:]); err != nil {
-		if err == io.EOF {
-			// Incomplete header, return malicious data
-			return nil, ErrMaliciousData
+		if errors.Is(err, io.EOF) {
+			// Incomplete header, return unexpected header
+			return nil, ErrUnexpectedHeader
 		}
 		return nil, err
 	}


### PR DESCRIPTION
When decrypting data with a secret key, that is used in decrypting
 admin requests or old MinIO backend configuration, consider an 
incomplete header as malicious data instead of returning io.EOF. 
That way, the error will be more understood by the end user.