### PR TITLE
Add CPU count in metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -640,6 +640,7 @@ type CPUMetrics struct {
 
 	TimesStat *cpu.TimesStat `json:"timesStat"`
 	LoadStat  *load.AvgStat  `json:"loadStat"`
+	Count     int            `json:"count"`
 }
 
 // Merge other into 'm'.

--- a/metrics.go
+++ b/metrics.go
@@ -640,7 +640,7 @@ type CPUMetrics struct {
 
 	TimesStat *cpu.TimesStat `json:"timesStat"`
 	LoadStat  *load.AvgStat  `json:"loadStat"`
-	Count     int            `json:"count"`
+	CPUCount  int            `json:"cpuCount"`
 }
 
 // Merge other into 'm'.


### PR DESCRIPTION
so that it can be used by the resource metrics collector to calculate "percentage" load (load * 100 / cpu-count)