### PR TITLE
Add `ListAccessKeysLDAPv2` to allow listing multiple users in one call

### DIFF
--- a/idp-commands.go
+++ b/idp-commands.go
@@ -285,8 +285,9 @@ type PolicyEntitiesResult struct {
 
 // UserPolicyEntities - user -> policies mapping
 type UserPolicyEntities struct {
-	User     string   `json:"user"`
-	Policies []string `json:"policies"`
+	User             string                `json:"user"`
+	Policies         []string              `json:"policies"`
+	MemberOfMappings []GroupPolicyEntities `json:"memberOfMappings,omitempty"`
 }
 
 // GroupPolicyEntities - group -> policies mapping

--- a/user-commands.go
+++ b/user-commands.go
@@ -634,7 +634,7 @@ const (
 // ListAccessKeysLDAPV2 - list service accounts belonging to the given users or all users
 func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
 	if len(userDNs) > 0 && all {
-		return nil, errors.New("user DNs cannot be specified with --all")
+		return nil, errors.New("either specify userDNs or all, not both")
 	}
 
 	queryValues := url.Values{}

--- a/user-commands.go
+++ b/user-commands.go
@@ -631,7 +631,7 @@ const (
 	AccessKeyListAll        = "all"
 )
 
-// ListAccessKeysLDAPv2 - list service accounts belonging to the given users or all users
+// ListAccessKeysLDAPBulk - list service accounts belonging to the given users or all users
 func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
 	if len(users) > 0 && all {
 		return nil, errors.New("either specify userDNs or all, not both")

--- a/user-commands.go
+++ b/user-commands.go
@@ -624,12 +624,23 @@ func (adm *AdminClient) ListAccessKeysLDAP(ctx context.Context, userDN string, l
 	return listResp, nil
 }
 
+const (
+	AccessKeyListUsersOnly  = "users-only"
+	AccessKeyListSTSOnly    = "sts-only"
+	AccessKeyListSvcaccOnly = "svcacc-only"
+	AccessKeyListAll        = "all"
+)
+
 // ListAccessKeysLDAPV2 - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, self bool) (map[string]ListAccessKeysLDAPResp, error) {
+func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
+	if len(userDNs) > 0 && all {
+		return nil, errors.New("user DNs cannot be specified with --all")
+	}
+
 	queryValues := url.Values{}
-	queryValues.Set("listType", listType)
+	queryValues.Set("listType", string(listType))
 	queryValues["userDNs"] = userDNs
-	if self {
+	if all {
 		queryValues.Set("all", "true")
 	}
 

--- a/user-commands.go
+++ b/user-commands.go
@@ -631,15 +631,15 @@ const (
 	AccessKeyListAll        = "all"
 )
 
-// ListAccessKeysLDAPV2 - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
-	if len(userDNs) > 0 && all {
+// ListAccessKeysLDAPv2 - list service accounts belonging to the given users or all users
+func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
+	if len(users) > 0 && all {
 		return nil, errors.New("either specify userDNs or all, not both")
 	}
 
 	queryValues := url.Values{}
-	queryValues.Set("listType", string(listType))
-	queryValues["userDNs"] = userDNs
+	queryValues.Set("listType", listType)
+	queryValues["userDNs"] = users
 	if all {
 		queryValues.Set("all", "true")
 	}

--- a/user-commands.go
+++ b/user-commands.go
@@ -632,7 +632,7 @@ const (
 )
 
 // ListAccessKeysLDAPv2 - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
+func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
 	if len(users) > 0 && all {
 		return nil, errors.New("either specify userDNs or all, not both")
 	}

--- a/user-commands.go
+++ b/user-commands.go
@@ -645,11 +645,11 @@ func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []stri
 	}
 
 	reqData := requestData{
-		relPath:     adminAPIPrefix + "/idp/ldap/list-access-keys-v2",
+		relPath:     adminAPIPrefix + "/idp/ldap/list-access-keys-bulk",
 		queryValues: queryValues,
 	}
 
-	// Execute GET on /minio/admin/v3/idp/ldap/list-access-keys-v2
+	// Execute GET on /minio/admin/v3/idp/ldap/list-access-keys-bulk
 	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
 	defer closeResponse(resp)
 	if err != nil {

--- a/user-commands.go
+++ b/user-commands.go
@@ -625,11 +625,11 @@ func (adm *AdminClient) ListAccessKeysLDAP(ctx context.Context, userDN string, l
 }
 
 // ListAccessKeysLDAPV2 - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
+func (adm *AdminClient) ListAccessKeysLDAPv2(ctx context.Context, userDNs []string, listType string, self bool) (map[string]ListAccessKeysLDAPResp, error) {
 	queryValues := url.Values{}
 	queryValues.Set("listType", listType)
 	queryValues["userDNs"] = userDNs
-	if all {
+	if self {
 		queryValues.Set("all", "true")
 	}
 


### PR DESCRIPTION
Previous `ListAccessKeysLDAP` only allows for listing one user at a time, this adds new ability to query accesskeys for multiple or all users