### PR TITLE
speedtest: Add 'noclear' flag to keep the generated data

### DIFF
--- a/perf-object.go
+++ b/perf-object.go
@@ -65,6 +65,7 @@ type SpeedtestOpts struct {
 	Autotune     bool          // Enable autotuning
 	StorageClass string        // Choose type of storage-class to be used while performing I/O
 	Bucket       string        // Choose a custom bucket name while performing I/O
+	KeepData     bool          // Avoid cleanup after running an object speed test
 }
 
 // Speedtest - perform speedtest on the MinIO servers
@@ -96,6 +97,9 @@ func (adm *AdminClient) Speedtest(ctx context.Context, opts SpeedtestOpts) (chan
 	}
 	if opts.Autotune {
 		queryVals.Set("autotune", "true")
+	}
+	if opts.KeepData {
+		queryVals.Set("keep-data", "true")
 	}
 	resp, err := adm.executeMethod(ctx,
 		http.MethodPost, requestData{

--- a/perf-object.go
+++ b/perf-object.go
@@ -65,7 +65,7 @@ type SpeedtestOpts struct {
 	Autotune     bool          // Enable autotuning
 	StorageClass string        // Choose type of storage-class to be used while performing I/O
 	Bucket       string        // Choose a custom bucket name while performing I/O
-	KeepData     bool          // Avoid cleanup after running an object speed test
+	NoClear      bool          // Avoid cleanup after running an object speed test
 }
 
 // Speedtest - perform speedtest on the MinIO servers
@@ -98,8 +98,8 @@ func (adm *AdminClient) Speedtest(ctx context.Context, opts SpeedtestOpts) (chan
 	if opts.Autotune {
 		queryVals.Set("autotune", "true")
 	}
-	if opts.KeepData {
-		queryVals.Set("keep-data", "true")
+	if opts.NoClear {
+		queryVals.Set("noclear", "true")
 	}
 	resp, err := adm.executeMethod(ctx,
 		http.MethodPost, requestData{


### PR DESCRIPTION
For mc support perf <alias>, the default behavior is to remove 
the generated objects when doing object speed test. Adding
 a flag to offer a possibility to keep the generated data, so we 
can have a way to quickly generate data of any size.

e.g.
mc support perf object <alias> --duration 30m --keep-data --size 1K