### PR TITLE
Change ListServiceAccountsResp type

### DIFF
--- a/user-commands.go
+++ b/user-commands.go
@@ -464,9 +464,14 @@ func (adm *AdminClient) UpdateServiceAccount(ctx context.Context, accessKey stri
 	return nil
 }
 
+type ServiceAccountInfo struct {
+	AccessKey  string     `json:"accessKey"`
+	Expiration *time.Time `json:"expiration,omitempty"`
+}
+
 // ListServiceAccountsResp is the response body of the list service accounts call
 type ListServiceAccountsResp struct {
-	Accounts []string `json:"accounts"`
+	Accounts []ServiceAccountInfo `json:"accounts"`
 }
 
 // ListServiceAccounts - list service accounts belonging to the specified user


### PR DESCRIPTION
As expiration date will also be returned for the Service Account listing, this commit changes the type for ListServiceAccountsResp.

This change is required for minio/mc#4576 to work.

Please merge this PR together with minio/mc#4576, minio/minio#17249 and minio/console#2824.