### PR TITLE
Use latest batch job metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -573,11 +573,14 @@ func (o *BatchJobMetrics) Merge(other *BatchJobMetrics) {
 		// Use latest timestamp
 		o.CollectedAt = other.CollectedAt
 	}
+	// Use latest metrics
 	if o.Jobs == nil {
 		o.Jobs = make(map[string]JobMetric, len(other.Jobs))
 	}
 	for k, v := range other.Jobs {
-		o.Jobs[k] = v
+		if exists, ok := o.Jobs[k]; !ok || exists.LastUpdate.Before(v.LastUpdate) {
+			o.Jobs[k] = v
+		}
 	}
 }
 


### PR DESCRIPTION
See https://github.com/miniohq/eos/issues/1042 for more context

Currently, `mc batch status <alias> <jobId>` will stop updating after a system restart, however brief.

The code at https://github.com/minio/madmin-go/blob/main/metrics.go#L579 simply overwrites the current metrics with remote metrics. However in the case the the local metrics are more recent than the remote metrics, e.g. if the batch job is running locally, this means that the metrics will not update after `globalNotificationSys` is reinitialized and thus no longer reflect the reality of the job.
```
	for k, v := range other.Jobs {
		o.Jobs[k] = v
	}
```

This PR ensures that the code updates the current metrics with remote metrics only if these remote metrics are more recent.
It requires subsequent patching of `eos`

---

#### Tests on `eos` using `replace github.com/minio/madmin-go/v4 => /home/ubuntu/github/allanrogerr/madmin-go`
1. Using https://gist.github.com/allanrogerr/dba740db9a6a8c6849d16b2bda628f97#file-batch_catalog_1m-yml, run a batch catalog job, save the id
```
input_bucket=bucket-1m
output_bucket=bucket-1m-no-filter-no-prefix-index
mc rb --force catalog/$output_bucket
mc mb catalog/$output_bucket
id=$(mc batch start catalog /home/ubuntu/catalog/batch_catalog_1m_no_filter_no_prefix.yml --json | jq -r '.result.id')
echo job $id
mc batch status catalog $id
```
```
Removed `catalog/bucket-1m-no-filter-no-prefix-index` successfully.
Bucket created successfully `catalog/bucket-1m-no-filter-no-prefix-index`.
job catalog-GzotFgBR2fjzvnLiQpJa9m:0

JobType:              catalog                                       
ObjectsScannedCount:  189230                                        
ObjectsMatchedCount:  189229                                        
LastScanned:          bucket-1m/myprefix27/myprefix17/object0000031 
LastMatched:          bucket-1m/myprefix27/myprefix17/object0000030 
RecordsWrittenCount:  189229                                        
OutputObjectsCount:   1                                             
Elapsed:              5s                                            
Scan Speed:           38189.974318 objects/s 
```

2. Run `mc admin service restart catalog`
```
Service status: ▰▰▰ [DONE]
Summary:
    ┌───────────────┬─────────────────────────────┐
    │ Servers:      │ 8 online, 0 offline, 0 hung │
    │ Restart Time: │ 255.677231ms                │
    └───────────────┴─────────────────────────────┘
```

3. Run `mc batch list catalog | grep in-progress`, observe the job in `in-progress` status
```
catalog-GzotFgBR2fjzvnLiQpJa9m:0 catalog  minioadmin  19 seconds ago  in-progress 
```

4. Run `mc batch status catalog $id`, observe the job in `in-progress` status
```
●∙∙
JobType:              catalog                                       
ObjectsScannedCount:  200102                                        
ObjectsMatchedCount:  200100                                        
LastScanned:          bucket-1m/myprefix28/myprefix25/object0000003 
LastMatched:          bucket-1m/myprefix28/myprefix25/object0000001 
RecordsWrittenCount:  200000                                        
OutputObjectsCount:   2                                             
Elapsed:              10s                                           
Scan Speed:           20966.932810 objects/s  
```

5. Wait between 5 and 10 minutes. Observe the job status has automatically continued. Wait and observe it to complete.
```
✔ ✔ ✔ 
JobType:              catalog                                       
ObjectsScannedCount:  948647                                        
ObjectsMatchedCount:  948645                                        
LastScanned:          bucket-1m/myprefix97/myprefix91/object0000095 
LastMatched:          bucket-1m/myprefix97/myprefix91/object0000095 
RecordsWrittenCount:  948545                                        
OutputObjectsCount:   10                                            
Elapsed:              9m36s                                         
Scan Speed:           1646.564880 objects/s 
```

6. Run `mc batch list catalog | grep $id`, observe the job in `completed` status
```
catalog-GzotFgBR2fjzvnLiQpJa9m:0 catalog  minioadmin  7 hours ago   completed 
```

7. Observe a new prefix under the batch catalog job id

8. Observe output under the new prefix
```
ubuntu@mincat-perf-1:~$ mc ls -r catalog/reports/output/bucket-1m-no-filter-no-prefix-index | grep catalog-GzotFgBR2fjzvnLiQpJa9m:0
[2025-07-12 04:57:09 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T04-57Z/files/0e70ba3e-3ea4-4a2d-afaa-06061ddf1c29.csv
[2025-07-12 04:57:14 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T04-57Z/files/6a79c7be-4b69-4743-bdde-e6a28189a478.csv
[2025-07-12 05:06:16 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/1131a069-296f-497a-9fff-460750ae5a78.csv
[2025-07-12 05:06:30 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/56aacdfc-0331-4c83-8bcc-e6152b49dce9.csv
[2025-07-12 05:06:39 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/7b54fbc9-9422-4d28-b5f3-4fd37ad2ead7.csv
[2025-07-12 05:06:41 UTC] 3.3MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/be79d772-8f1e-4a4b-8a7e-5d9dc873b5b3.csv
[2025-07-12 05:06:34 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/c58fb65b-c028-4351-bfe7-31a74ab99cb6.csv
[2025-07-12 05:06:11 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/d48de373-ba4b-42e6-b431-e89866721400.csv
[2025-07-12 05:06:20 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/d52e8437-e61e-43e3-ab33-de9585a32466.csv
[2025-07-12 05:06:25 UTC] 6.8MiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/files/ff24065c-e5db-4e82-adaf-093511139cec.csv
[2025-07-12 05:06:41 UTC] 2.4KiB STANDARD bucket-1m/catalog-GzotFgBR2fjzvnLiQpJa9m:0/2025-07-12T05-06Z/manifest.json
```