### PR TITLE
Direct msgp to decode time.Time in UTC for all time values

### DIFF
--- a/bucket-targets.go
+++ b/bucket-targets.go
@@ -27,6 +27,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp
 
 // BucketTargets represents a slice of bucket targets by type and endpoint

--- a/bucket-targets_gen.go
+++ b/bucket-targets_gen.go
@@ -142,7 +142,7 @@ func (z *BucketTarget) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "resetBeforeDate":
-			z.ResetBeforeDate, err = dc.ReadTime()
+			z.ResetBeforeDate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "ResetBeforeDate")
 				return
@@ -162,7 +162,7 @@ func (z *BucketTarget) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "lastOnline":
-			z.LastOnline, err = dc.ReadTime()
+			z.LastOnline, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastOnline")
 				return
@@ -879,7 +879,7 @@ func (z *BucketTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "resetBeforeDate":
-			z.ResetBeforeDate, bts, err = msgp.ReadTimeBytes(bts)
+			z.ResetBeforeDate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ResetBeforeDate")
 				return
@@ -899,7 +899,7 @@ func (z *BucketTarget) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "lastOnline":
-			z.LastOnline, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastOnline, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastOnline")
 				return
@@ -1186,7 +1186,7 @@ func (z *Credentials) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x4
 		case "expiration":
-			z.Expiration, err = dc.ReadTime()
+			z.Expiration, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "Expiration")
 				return
@@ -1394,7 +1394,7 @@ func (z *Credentials) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x4
 		case "expiration":
-			z.Expiration, bts, err = msgp.ReadTimeBytes(bts)
+			z.Expiration, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Expiration")
 				return

--- a/external.go
+++ b/external.go
@@ -24,6 +24,7 @@ package madmin
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -unexported -file $GOFILE
 
 type cpuTimesStat struct {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/safchain/ethtool v0.5.10
 	github.com/secure-io/sio-go v0.3.1
 	github.com/shirou/gopsutil/v4 v4.25.4
-	github.com/tinylib/msgp v1.2.5
+	github.com/tinylib/msgp v1.3.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/shirou/gopsutil/v4 v4.25.4 h1:cdtFO363VEOOFrUCjZRh4XVJkb548lyF0q0uTeM
 github.com/shirou/gopsutil/v4 v4.25.4/go.mod h1:xbuxyoZj+UsgnZrENu3lQivsngRR5BdjbJwf2fv4szA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
-github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
+github.com/tinylib/msgp v1.3.0 h1:ULuf7GPooDaIlbyvgAxBV/FI7ynli6LZ1/nVUNu+0ww=
+github.com/tinylib/msgp v1.3.0/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=

--- a/heal-commands.go
+++ b/heal-commands.go
@@ -32,6 +32,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // HealScanMode represents the type of healing scan

--- a/heal-commands_gen.go
+++ b/heal-commands_gen.go
@@ -2210,7 +2210,7 @@ func (z *HealStartSuccess) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, err = dc.ReadTime()
+			z.StartTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2309,7 +2309,7 @@ func (z *HealStartSuccess) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.StartTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2363,7 +2363,7 @@ func (z *HealStopSuccess) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, err = dc.ReadTime()
+			z.StartTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2462,7 +2462,7 @@ func (z *HealStopSuccess) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.StartTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2518,7 +2518,7 @@ func (z *HealTaskStatus) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, err = dc.ReadTime()
+			z.StartTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2727,7 +2727,7 @@ func (z *HealTaskStatus) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.StartTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
@@ -2845,13 +2845,13 @@ func (z *HealingDisk) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "started":
-			z.Started, err = dc.ReadTime()
+			z.Started, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "Started")
 				return
 			}
 		case "last_update":
-			z.LastUpdate, err = dc.ReadTime()
+			z.LastUpdate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -3393,13 +3393,13 @@ func (z *HealingDisk) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "started":
-			z.Started, bts, err = msgp.ReadTimeBytes(bts)
+			z.Started, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Started")
 				return
 			}
 		case "last_update":
-			z.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastUpdate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return

