### PR TITLE
Capture transparent hugepages config in health report

### DIFF
--- a/health.go
+++ b/health.go
@@ -396,17 +396,6 @@ type XFSErrorConfig struct {
 	MaxRetries int    `json:"max_retries"`
 }
 
-// THPConfigs - stores transparent huge pages (THP) related configs
-type THPConfigs struct {
-	// /sys/kernel/mm/transparent_hugepage/enabled
-	Enabled string `json:"enabled"`
-	// /sys/kernel/mm/transparent_hugepage/defrag
-	Defrag string `json:"defrag"`
-	// /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
-	MaxPtesNone int    `json:"max_ptes_none"`
-	Error       string `json:"error,omitempty"`
-}
-
 // GetOSInfo returns linux only operating system's information.
 func GetOSInfo(ctx context.Context, addr string) OSInfo {
 	if runtime.GOOS != "linux" {
@@ -500,28 +489,30 @@ func readIntFromFile(filePath string) (num int, err error) {
 	return strconv.Atoi(strings.TrimSpace(string(data)))
 }
 
-func getTHPConfigs() THPConfigs {
+func getTHPConfigs() map[string]interface{} {
+	configs := map[string]interface{}{}
 	data, err := os.ReadFile("/sys/kernel/mm/transparent_hugepage/enabled")
 	if err != nil {
-		return THPConfigs{Error: err.Error()}
+		return map[string]interface{}{"error": err.Error()}
 	}
-	configs := THPConfigs{Enabled: strings.TrimSpace(string(data))}
+	configs["enabled"] = strings.TrimSpace(string(data))
 
 	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/defrag")
 	if err != nil {
-		return THPConfigs{Error: err.Error()}
+		return map[string]interface{}{"error": err.Error()}
 	}
-	configs.Defrag = strings.TrimSpace(string(data))
+	configs["defrag"] = strings.TrimSpace(string(data))
 
 	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none")
 	if err != nil {
-		return THPConfigs{Error: err.Error()}
+		return map[string]interface{}{"error": err.Error()}
 	}
 
-	configs.MaxPtesNone, err = strconv.Atoi(strings.TrimSpace(string(data)))
+	configs["max_ptes_none"], err = strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
-		return THPConfigs{Error: err.Error()}
+		return map[string]interface{}{"error": err.Error()}
 	}
+
 	return configs
 }
 

--- a/health.go
+++ b/health.go
@@ -489,33 +489,22 @@ func readIntFromFile(filePath string) (num int, err error) {
 	return strconv.Atoi(strings.TrimSpace(string(data)))
 }
 
-func getTHPConfigs() map[string]interface{} {
-	configs := map[string]interface{}{}
-	data, err := os.ReadFile("/sys/kernel/mm/transparent_hugepage/enabled")
-	if err != nil {
-		configs["enabled_error"] = err.Error()
-	} else {
-		configs["enabled"] = strings.TrimSpace(string(data))
-	}
-
-	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/defrag")
-	if err != nil {
-		configs["defrag_error"] = err.Error()
-	} else {
-		configs["defrag"] = strings.TrimSpace(string(data))
-	}
-
-	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none")
-	if err != nil {
-		configs["max_ptes_none_error"] = err.Error()
-	} else {
-		configs["max_ptes_none"], err = strconv.Atoi(strings.TrimSpace(string(data)))
-		if err != nil {
-			configs["max_ptes_none_error"] = err.Error()
-		}
-	}
-
+func getTHPConfigs() map[string]string {
+	configs := map[string]string{}
+	captureTHPConfig(configs, "/sys/kernel/mm/transparent_hugepage/enabled", "enabled")
+	captureTHPConfig(configs, "/sys/kernel/mm/transparent_hugepage/defrag", "defrag")
+	captureTHPConfig(configs, "/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none", "max_ptes_none")
 	return configs
+}
+
+func captureTHPConfig(configs map[string]string, filePath string, cfgName string) {
+	errFieldName := "cfgName" + "_error"
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		configs[errFieldName] = err.Error()
+		return
+	}
+	configs[cfgName] = strings.TrimSpace(string(data))
 }
 
 func getXFSErrorMaxRetries() XFSErrorConfigs {

--- a/health.go
+++ b/health.go
@@ -498,7 +498,7 @@ func getTHPConfigs() map[string]string {
 }
 
 func captureTHPConfig(configs map[string]string, filePath string, cfgName string) {
-	errFieldName := "cfgName" + "_error"
+	errFieldName := cfgName + "_error"
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		configs[errFieldName] = err.Error()

--- a/health.go
+++ b/health.go
@@ -396,6 +396,17 @@ type XFSErrorConfig struct {
 	MaxRetries int    `json:"max_retries"`
 }
 
+// THPConfigs - stores transparent huge pages (THP) related configs
+type THPConfigs struct {
+	// /sys/kernel/mm/transparent_hugepage/enabled
+	Enabled string `json:"enabled"`
+	// /sys/kernel/mm/transparent_hugepage/defrag
+	Defrag string `json:"defrag"`
+	// /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
+	MaxPtesNone int    `json:"max_ptes_none"`
+	Error       string `json:"error,omitempty"`
+}
+
 // GetOSInfo returns linux only operating system's information.
 func GetOSInfo(ctx context.Context, addr string) OSInfo {
 	if runtime.GOOS != "linux" {
@@ -467,6 +478,8 @@ func GetSysConfig(_ context.Context, addr string) SysConfig {
 		sc.Config["xfs-error-config"] = xfsErrorConfigs
 	}
 
+	sc.Config["thp-config"] = getTHPConfigs()
+
 	return sc
 }
 
@@ -485,6 +498,31 @@ func readIntFromFile(filePath string) (num int, err error) {
 	}
 
 	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+func getTHPConfigs() THPConfigs {
+	data, err := os.ReadFile("/sys/kernel/mm/transparent_hugepage/enabled")
+	if err != nil {
+		return THPConfigs{Error: err.Error()}
+	}
+	configs := THPConfigs{Enabled: strings.TrimSpace(string(data))}
+
+	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/defrag")
+	if err != nil {
+		return THPConfigs{Error: err.Error()}
+	}
+	configs.Defrag = strings.TrimSpace(string(data))
+
+	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none")
+	if err != nil {
+		return THPConfigs{Error: err.Error()}
+	}
+
+	configs.MaxPtesNone, err = strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return THPConfigs{Error: err.Error()}
+	}
+	return configs
 }
 
 func getXFSErrorMaxRetries() XFSErrorConfigs {

--- a/health.go
+++ b/health.go
@@ -493,24 +493,26 @@ func getTHPConfigs() map[string]interface{} {
 	configs := map[string]interface{}{}
 	data, err := os.ReadFile("/sys/kernel/mm/transparent_hugepage/enabled")
 	if err != nil {
-		return map[string]interface{}{"error": err.Error()}
+		configs["enabled_error"] = err.Error()
+	} else {
+		configs["enabled"] = strings.TrimSpace(string(data))
 	}
-	configs["enabled"] = strings.TrimSpace(string(data))
 
 	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/defrag")
 	if err != nil {
-		return map[string]interface{}{"error": err.Error()}
+		configs["defrag_error"] = err.Error()
+	} else {
+		configs["defrag"] = strings.TrimSpace(string(data))
 	}
-	configs["defrag"] = strings.TrimSpace(string(data))
 
 	data, err = os.ReadFile("/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none")
 	if err != nil {
-		return map[string]interface{}{"error": err.Error()}
-	}
-
-	configs["max_ptes_none"], err = strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return map[string]interface{}{"error": err.Error()}
+		configs["max_ptes_none_error"] = err.Error()
+	} else {
+		configs["max_ptes_none"], err = strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			configs["max_ptes_none_error"] = err.Error()
+		}
 	}
 
 	return configs


### PR DESCRIPTION
Add a new node `thp-config` under `sys -> config` and inside it add values from following config files:

/sys/kernel/mm/transparent_hugepage/enabled
/sys/kernel/mm/transparent_hugepage/defrag
/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none

ref: https://tip.golang.org/doc/gc-guide#Linux_transparent_huge_pages