### PR TITLE
Fix logTrace type mismatch

### DIFF
--- a/api-log-entry.go
+++ b/api-log-entry.go
@@ -28,9 +28,9 @@ type logArgs struct {
 
 // Trace - defines the trace.
 type logTrace struct {
-	Message   string            `json:"message,omitempty"`
-	Source    []string          `json:"source,omitempty"`
-	Variables map[string]string `json:"variables,omitempty"`
+	Message   string                 `json:"message,omitempty"`
+	Source    []string               `json:"source,omitempty"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
 }
 
 // API - defines the api type and its args.


### PR DESCRIPTION
Now matches https://github.com/minio/pkg/blob/main/logger/message/log/entry.go#L46

Fixes infinite loop in GetLogs.