### PR TITLE
FIX: repaired kauditd process detection

### DIFF
--- a/health.go
+++ b/health.go
@@ -531,7 +531,7 @@ func isKauditdRunning() (bool, error) {
 	}
 	for _, proc := range procs {
 		pname, err := proc.Name()
-		if err != nil && pname == "kauditd" {
+		if err == nil && pname == "kauditd" {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Prior to fix `audit` would only be detected if `audit=1` was in `/proc/cmdline`. Fix allows the `kauditd` process to be detected in the absence of errors. Not quite sure how I would write a test for this and would like some guidance (it's my first open source pull request).