### PR TITLE
heal: Add Finished bool field to drive healing info

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -380,9 +380,12 @@ type HealingDisk struct {
 
 	// Filled on startup/restarts.
 	QueuedBuckets []string `json:"queued_buckets"`
-
 	// Filled during heal.
 	HealedBuckets []string `json:"healed_buckets"`
+
+	// Healing of this drive is finished, successfully or not
+	Finished bool `json:"finished"`
+
 	// future add more tracking capabilities
 }
 


### PR DESCRIPTION
Currently .healing.bin is removed when healing is finished. However, we are 
going to preserve .healing.bin to keep historical information. So adding 
Finished as a boolean flag to indicate that healing of a drive is finished 
will be needed.