--- a/info-commands.go
+++ b/info-commands.go
@@ -30,6 +30,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // BackendType - represents different backend types.

--- a/info-commands_gen.go
+++ b/info-commands_gen.go
@@ -2054,7 +2054,7 @@ func (z *DataUsageInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "lastUpdate":
-			z.LastUpdate, err = dc.ReadTime()
+			z.LastUpdate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -2535,7 +2535,7 @@ func (z *DataUsageInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "lastUpdate":
-			z.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastUpdate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -5608,7 +5608,7 @@ func (z *GCStats) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "last_gc":
-			z.LastGC, err = dc.ReadTime()
+			z.LastGC, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastGC")
 				return
@@ -5657,7 +5657,7 @@ func (z *GCStats) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.PauseEnd = make([]time.Time, zb0003)
 			}
 			for za0002 := range z.PauseEnd {
-				z.PauseEnd[za0002], err = dc.ReadTime()
+				z.PauseEnd[za0002], err = dc.ReadTimeUTC()
 				if err != nil {
 					err = msgp.WrapError(err, "PauseEnd", za0002)
 					return
@@ -5791,7 +5791,7 @@ func (z *GCStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "last_gc":
-			z.LastGC, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastGC, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastGC")
 				return
@@ -5840,7 +5840,7 @@ func (z *GCStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.PauseEnd = make([]time.Time, zb0003)
 			}
 			for za0002 := range z.PauseEnd {
-				z.PauseEnd[za0002], bts, err = msgp.ReadTimeBytes(bts)
+				z.PauseEnd[za0002], bts, err = msgp.ReadTimeUTCBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PauseEnd", za0002)
 					return

--- a/info-v4-commands.go
+++ b/info-v4-commands.go
@@ -33,6 +33,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // ClusterInfo cluster level information

--- a/license.go
+++ b/license.go
@@ -28,6 +28,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp
 // LicenseInfo is a structure containing MinIO license information.
 

--- a/license_gen.go
+++ b/license_gen.go
@@ -43,13 +43,13 @@ func (z *LicenseInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "IssuedAt":
-			z.IssuedAt, err = dc.ReadTime()
+			z.IssuedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "IssuedAt")
 				return
 			}
 		case "ExpiresAt":
-			z.ExpiresAt, err = dc.ReadTime()
+			z.ExpiresAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "ExpiresAt")
 				return
@@ -218,13 +218,13 @@ func (z *LicenseInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "IssuedAt":
-			z.IssuedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.IssuedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "IssuedAt")
 				return
 			}
 		case "ExpiresAt":
-			z.ExpiresAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.ExpiresAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ExpiresAt")
 				return

--- a/metrics.go
+++ b/metrics.go
@@ -39,6 +39,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -unexported -file $GOFILE
 
 // MetricType is a bitfield representation of different metric types.

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -29,7 +29,7 @@ func (z *BatchJobMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -153,7 +153,7 @@ func (z *BatchJobMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -231,7 +231,7 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -403,7 +403,7 @@ func (z *CPUMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -1355,7 +1355,7 @@ func (z *DiskMetric) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -1761,7 +1761,7 @@ func (z *DiskMetric) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -2193,13 +2193,13 @@ func (z *JobMetric) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, err = dc.ReadTime()
+			z.StartTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
 			}
 		case "lastUpdate":
-			z.LastUpdate, err = dc.ReadTime()
+			z.LastUpdate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -2642,13 +2642,13 @@ func (z *JobMetric) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "startTime":
-			z.StartTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.StartTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
 			}
 		case "lastUpdate":
-			z.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastUpdate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -3584,7 +3584,7 @@ func (z *MemMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -3668,7 +3668,7 @@ func (z *MemMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -3891,7 +3891,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					}
 					switch msgp.UnsafeString(field) {
 					case "collected":
-						z.Net.CollectedAt, err = dc.ReadTime()
+						z.Net.CollectedAt, err = dc.ReadTimeUTC()
 						if err != nil {
 							err = msgp.WrapError(err, "Net", "CollectedAt")
 							return
@@ -3945,7 +3945,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					}
 					switch msgp.UnsafeString(field) {
 					case "collected":
-						z.Mem.CollectedAt, err = dc.ReadTime()
+						z.Mem.CollectedAt, err = dc.ReadTimeUTC()
 						if err != nil {
 							err = msgp.WrapError(err, "Mem", "CollectedAt")
 							return
@@ -4694,7 +4694,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch msgp.UnsafeString(field) {
 					case "collected":
-						z.Net.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+						z.Net.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Net", "CollectedAt")
 							return
@@ -4747,7 +4747,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 					switch msgp.UnsafeString(field) {
 					case "collected":
-						z.Mem.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+						z.Mem.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 						if err != nil {
 							err = msgp.WrapError(err, "Mem", "CollectedAt")
 							return
@@ -5342,7 +5342,7 @@ func (z *NetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -5445,7 +5445,7 @@ func (z *NetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -5501,7 +5501,7 @@ func (z *OSMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -5790,7 +5790,7 @@ func (z *OSMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -5944,7 +5944,7 @@ func (z *RPCMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collectedAt":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -6010,7 +6010,7 @@ func (z *RPCMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "lastPongTime":
-			z.LastPongTime, err = dc.ReadTime()
+			z.LastPongTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastPongTime")
 				return
@@ -6028,7 +6028,7 @@ func (z *RPCMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "lastConnectTime":
-			z.LastConnectTime, err = dc.ReadTime()
+			z.LastConnectTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastConnectTime")
 				return
@@ -6455,7 +6455,7 @@ func (z *RPCMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collectedAt":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -6521,7 +6521,7 @@ func (z *RPCMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "lastPongTime":
-			z.LastPongTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastPongTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastPongTime")
 				return
@@ -6539,7 +6539,7 @@ func (z *RPCMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "lastConnectTime":
-			z.LastConnectTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastConnectTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastConnectTime")
 				return
@@ -7984,7 +7984,7 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -8616,7 +8616,7 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -8944,7 +8944,7 @@ func (z *SiteResyncMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, err = dc.ReadTime()
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -8957,13 +8957,13 @@ func (z *SiteResyncMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x1
 		case "startTime":
-			z.StartTime, err = dc.ReadTime()
+			z.StartTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
 			}
 		case "lastUpdate":
-			z.LastUpdate, err = dc.ReadTime()
+			z.LastUpdate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
@@ -9349,7 +9349,7 @@ func (z *SiteResyncMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "collected":
-			z.CollectedAt, bts, err = msgp.ReadTimeBytes(bts)
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CollectedAt")
 				return
@@ -9362,13 +9362,13 @@ func (z *SiteResyncMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x1
 		case "startTime":
-			z.StartTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.StartTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "StartTime")
 				return
 			}
 		case "lastUpdate":
-			z.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastUpdate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return

--- a/opentelemetry.go
+++ b/opentelemetry.go
@@ -27,9 +27,9 @@ import (
 	"github.com/minio/madmin-go/v4/estream"
 )
 
-//go:generate msgp $GOFILE
-
+//msgp:timezone utc
 //msgp:replace TraceType with:uint64
+//go:generate msgp $GOFILE
 
 // ServiceTelemetryOpts is a request to add following types to tracing.
 type ServiceTelemetryOpts struct {

--- a/replication-api.go
+++ b/replication-api.go
@@ -27,6 +27,7 @@ import (
 	"time"
 )
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // ReplDiffOpts holds options for `mc replicate diff` command

--- a/scanner.go
+++ b/scanner.go
@@ -28,6 +28,7 @@ import (
 )
 
 //msgp:clearomitted
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // BucketScanInfo contains information of a bucket scan in a given pool/set

--- a/scanner_gen.go
+++ b/scanner_gen.go
@@ -53,13 +53,13 @@ func (z *BucketScanInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "last_update":
-			z.LastUpdate, err = dc.ReadTime()
+			z.LastUpdate, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
 			}
 		case "last_started":
-			z.LastStarted, err = dc.ReadTime()
+			z.LastStarted, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastStarted")
 				return
@@ -77,7 +77,7 @@ func (z *BucketScanInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.Completed = make([]time.Time, zb0002)
 			}
 			for za0001 := range z.Completed {
-				z.Completed[za0001], err = dc.ReadTime()
+				z.Completed[za0001], err = dc.ReadTimeUTC()
 				if err != nil {
 					err = msgp.WrapError(err, "Completed", za0001)
 					return
@@ -292,13 +292,13 @@ func (z *BucketScanInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "last_update":
-			z.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastUpdate, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
 			}
 		case "last_started":
-			z.LastStarted, bts, err = msgp.ReadTimeBytes(bts)
+			z.LastStarted, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastStarted")
 				return
@@ -316,7 +316,7 @@ func (z *BucketScanInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.Completed = make([]time.Time, zb0002)
 			}
 			for za0001 := range z.Completed {
-				z.Completed[za0001], bts, err = msgp.ReadTimeBytes(bts)
+				z.Completed[za0001], bts, err = msgp.ReadTimeUTCBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Completed", za0001)
 					return

--- a/summary-object.go
+++ b/summary-object.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+//msgp:timezone utc
 //go:generate msgp -unexported -file=$GOFILE
 
 // ObjectSummaryOptions provides options for ObjectSummary call.

--- a/summary-object_gen.go
+++ b/summary-object_gen.go
@@ -2152,7 +2152,7 @@ func (z *ObjectVersionSummary) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "ModTime":
-			z.ModTime, err = dc.ReadTime()
+			z.ModTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "ModTime")
 				return
@@ -2270,7 +2270,7 @@ func (z *ObjectVersionSummary) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "ModTime":
-			z.ModTime, bts, err = msgp.ReadTimeBytes(bts)
+			z.ModTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ModTime")
 				return

--- a/tier-azure.go
+++ b/tier-azure.go
@@ -21,6 +21,7 @@ package madmin
 
 import "errors"
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // ServicePrincipalAuth holds fields for a successful SP authentication with Azure

--- a/tier-config.go
+++ b/tier-config.go
@@ -25,6 +25,7 @@ import (
 	"log"
 )
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // TierConfigVer refers to the current tier config version

--- a/tier-gcs.go
+++ b/tier-gcs.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 )
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // TierGCS represents the remote tier configuration for Google Cloud Storage

--- a/tier-minio.go
+++ b/tier-minio.go
@@ -19,6 +19,7 @@
 
 package madmin
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // TierMinIO represents the remote tier configuration for MinIO object storage backend.

--- a/tier-s3.go
+++ b/tier-s3.go
@@ -19,6 +19,7 @@
 
 package madmin
 
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 // TierS3 represents the remote tier configuration for AWS S3 compatible backend.

--- a/utils.go
+++ b/utils.go
@@ -33,6 +33,7 @@ import (
 
 //msgp:clearomitted
 //msgp:tag json
+//msgp:timezone utc
 //go:generate msgp -file $GOFILE
 
 var (


### PR DESCRIPTION
Currently the node your admin request hits will return UTC, but every other node will return `.Local()` timezone:

```
❯ mc admin heal vms --json | jq . |  grep last_update
              "last_update": "2025-05-07T12:17:19.098791885Z",
              "last_update": "2025-05-07T14:17:19.074143691+02:00",
              "last_update": "2025-05-07T14:17:18.015376327+02:00",
              "last_update": "2025-05-07T12:17:19.101336448Z",
              "last_update": "2025-05-07T14:17:19.078391397+02:00",
              "last_update": "2025-05-07T14:17:18.009332111+02:00",
```

After:

```
❯ mc admin heal vms --json | jq . |  grep last_update
              "last_update": "2025-05-07T12:55:17.304706378Z",
              "last_update": "2025-05-07T12:55:17.331246424Z",
              "last_update": "2025-05-07T12:55:17.333792588Z",
              "last_update": "2025-05-07T12:55:17.305889423Z",
              "last_update": "2025-05-07T12:55:17.332239139Z",
              "last_update": "2025-05-07T12:55:17.334615298Z",
```