### PR TITLE
Add ResourceMetrics method

### DIFF
--- a/metrics_client.go
+++ b/metrics_client.go
@@ -98,8 +98,8 @@ func privateNewMetricsClient(endpointURL *url.URL, jwtToken string, secure bool)
 	return clnt, nil
 }
 
-// executeRequest - instantiates a Get method and performs the request
-func (client MetricsClient) executeRequest(ctx context.Context, reqData metricsRequestData) (res *http.Response, err error) {
+// executeGetRequest - instantiates a Get method and performs the request
+func (client MetricsClient) executeGetRequest(ctx context.Context, reqData metricsRequestData) (res *http.Response, err error) {
 	req, err := client.newGetRequest(ctx, reqData)
 	if err != nil {
 		return nil, err

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -41,7 +41,7 @@ func (client *MetricsClient) NodeMetrics(ctx context.Context) ([]*prom2json.Fami
 	}
 
 	// Execute GET on /minio/v2/metrics/node
-	resp, err := client.executeRequest(ctx, reqData)
+	resp, err := client.executeGetRequest(ctx, reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (client *MetricsClient) ClusterMetrics(ctx context.Context) ([]*prom2json.F
 	}
 
 	// Execute GET on /minio/v2/metrics/cluster
-	resp, err := client.executeRequest(ctx, reqData)
+	resp, err := client.executeGetRequest(ctx, reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,27 @@ func (client *MetricsClient) BucketMetrics(ctx context.Context) ([]*prom2json.Fa
 	}
 
 	// Execute GET on /minio/v2/metrics/bucket
-	resp, err := client.executeRequest(ctx, reqData)
+	resp, err := client.executeGetRequest(ctx, reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+}
+
+// ResourceMetrics - returns Resource Metrics in Prometheus format
+func (client *MetricsClient) ResourceMetrics(ctx context.Context) ([]*prom2json.Family, error) {
+	reqData := metricsRequestData{
+		relativePath: "/v2/metrics/resource",
+	}
+
+	// Execute GET on /minio/v2/metrics/resource
+	resp, err := client.executeGetRequest(ctx, reqData)
 	if err != nil {
 		return nil, err
 	}

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -36,71 +36,31 @@ const (
 //
 //	The client needs to be configured with the endpoint of the desired node
 func (client *MetricsClient) NodeMetrics(ctx context.Context) ([]*prom2json.Family, error) {
-	reqData := metricsRequestData{
-		relativePath: "/v2/metrics/node",
-	}
-
-	// Execute GET on /minio/v2/metrics/node
-	resp, err := client.executeGetRequest(ctx, reqData)
-	if err != nil {
-		return nil, err
-	}
-	defer closeResponse(resp)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, httpRespToErrorResponse(resp)
-	}
-
-	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+	return client.fetchMetrics(ctx, "node")
 }
 
 // ClusterMetrics - returns Cluster Metrics in Prometheus format
 func (client *MetricsClient) ClusterMetrics(ctx context.Context) ([]*prom2json.Family, error) {
-	reqData := metricsRequestData{
-		relativePath: "/v2/metrics/cluster",
-	}
-
-	// Execute GET on /minio/v2/metrics/cluster
-	resp, err := client.executeGetRequest(ctx, reqData)
-	if err != nil {
-		return nil, err
-	}
-	defer closeResponse(resp)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, httpRespToErrorResponse(resp)
-	}
-
-	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+	return client.fetchMetrics(ctx, "cluster")
 }
 
 // BucketMetrics - returns Bucket Metrics in Prometheus format
 func (client *MetricsClient) BucketMetrics(ctx context.Context) ([]*prom2json.Family, error) {
-	reqData := metricsRequestData{
-		relativePath: "/v2/metrics/bucket",
-	}
-
-	// Execute GET on /minio/v2/metrics/bucket
-	resp, err := client.executeGetRequest(ctx, reqData)
-	if err != nil {
-		return nil, err
-	}
-	defer closeResponse(resp)
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, httpRespToErrorResponse(resp)
-	}
-
-	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+	return client.fetchMetrics(ctx, "bucket")
 }
 
 // ResourceMetrics - returns Resource Metrics in Prometheus format
 func (client *MetricsClient) ResourceMetrics(ctx context.Context) ([]*prom2json.Family, error) {
+	return client.fetchMetrics(ctx, "resource")
+}
+
+// fetchMetrics - returns Metrics of given subsystem in Prometheus format
+func (client *MetricsClient) fetchMetrics(ctx context.Context, subSystem string) ([]*prom2json.Family, error) {
 	reqData := metricsRequestData{
-		relativePath: "/v2/metrics/resource",
+		relativePath: "/v2/metrics/" + subSystem,
 	}
 
-	// Execute GET on /minio/v2/metrics/resource
+	// Execute GET on /minio/v2/metrics/<subSys>
 	resp, err := client.executeGetRequest(ctx, reqData)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Similar to https://github.com/minio/madmin-go/pull/218, this adds the Resource method equivalent to `/minio/v2/metrics/resource` endpoint.

Also renames a method to be more clear on what it does.

### Test Steps:
- Create a client
- Run Metrics API
- Parse the response to string to visualize it

```
ctx := context.Background()
madminClient, _ := madmin.NewMetricsClient(
		"http://localhost:9000",
		"accesskey",
		"secretKey",
		false,
	)
metrics, _ := metricsClient.ResourceMetrics(ctx)

result, _ := json.MarshalIndent(metrics, "", " ")
log.Println(string(result))
```
Output would look like:
```
[
 {
  "name": "someMetrics",
  "help": "Some help",
  "type": "GAUGE",
  "metrics": [
   {
    "value": "1.76933784e+08"
   }
  ]
 },
 {
  "name": "someMetrics",
  "help": "Some other help.",
  "type": "COUNTER",
  "metrics": [
   {
    "value": "2.59015547e+08"
   }
  ]
 },
 ...
 ]
```