### PR TITLE
Add drive model to partitions in health report

### DIFF
--- a/health.go
+++ b/health.go
@@ -25,10 +25,12 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -67,6 +69,12 @@ const (
 const (
 	SrvSELinux      = "selinux"
 	SrvNotInstalled = "not-installed"
+)
+
+const (
+	sysClassBlock = "/sys/class/block"
+	devDir        = "/dev/"
+	devLoopDir    = "/dev/loop"
 )
 
 // NodeInfo - Interface to abstract any struct that contains address/endpoint and error fields
@@ -222,6 +230,7 @@ type Partition struct {
 	Error string `json:"error,omitempty"`
 
 	Device       string `json:"device,omitempty"`
+	Model        string `json:"model,omitempty"`
 	Mountpoint   string `json:"mountpoint,omitempty"`
 	FSType       string `json:"fs_type,omitempty"`
 	MountOptions string `json:"mount_options,omitempty"`
@@ -237,6 +246,40 @@ type Partitions struct {
 	NodeCommon
 
 	Partitions []Partition `json:"partitions,omitempty"`
+}
+
+func getDeviceModel(partDevice string) (string, error) {
+	var model string
+
+	partDevName := strings.ReplaceAll(partDevice, devDir, "")
+	partDevPath := path.Join(sysClassBlock, partDevName)
+	devPath, err := os.Readlink(partDevPath)
+	if err != nil {
+		return model, err
+	}
+
+	if !path.IsAbs(devPath) {
+		devPath = path.Join(sysClassBlock, devPath)
+	}
+
+	devModelPath := path.Join(devPath, "device", "model")
+
+	_, err = os.Stat(devModelPath)
+	if err != nil {
+		// check parent dir
+		devModelPath = path.Join(devPath, "..", "device", "model")
+		_, err = os.Stat(devModelPath)
+		if err != nil {
+			return model, err
+		}
+	}
+
+	data, err := ioutil.ReadFile(devModelPath)
+	if err == nil {
+		model = strings.TrimSpace(string(data))
+	}
+
+	return model, err
 }
 
 // GetPartitions returns all disk partitions information of a node running linux only operating system.
@@ -270,8 +313,15 @@ func GetPartitions(ctx context.Context, addr string) Partitions {
 				Error:  err.Error(),
 			})
 		} else {
+			var model string
+			device := parts[i].Device
+			if strings.HasPrefix(device, devDir) && !strings.HasPrefix(device, devLoopDir) {
+				// ignore any error in finding device model
+				model, _ = getDeviceModel(device)
+			}
+
 			partitions = append(partitions, Partition{
-				Device:       parts[i].Device,
+				Device:       device,
 				Mountpoint:   parts[i].Mountpoint,
 				FSType:       parts[i].Fstype,
 				MountOptions: strings.Join(parts[i].Opts, ","),
@@ -280,6 +330,7 @@ func GetPartitions(ctx context.Context, addr string) Partitions {
 				SpaceFree:    usage.Free,
 				InodeTotal:   usage.InodesTotal,
 				InodeFree:    usage.InodesFree,
+				Model:        model,
 			})
 		}
 	}


### PR DESCRIPTION
Capture the drive model in partitions data in the health report. It will be read from `/run/udev/data/b<major>:<minor>`