### PR TITLE
fix: Add total sets and drives per set per pool information

### DIFF
--- a/info-commands.go
+++ b/info-commands.go
@@ -382,6 +382,10 @@ type ErasureBackend struct {
 	StandardSCParity int `json:"standardSCParity"`
 	// Parity disks for currently configured Reduced Redundancy storage class.
 	RRSCParity int `json:"rrSCParity"`
+
+	// Per pool information
+	TotalSets    []int `json:"totalSets"`
+	DrivesPerSet []int `json:"totalDrivesPerSet"`
 }
 
 // ServerProperties holds server information


### PR DESCRIPTION
It can be calculated from disks info as well, but sometimes disks are offline. 
This is the correct way to publish drives per set and total sets per pool.