### PR TITLE
Add Kubernetes subsystem config constant to v3

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.23.x ]
+        go-version: [ 1.24.x ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/minio/madmin-go/v3
 
 go 1.24.0
 
+toolchain go1.24.2
+
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/minio/madmin-go/v3
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.24.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/parse-config.go
+++ b/parse-config.go
@@ -70,6 +70,7 @@ const (
 	LambdaWebhookSubSys = "lambda_webhook"
 
 	BrowserSubSys          = "browser"
+	KubernetesSubSys       = "kubernetes"
 	AuditEventQueueSubSys  = "audit_event_queue"
 	ErasureSubSys          = "erasure"
 	BucketEventQueueSubSys = "bucket_event_queue"
@@ -114,6 +115,7 @@ var SubSystems = set.CreateStringSet(
 	NotifyWebhookSubSys,
 	LambdaWebhookSubSys,
 	BrowserSubSys,
+	KubernetesSubSys,
 )
 
 // EOSSubSystems - list of all subsystems for EOS


### PR DESCRIPTION
# Add Kubernetes subsystem Config constant to v3 package

eos is still using the v3 version of this package, although this commit is already merged into main branch (v4), upgrading eos to v4 might be a little too soon.

By cherry-picking [this commit](https://github.com/minio/madmin-go/commit/6e378b77df7ec72575397f35b5fc6f9cca5a54b6) to `v3` branch we can update eos to have the `kubernetes` subsystem constant with minimal update of this package and it's dependencies.

