### PR TITLE
tier: az: Have an empty Endpoint by default

### DIFF
--- a/tier-azure.go
+++ b/tier-azure.go
@@ -114,7 +114,7 @@ func NewTierAzure(name, accountName, accountKey, bucket string, options ...Azure
 		AccountKey:  accountKey,
 		Bucket:      bucket,
 		// Defaults
-		Endpoint:     "http://blob.core.windows.net",
+		Endpoint:     "",
 		Prefix:       "",
 		Region:       "",
 		StorageClass: "",


### PR DESCRIPTION
blob.core.windows.net is not DNS resolvable alread, avoid setting this value 
since it is confusing and not useful.