### PR TITLE
Remove legacy trace conversion

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -152,26 +152,6 @@ func (t TraceInfo) Mask() uint64 {
 	return t.TraceType.Mask()
 }
 
-// traceInfoLegacy - represents a trace record, additionally
-// also reports errors if any while listening on trace.
-// For minio versions before July 2022.
-type traceInfoLegacy struct {
-	TraceInfo
-
-	ReqInfo   *TraceRequestInfo  `json:"request"`
-	RespInfo  *TraceResponseInfo `json:"response"`
-	CallStats *TraceCallStats    `json:"stats"`
-
-	StorageStats *struct {
-		Path     string        `json:"path"`
-		Duration time.Duration `json:"duration"`
-	} `json:"storageStats"`
-	OSStats *struct {
-		Path     string        `json:"path"`
-		Duration time.Duration `json:"duration"`
-	} `json:"osStats"`
-}
-
 type TraceHTTPStats struct {
 	ReqInfo   TraceRequestInfo  `json:"request"`
 	RespInfo  TraceResponseInfo `json:"response"`


### PR DESCRIPTION
Remove conversion of traces for minio versions before July 2022 from PR #91

Seems like a reasonable time moving to v4.