### PR TITLE
Add length check for empty policy content

### DIFF
--- a/policy-commands.go
+++ b/policy-commands.go
@@ -169,7 +169,7 @@ func (adm *AdminClient) RemoveCannedPolicy(ctx context.Context, policyName strin
 
 // AddCannedPolicy - adds a policy for a canned.
 func (adm *AdminClient) AddCannedPolicy(ctx context.Context, policyName string, policy []byte) error {
-	if policy == nil {
+	if len(policy) == 0 {
 		return ErrInvalidArgument("policy input cannot be empty")
 	}
 


### PR DESCRIPTION
If an empty file used as input for policy creation a zero sized byte array gets passed. Corrected the check to see length and if it's zero, error out.

Fixes: https://github.com/minio/mc/issues/5108