### PR TITLE
fix: the result have a empty endpoint

### DIFF
--- a/perf-client.go
+++ b/perf-client.go
@@ -93,7 +93,6 @@ func (adm *AdminClient) ClientPerf(ctx context.Context, dur time.Duration) (resu
 	}
 	ctx, cancel := context.WithTimeout(ctx, dur)
 	defer cancel()
-	result.Endpoint = adm.endpointURL.String()
 	queryVals := make(url.Values)
 	reader := &clientPerfReader{}
 	reader.Start()
@@ -131,5 +130,6 @@ func (adm *AdminClient) ClientPerf(ctx context.Context, dur time.Duration) (resu
 		BytesSend: reader.count,
 		TimeSpent: durSpend,
 		Error:     "",
+		Endpoint:  adm.endpointURL.String(),
 	}, err
 }


### PR DESCRIPTION
the result have a empty endpoint.
fix this comment https://github.com/minio/minio/pull/17718#issuecomment-1673308502
```shell
./mc support perf client myminio --airgap --dev

Client: ✔ 

ENDPOINT        TX               
                230 MiB/s
mc: MinIO performance report saved at myminio-perf_20230810115721.zip, please upload to SUBNET portal manually
```