### PR TITLE
heal: Add RetryAttempts field to healing info drive

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -361,6 +361,8 @@ type HealingDisk struct {
 	Started    time.Time `json:"started"`
 	LastUpdate time.Time `json:"last_update"`
 
+	RetryAttempts uint64 `json:"retry_attempts"`
+
 	ObjectsTotalCount uint64 `json:"objects_total_count"`
 	ObjectsTotalSize  uint64 `json:"objects_total_size"`
 


### PR DESCRIPTION
This will help mc to show accurate information, since a retry can confuse the ETA