### PR TITLE
remove unncessary CPU freqStats

### DIFF
--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -2,7 +2,7 @@
 // +build linux
 
 //
-// Copyright (c) 2015-2024 MinIO, Inc.
+// Copyright (c) 2015-2025 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -23,37 +23,33 @@
 package madmin
 
 import (
-	"github.com/prometheus/procfs/sysfs"
+	"os"
+	"path/filepath"
+	"strconv"
 )
 
-func getCPUFreqStats() ([]CPUFreqStats, error) {
-	fs, err := sysfs.NewFS("/sys")
-	if err != nil {
-		return nil, err
-	}
+func getCPUFreqStats() (stats []CPUFreqStats, err error) {
+	for i := 0; ; i++ {
+		governorPath := filepath.Join(
+			"/sys/devices/system/cpu",
+			"cpu"+strconv.Itoa(i),
+			"cpufreq",
+			"scaling_governor",
+		)
 
-	stats, err := fs.SystemCpufreq()
-	if err != nil {
-		return nil, err
-	}
+		content, err1 := os.ReadFile(governorPath)
+		if err1 != nil {
+			err = err1
+			continue
+		}
 
-	out := make([]CPUFreqStats, 0, len(stats))
-	for _, stat := range stats {
-		out = append(out, CPUFreqStats{
-			Name:                     stat.Name,
-			CpuinfoCurrentFrequency:  stat.CpuinfoCurrentFrequency,
-			CpuinfoMinimumFrequency:  stat.CpuinfoMinimumFrequency,
-			CpuinfoMaximumFrequency:  stat.CpuinfoMaximumFrequency,
-			CpuinfoTransitionLatency: stat.CpuinfoTransitionLatency,
-			ScalingCurrentFrequency:  stat.ScalingCurrentFrequency,
-			ScalingMinimumFrequency:  stat.ScalingMinimumFrequency,
-			ScalingMaximumFrequency:  stat.ScalingMaximumFrequency,
-			AvailableGovernors:       stat.AvailableGovernors,
-			Driver:                   stat.Driver,
-			Governor:                 stat.Governor,
-			RelatedCpus:              stat.RelatedCpus,
-			SetSpeed:                 stat.SetSpeed,
+		stats = append(stats, CPUFreqStats{
+			Name:     "cpu" + strconv.Itoa(i),
+			Governor: string(content),
 		})
+		// Once we can read one CPU governor stat, its enough.
+		break
 	}
-	return out, nil
+
+	return stats, err
 }

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -23,6 +23,7 @@
 package madmin
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -30,9 +31,11 @@ import (
 
 func getCPUFreqStats() (stats []CPUFreqStats, err error) {
 	for i := 0; ; i++ {
+		cpuName := "cpu" + strconv.Itoa(i)
+
 		governorPath := filepath.Join(
 			"/sys/devices/system/cpu",
-			"cpu"+strconv.Itoa(i),
+			cpuName,
 			"cpufreq",
 			"scaling_governor",
 		)
@@ -44,8 +47,8 @@ func getCPUFreqStats() (stats []CPUFreqStats, err error) {
 		}
 
 		stats = append(stats, CPUFreqStats{
-			Name:     "cpu" + strconv.Itoa(i),
-			Governor: string(content),
+			Name:     cpuName,
+			Governor: string(bytes.TrimSpace(content)),
 		})
 		// Once we can read one CPU governor stat, its enough.
 		break

--- a/cpu_nolinux.go
+++ b/cpu_nolinux.go
@@ -1,31 +1,10 @@
 //go:build !linux
 // +build !linux
 
-//
-// Copyright (c) 2015-2024 MinIO, Inc.
-//
-// This file is part of MinIO Object Storage stack
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
-
 package madmin
 
-import (
-	"errors"
-)
+import "errors"
 
-func getCPUFreqStats() ([]CPUFreqStats, error) {
+func getCPUFreqStats() (stats []CPUFreqStats, err error) {
 	return nil, errors.New("Not implemented for non-linux platforms")
 }

--- a/health.go
+++ b/health.go
@@ -161,19 +161,21 @@ type CPUs struct {
 
 // CPUFreqStats CPU frequency stats
 type CPUFreqStats struct {
-	Name                     string
-	CpuinfoCurrentFrequency  *uint64
-	CpuinfoMinimumFrequency  *uint64
-	CpuinfoMaximumFrequency  *uint64
-	CpuinfoTransitionLatency *uint64
-	ScalingCurrentFrequency  *uint64
-	ScalingMinimumFrequency  *uint64
-	ScalingMaximumFrequency  *uint64
-	AvailableGovernors       string
-	Driver                   string
-	Governor                 string
-	RelatedCpus              string
-	SetSpeed                 string
+	Name     string `json:",omitempty"`
+	Governor string `json:",omitempty"`
+
+	// All these fields are not set, kept here for future purposes.
+	CpuinfoCurrentFrequency  *uint64 `json:",omitempty"`
+	CpuinfoMinimumFrequency  *uint64 `json:",omitempty"`
+	CpuinfoMaximumFrequency  *uint64 `json:",omitempty"`
+	CpuinfoTransitionLatency *uint64 `json:",omitempty"`
+	ScalingCurrentFrequency  *uint64 `json:",omitempty"`
+	ScalingMinimumFrequency  *uint64 `json:",omitempty"`
+	ScalingMaximumFrequency  *uint64 `json:",omitempty"`
+	AvailableGovernors       string  `json:",omitempty"`
+	Driver                   string  `json:",omitempty"`
+	RelatedCpus              string  `json:",omitempty"`
+	SetSpeed                 string  `json:",omitempty"`
 }
 
 // GetCPUs returns system's all CPU information.

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,148 @@
+//
+// Copyright (c) 2015-2025 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestCPUFreqStatsJSONMarshal tests that only Name and Governor are included in JSON output when set
+func TestCPUFreqStatsJSONMarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    CPUFreqStats
+		expected string
+	}{
+		{
+			name: "Only Name and Governor set",
+			input: CPUFreqStats{
+				Name:     "cpu0",
+				Governor: "performance",
+			},
+			expected: `{"Name":"cpu0","Governor":"performance"}`,
+		},
+		{
+			name: "Only Name set",
+			input: CPUFreqStats{
+				Name: "cpu0",
+			},
+			expected: `{"Name":"cpu0"}`,
+		},
+		{
+			name: "Only Governor set",
+			input: CPUFreqStats{
+				Governor: "powersave",
+			},
+			expected: `{"Governor":"powersave"}`,
+		},
+		{
+			name:     "Empty struct",
+			input:    CPUFreqStats{},
+			expected: `{}`,
+		},
+		{
+			name: "All fields set",
+			input: CPUFreqStats{
+				Name:                     "cpu0",
+				Governor:                 "performance",
+				CpuinfoCurrentFrequency:  ptr(uint64(2000000)),
+				CpuinfoMinimumFrequency:  ptr(uint64(800000)),
+				CpuinfoMaximumFrequency:  ptr(uint64(3000000)),
+				CpuinfoTransitionLatency: ptr(uint64(1000)),
+				ScalingCurrentFrequency:  ptr(uint64(2000000)),
+				ScalingMinimumFrequency:  ptr(uint64(800000)),
+				ScalingMaximumFrequency:  ptr(uint64(3000000)),
+				AvailableGovernors:       "performance powersave",
+				Driver:                   "intel_pstate",
+				RelatedCpus:              "0-3",
+				SetSpeed:                 "2000000",
+			},
+			expected: `{"Name":"cpu0","Governor":"performance","CpuinfoCurrentFrequency":2000000,"CpuinfoMinimumFrequency":800000,"CpuinfoMaximumFrequency":3000000,"CpuinfoTransitionLatency":1000,"ScalingCurrentFrequency":2000000,"ScalingMinimumFrequency":800000,"ScalingMaximumFrequency":3000000,"AvailableGovernors":"performance powersave","Driver":"intel_pstate","RelatedCpus":"0-3","SetSpeed":"2000000"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("Failed to marshal JSON: %v", err)
+			}
+
+			if string(output) != tt.expected {
+				t.Errorf("Expected JSON: %s, got: %s", tt.expected, string(output))
+			}
+
+			// Unmarshal back to verify structure
+			var result CPUFreqStats
+			if err := json.Unmarshal(output, &result); err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
+
+			// Compare non-omitted fields
+			if tt.input.Name != result.Name {
+				t.Errorf("Expected Name: %s, got: %s", tt.input.Name, result.Name)
+			}
+			if tt.input.Governor != result.Governor {
+				t.Errorf("Expected Governor: %s, got: %s", tt.input.Governor, result.Governor)
+			}
+
+			// Verify that unset fields remain unset after unmarshaling
+			if tt.input.CpuinfoCurrentFrequency == nil && result.CpuinfoCurrentFrequency != nil {
+				t.Errorf("Expected CpuinfoCurrentFrequency to be nil, got: %v", result.CpuinfoCurrentFrequency)
+			}
+			if tt.input.CpuinfoMinimumFrequency == nil && result.CpuinfoMinimumFrequency != nil {
+				t.Errorf("Expected CpuinfoMinimumFrequency to be nil, got: %v", result.CpuinfoMinimumFrequency)
+			}
+			if tt.input.CpuinfoMaximumFrequency == nil && result.CpuinfoMaximumFrequency != nil {
+				t.Errorf("Expected CpuinfoMaximumFrequency to be nil, got: %v", result.CpuinfoMaximumFrequency)
+			}
+			if tt.input.CpuinfoTransitionLatency == nil && result.CpuinfoTransitionLatency != nil {
+				t.Errorf("Expected CpuinfoTransitionLatency to be nil, got: %v", result.CpuinfoTransitionLatency)
+			}
+			if tt.input.ScalingCurrentFrequency == nil && result.ScalingCurrentFrequency != nil {
+				t.Errorf("Expected ScalingCurrentFrequency to be nil, got: %v", result.ScalingCurrentFrequency)
+			}
+			if tt.input.ScalingMinimumFrequency == nil && result.ScalingMinimumFrequency != nil {
+				t.Errorf("Expected ScalingMinimumFrequency to be nil, got: %v", result.ScalingMinimumFrequency)
+			}
+			if tt.input.ScalingMaximumFrequency == nil && result.ScalingMaximumFrequency != nil {
+				t.Errorf("Expected ScalingMaximumFrequency to be nil, got: %v", result.ScalingMaximumFrequency)
+			}
+			if tt.input.AvailableGovernors == "" && result.AvailableGovernors != "" {
+				t.Errorf("Expected AvailableGovernors to be empty, got: %s", result.AvailableGovernors)
+			}
+			if tt.input.Driver == "" && result.Driver != "" {
+				t.Errorf("Expected Driver to be empty, got: %s", result.Driver)
+			}
+			if tt.input.RelatedCpus == "" && result.RelatedCpus != "" {
+				t.Errorf("Expected RelatedCpus to be empty, got: %s", result.RelatedCpus)
+			}
+			if tt.input.SetSpeed == "" && result.SetSpeed != "" {
+				t.Errorf("Expected SetSpeed to be empty, got: %s", result.SetSpeed)
+			}
+		})
+	}
+}
+
+// ptr is a helper function to create a pointer to a uint64
+func ptr(val uint64) *uint64 {
+	return &val
+}

--- a/info-commands.go
+++ b/info-commands.go
@@ -470,19 +470,22 @@ type DiskMetrics struct {
 	APICalls   map[string]uint64      `json:"apiCalls,omitempty"`
 
 	// TotalTokens set per drive max concurrent I/O.
-	TotalTokens uint32 `json:"totalTokens,omitempty"`
+	TotalTokens uint32 `json:"totalTokens,omitempty"` // Deprecated (unused)
+
 	// TotalWaiting the amount of concurrent I/O waiting on disk
 	TotalWaiting uint32 `json:"totalWaiting,omitempty"`
 
 	// Captures all data availability errors such as
 	// permission denied, faulty disk and timeout errors.
 	TotalErrorsAvailability uint64 `json:"totalErrorsAvailability,omitempty"`
+
 	// Captures all timeout only errors
 	TotalErrorsTimeout uint64 `json:"totalErrorsTimeout,omitempty"`
 
 	// Total writes on disk (could be empty if the feature
 	// is not enabled on the server)
 	TotalWrites uint64 `json:"totalWrites,omitempty"`
+
 	// Total deletes on disk (could be empty if the feature
 	// is not enabled on the server)
 	TotalDeletes uint64 `json:"totalDeletes,omitempty"`


### PR DESCRIPTION
CPU stats are usually empty, capturing
this is useless for all practical purposes.

this adds some insane amount of information,
with literally no useful information to SUBNET,
trim this down.