### PR TITLE
Make EnableSha256 in mc perf object test configurable

### DIFF
--- a/perf-object.go
+++ b/perf-object.go
@@ -66,6 +66,7 @@ type SpeedtestOpts struct {
 	StorageClass string        // Choose type of storage-class to be used while performing I/O
 	Bucket       string        // Choose a custom bucket name while performing I/O
 	NoClear      bool          // Avoid cleanup after running an object speed test
+	EnableSha256 bool          // Enable calculating sha256 for uploads
 }
 
 // Speedtest - perform speedtest on the MinIO servers
@@ -100,6 +101,9 @@ func (adm *AdminClient) Speedtest(ctx context.Context, opts SpeedtestOpts) (chan
 	}
 	if opts.NoClear {
 		queryVals.Set("noclear", "true")
+	}
+	if opts.EnableSha256 {
+		queryVals.Set("enableSha256", "true")
 	}
 	resp, err := adm.executeMethod(ctx,
 		http.MethodPost, requestData{


### PR DESCRIPTION
current mc perf test  hardcode   DisableContentSha256 as true, this PR is to make it configurable by mc cmd. 
cmd/perf-tests.go
 97 @@ -95,7 +95,7 @@ func selfSpeedTest(ctx context.Context, opts speedTestOpts) (SpeedTestResult, er
 98         userMetadata[globalObjectPerfUserMetadata] = "true" // Bypass S3 API freeze
 99         popts := minio.PutObjectOptions{
100                 UserMetadata:         userMetadata,
101 -               **DisableContentSha256: true,**
