### PR TITLE
Added endpoint and version

### DIFF
--- a/info-commands.go
+++ b/info-commands.go
@@ -275,7 +275,8 @@ func (info InfoMessage) StandardParity() int {
 
 // Services contains different services information
 type Services struct {
-	KMS           []KMS                         `json:"kms,omitempty"`
+	KMS           KMS                           `json:"kms,omitempty"` // deprecated july 2023
+	KMSV2         []KMS                         `json:"kmsv2,omitempty"`
 	LDAP          LDAP                          `json:"ldap,omitempty"`
 	Logger        []Logger                      `json:"logger,omitempty"`
 	Audit         []Audit                       `json:"audit,omitempty"`

--- a/info-commands.go
+++ b/info-commands.go
@@ -276,7 +276,7 @@ func (info InfoMessage) StandardParity() int {
 // Services contains different services information
 type Services struct {
 	KMS           KMS                           `json:"kms,omitempty"` // deprecated july 2023
-	KMSV2         []KMS                         `json:"kmsv2,omitempty"`
+	KMSStatus     []KMS                         `json:"kmsStatus,omitempty"`
 	LDAP          LDAP                          `json:"ldap,omitempty"`
 	Logger        []Logger                      `json:"logger,omitempty"`
 	Audit         []Audit                       `json:"audit,omitempty"`

--- a/info-commands.go
+++ b/info-commands.go
@@ -275,7 +275,7 @@ func (info InfoMessage) StandardParity() int {
 
 // Services contains different services information
 type Services struct {
-	KMS           KMS                           `json:"kms,omitempty"`
+	KMS           []KMS                         `json:"kms,omitempty"`
 	LDAP          LDAP                          `json:"ldap,omitempty"`
 	Logger        []Logger                      `json:"logger,omitempty"`
 	Audit         []Audit                       `json:"audit,omitempty"`
@@ -316,9 +316,11 @@ type TierStats struct {
 
 // KMS contains KMS status information
 type KMS struct {
-	Status  string `json:"status,omitempty"`
-	Encrypt string `json:"encrypt,omitempty"`
-	Decrypt string `json:"decrypt,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Encrypt  string `json:"encrypt,omitempty"`
+	Decrypt  string `json:"decrypt,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Version  string `json:"version,omitempty"`
 }
 
 // LDAP contains ldap status


### PR DESCRIPTION
This PR adds `endpoint` and `version` attributes to a KMS instance. Also for `admin info` command, `services.kms` would now be a list of KMS instances.