### PR TITLE
Fix field name in Service Account example

### DIFF
--- a/examples/service-account.go
+++ b/examples/service-account.go
@@ -59,8 +59,8 @@ func main() {
 	// update service account
 	newExpiration := time.Now().Add(45 * time.Minute)
 	updateReq := madmin.UpdateServiceAccountReq{
-		NewStatus:  "my-status",
-		Expiration: &newExpiration,
+		NewStatus:     "my-status",
+		NewExpiration: &newExpiration,
 	}
 	if err := madminClient.UpdateServiceAccount(ctx, "my-accesskey", updateReq); err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
Previously, the file was returning the following error:

```
./service-account.go:63:3: unknown field 'Expiration' in struct literal of type madmin.UpdateServiceAccountReq
```