### PR TITLE
Add support of per bucket scanner report

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -234,14 +234,12 @@ type ScannerMetrics struct {
 	// Time these metrics were collected
 	CollectedAt time.Time `json:"collected"`
 
-	// Current scanner cycle
-	CurrentCycle uint64 `json:"current_cycle"`
+	CurrentCycle      uint64      `json:"current_cycle"`        // Deprecated Mar 2024
+	CurrentStarted    time.Time   `json:"current_started"`      // Deprecated Mar 2024
+	CyclesCompletedAt []time.Time `json:"cycle_complete_times"` // Deprecated Mar 2024
 
-	// Start time of current cycle
-	CurrentStarted time.Time `json:"current_started"`
-
-	// History of when last cycles completed
-	CyclesCompletedAt []time.Time `json:"cycle_complete_times"`
+	// Number of buckets currently scanning
+	OngoingBuckets int `json:"ongoing_buckets"`
 
 	// Number of accumulated operations by type since server restart.
 	LifeTimeOps map[string]uint64 `json:"life_time_ops,omitempty"`
@@ -296,10 +294,16 @@ func (s *ScannerMetrics) Merge(other *ScannerMetrics) {
 	if other == nil {
 		return
 	}
+
 	if s.CollectedAt.Before(other.CollectedAt) {
 		// Use latest timestamp
 		s.CollectedAt = other.CollectedAt
 	}
+
+	if s.OngoingBuckets < other.OngoingBuckets {
+		s.OngoingBuckets = other.OngoingBuckets
+	}
+
 	if s.CurrentCycle < other.CurrentCycle {
 		s.CurrentCycle = other.CurrentCycle
 		s.CyclesCompletedAt = other.CyclesCompletedAt

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type BucketScanInfo struct {
+	Pool, Set   int
+	Cycle       uint64
+	LastUpdate  time.Time
+	LastStarted time.Time
+	Completed   []time.Time
+}
+
+func (adm *AdminClient) BucketScanInfo(ctx context.Context, bucket string) ([]BucketScanInfo, error) {
+	resp, err := adm.executeMethod(ctx,
+		http.MethodGet,
+		requestData{relPath: adminAPIPrefix + "/scanner/status/" + bucket})
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var info []BucketScanInfo
+	err = json.Unmarshal(respBytes, &info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}

--- a/scanner.go
+++ b/scanner.go
@@ -26,6 +26,7 @@ import (
 	"time"
 )
 
+// BucketScanInfo contains information of a bucket scan in a given pool/set
 type BucketScanInfo struct {
 	Pool, Set   int
 	Cycle       uint64
@@ -34,6 +35,7 @@ type BucketScanInfo struct {
 	Completed   []time.Time
 }
 
+// BucketScanInfo returns information of a bucket scan in all pools/sets
 func (adm *AdminClient) BucketScanInfo(ctx context.Context, bucket string) ([]BucketScanInfo, error) {
 	resp, err := adm.executeMethod(ctx,
 		http.MethodGet,


### PR DESCRIPTION
Each bucket will be scanned individually, this commit will deprecate 
old cycle scan metrics since there is no concept of a full cycle in the
upcoming per bucket scan change.