### PR TITLE
tier: Add validation to tier configuration

### DIFF
--- a/cgroup/nolinux.go
+++ b/cgroup/nolinux.go
@@ -24,6 +24,6 @@ package cgroup
 import "errors"
 
 // GetMemoryLimit - Not implemented in non-linux platforms
-func GetMemoryLimit(pid int) (limit uint64, err error) {
+func GetMemoryLimit(_ int) (limit uint64, err error) {
 	return limit, errors.New("Not implemented for non-linux platforms")
 }

--- a/tier.go
+++ b/tier.go
@@ -111,8 +111,14 @@ func (adm *AdminClient) ListTiers(ctx context.Context) ([]*TierConfig, error) {
 type TierCreds struct {
 	AccessKey string `json:"access,omitempty"`
 	SecretKey string `json:"secret,omitempty"`
+
+	AWSRole                     bool   `json:"awsrole"`
+	AWSRoleWebIdentityTokenFile string `json:"awsroleWebIdentity,omitempty"`
+	AWSRoleARN                  string `json:"awsroleARN,omitempty"`
+
+	AzSP ServicePrincipalAuth `json:"azSP,omitempty"`
+
 	CredsJSON []byte `json:"creds,omitempty"`
-	AWSRole   bool   `json:"awsrole"`
 }
 
 // EditTier supports updating credentials for the remote tier identified by tierName.


### PR DESCRIPTION
Bonus, also add missing aws role web identity and role ARN when editing the tier 