### PR TITLE
Use typed backend information

### DIFF
--- a/health.go
+++ b/health.go
@@ -1066,7 +1066,7 @@ type MinioInfo struct {
 	Objects      Objects          `json:"objects,omitempty"`
 	Usage        Usage            `json:"usage,omitempty"`
 	Services     Services         `json:"services,omitempty"`
-	Backend      interface{}      `json:"backend,omitempty"`
+	Backend      BackendInfo      `json:"backend,omitempty"`
 	Servers      []ServerInfo     `json:"servers,omitempty"`
 	TLS          *TLSInfo         `json:"tls"`
 	IsKubernetes *bool            `json:"is_kubernetes"`


### PR DESCRIPTION
The `MinioInfo` structure contains backend information, but it's not typed.

PS: I'm not sure if there is a specific reason why this wasn't typed, so please close and comment if it cannot be typed for some reason.