### PR TITLE
Add BucketMetrics method

### DIFF
--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -74,6 +74,26 @@ func (client *MetricsClient) ClusterMetrics(ctx context.Context) ([]*prom2json.F
 	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
 }
 
+// BucketMetrics - returns Bucket Metrics in Prometheus format
+func (client *MetricsClient) BucketMetrics(ctx context.Context) ([]*prom2json.Family, error) {
+	reqData := metricsRequestData{
+		relativePath: "/v2/metrics/bucket",
+	}
+
+	// Execute GET on /minio/v2/metrics/bucket
+	resp, err := client.executeRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+}
+
 func parsePrometheusResults(reader io.Reader) (results []*prom2json.Family, err error) {
 	mfChan := make(chan *dto.MetricFamily)
 	errChan := make(chan error)


### PR DESCRIPTION
Similar to https://github.com/minio/madmin-go/pull/218, this adds the Bucket method equivalent to `/minio/v2/metrics/bucket` endpoint.

It also adds some documentation to the NodeMetrics method since that one only makes sense if the client is using the node's of interest endpoint.

### Test Steps:
- Create a client
- Run Metrics API
- Parse the response to string to visualize it

```
ctx := context.Background()
madminClient, _ := madmin.NewMetricsClient(
		"http://localhost:9000",
		"accesskey",
		"secretKey",
		false,
	)
metrics, _ := metricsClient.BucketMetrics(ctx)

result, _ := json.MarshalIndent(metrics, "", " ")
log.Println(string(result))
```
Output would look like:
```
[
 {
  "name": "someMetrics",
  "help": "Some help",
  "type": "GAUGE",
  "metrics": [
   {
    "value": "1.76933784e+08"
   }
  ]
 },
 {
  "name": "someMetrics",
  "help": "Some other help.",
  "type": "COUNTER",
  "metrics": [
   {
    "value": "2.59015547e+08"
   }
  ]
 },
 ...
 ]
```