### PR TITLE
batch-expiry: Change lesserThan to lessThan

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.21.3 ]
+        go-version: [ 1.21.4 ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/batch-job.go
+++ b/batch-job.go
@@ -161,7 +161,7 @@ const BatchJobExpireTemplate = `expire:
         - key: content-type
           value: image/* # match objects with 'content-type', all values starting with 'image/'
       size:
-        lesserThan: 10MiB # match objects with size lesser than this value (e.g. 10MiB)
+        lessThan: 10MiB # match objects with size less than this value (e.g. 10MiB)
         greaterThan: 1MiB # match objects with size greater than this value (e.g. 1MiB)
       purge:
           # retainVersions: 0 # (default) delete all versions of the object. This option is the fastest.


### PR DESCRIPTION
lesserThan is gramatically incorrect.