### PR TITLE
heal: Add UpdateParity to rewrite objects with an updated parity setting

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -46,12 +46,13 @@ const (
 
 // HealOpts - collection of options for a heal sequence
 type HealOpts struct {
-	Recursive bool         `json:"recursive"`
-	DryRun    bool         `json:"dryRun"`
-	Remove    bool         `json:"remove"`
-	Recreate  bool         `json:"recreate"` // Rewrite all resources specified at the bucket or prefix.
-	ScanMode  HealScanMode `json:"scanMode"`
-	NoLock    bool         `json:"nolock"`
+	Recursive    bool         `json:"recursive"`
+	DryRun       bool         `json:"dryRun"`
+	Remove       bool         `json:"remove"`
+	Recreate     bool         `json:"recreate"` // Rewrite all resources specified at the bucket or prefix.
+	ScanMode     HealScanMode `json:"scanMode"`
+	UpdateParity bool         `json:"updateParity"` // Update the parity of the existing object with a new one
+	NoLock       bool         `json:"nolock"`
 }
 
 // Equal returns true if no is same as o.
@@ -68,6 +69,10 @@ func (o HealOpts) Equal(no HealOpts) bool {
 	if o.Recreate != no.Recreate {
 		return false
 	}
+	if o.UpdateParity != no.UpdateParity {
+		return false
+	}
+
 	return o.ScanMode == no.ScanMode
 }
 


### PR DESCRIPTION
If the user changes the parity setting for a particular storage class
in a MinIO cluster, he can also rewrites some objects with a new parity 
by setting UpdateParity to true in madmin.Heal() API.