### PR TITLE
Make ParsePrometheusResults method public

### DIFF
--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -71,10 +71,11 @@ func (client *MetricsClient) fetchMetrics(ctx context.Context, subSystem string)
 		return nil, httpRespToErrorResponse(resp)
 	}
 
-	return parsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
+	return ParsePrometheusResults(io.LimitReader(resp.Body, metricsRespBodyLimit))
 }
 
-func parsePrometheusResults(reader io.Reader) (results []*prom2json.Family, err error) {
+// ParsePrometheusResults Returns Prometheus objects from string reader
+func ParsePrometheusResults(reader io.Reader) (results []*prom2json.Family, err error) {
 	mfChan := make(chan *dto.MetricFamily)
 	errChan := make(chan error)
 

--- a/prometheus_metrics_test.go
+++ b/prometheus_metrics_test.go
@@ -33,7 +33,7 @@ func TestParsePrometheusResultsReturnsPrometheusObjectsFromStringReader(t *testi
 		go_gc_duration_seconds_count 397
 	`
 	myReader := strings.NewReader(prometheusResults)
-	results, err := parsePrometheusResults(myReader)
+	results, err := ParsePrometheusResults(myReader)
 	if err != nil {
 		t.Errorf("error not expected, got: %v", err)
 	}


### PR DESCRIPTION
We'll be using this method in other minIO products so sharing this so that we don't have to duplicate code. It already has tests.