### PR TITLE
Bugfix: move `kubernetes` subsystem to EOS

### DIFF
--- a/parse-config.go
+++ b/parse-config.go
@@ -115,7 +115,6 @@ var SubSystems = set.CreateStringSet(
 	NotifyWebhookSubSys,
 	LambdaWebhookSubSys,
 	BrowserSubSys,
-	KubernetesSubSys,
 )
 
 // EOSSubSystems - list of all subsystems for EOS
@@ -160,6 +159,7 @@ var EOSSubSystems = set.CreateStringSet(
 	AuditEventQueueSubSys,
 	ErasureSubSys,
 	BucketEventQueueSubSys,
+	KubernetesSubSys,
 )
 
 // Standard config keys and values.


### PR DESCRIPTION
Kubernetes subsystem is an EOS only subsystem

Fixes this error in eos while trying to set audience:

```
mc admin config set [ALIAS] kubernetes token_audience=sts.min.io 
mc: <ERROR> Unable to set 'kubernetes token_audience=sts.min.io' to server: unknown sub-system kubernetes token_audience=sts.min.io.
```