### PR TITLE
Add ClusterMetrics method to MetricsClient

### DIFF
--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -33,12 +33,34 @@ const (
 )
 
 // NodeMetrics - returns Node Metrics in Prometheus format
+//
+//	The client needs to be configured with the endpoint of the desired node
 func (client *MetricsClient) NodeMetrics(ctx context.Context) ([]*prom2json.Family, error) {
 	reqData := metricsRequestData{
 		relativePath: "/v2/metrics/node",
 	}
 
 	// Execute GET on /minio/v2/metrics/node
+	resp, err := client.executeRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+}
+
+// ClusterMetrics - returns Cluster Metrics in Prometheus format
+func (client *MetricsClient) ClusterMetrics(ctx context.Context) ([]*prom2json.Family, error) {
+	reqData := metricsRequestData{
+		relativePath: "/v2/metrics/cluster",
+	}
+
+	// Execute GET on /minio/v2/metrics/cluster
 	resp, err := client.executeRequest(ctx, reqData)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Similar to https://github.com/minio/madmin-go/pull/218, this adds the Cluster method equivalent to `/minio/v2/metrics/cluster` endpoint.

It also adds some documentation to the NodeMetrics method since that one only makes sense if the client is using the node's of interest endpoint.

### Test Steps:
- Create a client
- Run Metrics API
- Parse the response to string to visualize it

```
ctx := context.Background()
madminClient, _ := madmin.NewMetricsClient(
		"http://localhost:9000",
		"accesskey",
		"secretKey",
		false,
	)
metrics, _ := metricsClient.ClusterMetrics(ctx)

result, _ := json.MarshalIndent(metrics, "", " ")
log.Println(string(result))
```
Output would look like:
```
[
 {
  "name": "someMetrics",
  "help": "Some help",
  "type": "GAUGE",
  "metrics": [
   {
    "value": "1.76933784e+08"
   }
  ]
 },
 {
  "name": "someMetrics",
  "help": "Some other help.",
  "type": "COUNTER",
  "metrics": [
   {
    "value": "2.59015547e+08"
   }
  ]
 },
 ...
 ]
```