### PR TITLE
problem

### DIFF
--- a/kernel/kernel_utsname_int8.go
+++ b/kernel/kernel_utsname_int8.go
@@ -17,8 +17,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-//go:build (linux && 386) || (linux && amd64) || (linux && arm64) || (linux && loong64) || (linux && mips64) || (linux && mips64le) || (linux && mips)
-// +build linux,386 linux,amd64 linux,arm64 linux,loong64 linux,mips64 linux,mips64le linux,mips
+//go:build (linux && 386) || (linux && amd64) || (linux && arm64) || (linux && loong64) || (linux && mips64) || (linux && mips64le) || (linux && mips) || (linux && loong64)
+// +build linux,386 linux,amd64 linux,arm64 linux,loong64 linux,mips64 linux,mips64le linux,mips linux,loong64
 
 package kernel
 


### PR DESCRIPTION
Similar problems have occurred under the Loongarch64 #260

`# github.com/minio/madmin-go/kernel
../../go-workspace/pkg/mod/github.com/minio/madmin-go@v1.7.5/kernel/kernel.go:73:32: undefined: utsnameStr`


