### PR TITLE
Add mips64le as a recognized architecture

### DIFF
--- a/kernel/kernel_utsname_int8.go
+++ b/kernel/kernel_utsname_int8.go
@@ -17,8 +17,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-//go:build (linux && 386) || (linux && amd64) || (linux && arm64) || (linux && loong64) || (linux && mips64) || (linux && mips)
-// +build linux,386 linux,amd64 linux,arm64 linux,loong64 linux,mips64 linux,mips
+//go:build (linux && 386) || (linux && amd64) || (linux && arm64) || (linux && loong64) || (linux && mips64) || (linux && mips64le) || (linux && mips)
+// +build linux,386 linux,amd64 linux,arm64 linux,loong64 linux,mips64 linux,mips64le linux,mips
 
 package kernel
 


### PR DESCRIPTION
Currently, trying to build this library on a mips64le system produces the following error:

```
# github.com/minio/madmin-go/kernel
src/github.com/minio/madmin-go/kernel/kernel.go:76:32: undefined: utsnameStr
```

That's because there's no build check for mips64le in `kernel/kernel_utsname_int8.go`. I think that's the correct file to add it to, so I did.

Initially noticed while trying to build another program for Debian on a mips64le host. I have tested the changes on the Debian mips64el porter box; everything builds, and all the tests pass.