### PR TITLE
Bugfix: move `kubernetes` subsystem to EOS in `v3`

### DIFF
--- a/parse-config.go
+++ b/parse-config.go
@@ -115,7 +115,6 @@ var SubSystems = set.CreateStringSet(
 	NotifyWebhookSubSys,
 	LambdaWebhookSubSys,
 	BrowserSubSys,
-	KubernetesSubSys,
 )
 
 // EOSSubSystems - list of all subsystems for EOS
@@ -160,6 +159,7 @@ var EOSSubSystems = set.CreateStringSet(
 	AuditEventQueueSubSys,
 	ErasureSubSys,
 	BucketEventQueueSubSys,
+	KubernetesSubSys,
 )
 
 // Standard config keys and values.


### PR DESCRIPTION
This is a cherry-pick of https://github.com/minio/madmin-go/pull/373