### PR TITLE
Add `ListAccessKeysBulk`

### DIFF
--- a/idp-commands.go
+++ b/idp-commands.go
@@ -442,6 +442,8 @@ func (adm *AdminClient) attachOrDetachPolicyLDAP(ctx context.Context, isAttach b
 type ListAccessKeysLDAPResp ListAccessKeysResp
 
 // ListAccessKeysLDAP - list service accounts belonging to the specified user
+//
+// Deprecated: Use ListAccessKeysLDAP instead.
 func (adm *AdminClient) ListAccessKeysLDAP(ctx context.Context, userDN string, listType string) (ListAccessKeysLDAPResp, error) {
 	queryValues := url.Values{}
 	queryValues.Set("listType", listType)
@@ -452,7 +454,7 @@ func (adm *AdminClient) ListAccessKeysLDAP(ctx context.Context, userDN string, l
 		queryValues: queryValues,
 	}
 
-	// Execute GET on /minio/admin/v3/list-service-accounts
+	// Execute GET on /minio/admin/v3/idp/ldap/list-access-keys
 	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
 	defer closeResponse(resp)
 	if err != nil {
@@ -475,23 +477,16 @@ func (adm *AdminClient) ListAccessKeysLDAP(ctx context.Context, userDN string, l
 	return listResp, nil
 }
 
-const (
-	AccessKeyListUsersOnly  = "users-only"
-	AccessKeyListSTSOnly    = "sts-only"
-	AccessKeyListSvcaccOnly = "svcacc-only"
-	AccessKeyListAll        = "all"
-)
-
-// ListAccessKeysLDAPBulk - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysLDAPResp, error) {
-	if len(users) > 0 && all {
+// ListAccessKeysLDAPBulk - list access keys belonging to the given users or all users
+func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []string, opts ListAccessKeysOpts) (map[string]ListAccessKeysLDAPResp, error) {
+	if len(users) > 0 && opts.All {
 		return nil, errors.New("either specify userDNs or all, not both")
 	}
 
 	queryValues := url.Values{}
-	queryValues.Set("listType", listType)
+	queryValues.Set("listType", opts.ListType)
 	queryValues["userDNs"] = users
-	if all {
+	if opts.All {
 		queryValues.Set("all", "true")
 	}
 

--- a/idp-commands.go
+++ b/idp-commands.go
@@ -522,38 +522,3 @@ func (adm *AdminClient) ListAccessKeysLDAPBulk(ctx context.Context, users []stri
 	}
 	return listResp, nil
 }
-
-type InfoAccessKeyLDAPResp InfoAccessKeyResp
-
-// InfoAccessKey - returns the info of the given access key (sts or service account)
-func (adm *AdminClient) InfoAccessKeyLDAP(ctx context.Context, accessKey string) (InfoAccessKeyLDAPResp, error) {
-	queryValues := url.Values{}
-	queryValues.Set("accessKey", accessKey)
-
-	reqData := requestData{
-		relPath:     adminAPIPrefix + "/idp/ldap/info-access-key",
-		queryValues: queryValues,
-	}
-
-	// Execute GET on /minio/admin/v3/info-access-key
-	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
-	defer closeResponse(resp)
-	if err != nil {
-		return InfoAccessKeyLDAPResp{}, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return InfoAccessKeyLDAPResp{}, httpRespToErrorResponse(resp)
-	}
-
-	data, err := DecryptData(adm.getSecretKey(), resp.Body)
-	if err != nil {
-		return InfoAccessKeyLDAPResp{}, err
-	}
-
-	var infoResp InfoAccessKeyLDAPResp
-	if err = json.Unmarshal(data, &infoResp); err != nil {
-		return InfoAccessKeyLDAPResp{}, err
-	}
-	return infoResp, nil
-}

--- a/user-commands.go
+++ b/user-commands.go
@@ -602,7 +602,7 @@ type ListAccessKeysResp struct {
 	STSKeys         []ServiceAccountInfo `json:"stsKeys"`
 }
 
-// ListAccessKeysLDAPBulk - list service accounts belonging to the given users or all users
+// ListAccessKeysBulk - list service accounts belonging to the given users or all users
 func (adm *AdminClient) ListAccessKeysBulk(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysResp, error) {
 	if len(users) > 0 && all {
 		return nil, errors.New("either specify users or all, not both")
@@ -641,50 +641,6 @@ func (adm *AdminClient) ListAccessKeysBulk(ctx context.Context, users []string, 
 		return nil, err
 	}
 	return listResp, nil
-}
-
-type InfoAccessKeyResp struct {
-	Type          string     `json:"type"`
-	ParentUser    string     `json:"parentUser"`
-	AccountStatus string     `json:"accountStatus"`
-	ImpliedPolicy bool       `json:"impliedPolicy"`
-	Policy        string     `json:"policy"`
-	Name          string     `json:"name,omitempty"`
-	Description   string     `json:"description,omitempty"`
-	Expiration    *time.Time `json:"expiration,omitempty"`
-}
-
-// InfoAccessKey - returns the info of the given access key (sts or service account)
-func (adm *AdminClient) InfoAccessKey(ctx context.Context, accessKey string) (InfoAccessKeyResp, error) {
-	queryValues := url.Values{}
-	queryValues.Set("accessKey", accessKey)
-
-	reqData := requestData{
-		relPath:     adminAPIPrefix + "/info-access-key",
-		queryValues: queryValues,
-	}
-
-	// Execute GET on /minio/admin/v3/info-access-key
-	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
-	defer closeResponse(resp)
-	if err != nil {
-		return InfoAccessKeyResp{}, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return InfoAccessKeyResp{}, httpRespToErrorResponse(resp)
-	}
-
-	data, err := DecryptData(adm.getSecretKey(), resp.Body)
-	if err != nil {
-		return InfoAccessKeyResp{}, err
-	}
-
-	var infoResp InfoAccessKeyResp
-	if err = json.Unmarshal(data, &infoResp); err != nil {
-		return InfoAccessKeyResp{}, err
-	}
-	return infoResp, nil
 }
 
 // InfoServiceAccountResp is the response body of the info service account call

--- a/user-commands.go
+++ b/user-commands.go
@@ -602,16 +602,29 @@ type ListAccessKeysResp struct {
 	STSKeys         []ServiceAccountInfo `json:"stsKeys"`
 }
 
-// ListAccessKeysBulk - list service accounts belonging to the given users or all users
-func (adm *AdminClient) ListAccessKeysBulk(ctx context.Context, users []string, listType string, all bool) (map[string]ListAccessKeysResp, error) {
-	if len(users) > 0 && all {
+const (
+	AccessKeyListUsersOnly  = "users-only"
+	AccessKeyListSTSOnly    = "sts-only"
+	AccessKeyListSvcaccOnly = "svcacc-only"
+	AccessKeyListAll        = "all"
+)
+
+// ListAccessKeysOpts - options for listing access keys
+type ListAccessKeysOpts struct {
+	ListType string
+	All      bool
+}
+
+// ListAccessKeysBulk - list access keys belonging to the given users or all users
+func (adm *AdminClient) ListAccessKeysBulk(ctx context.Context, users []string, opts ListAccessKeysOpts) (map[string]ListAccessKeysResp, error) {
+	if len(users) > 0 && opts.All {
 		return nil, errors.New("either specify users or all, not both")
 	}
 
 	queryValues := url.Values{}
-	queryValues.Set("listType", listType)
+	queryValues.Set("listType", opts.ListType)
 	queryValues["users"] = users
-	if all {
+	if opts.All {
 		queryValues.Set("all", "true")
 	}
 


### PR DESCRIPTION
Adds `ListAccessKeysBulk` API to bring `ListAccessKeysLDAPBulk` features to builtin access key listing. Moves `ListAccessKeysLDAP`/`Bulk` to idp-commands.go for consistency