### PR TITLE
refactor: use typed HealScanMode for constant

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -43,10 +43,10 @@ const (
 	HealUnknownScan HealScanMode = 0
 
 	// HealNormalScan checks if parts are present and not outdated
-	HealNormalScan = iota
+	HealNormalScan HealScanMode = iota
 
 	// HealDeepScan checks for parts bitrot checksums
-	HealDeepScan = 1 << (iota - 1)
+	HealDeepScan HealScanMode = 1 << (iota - 1)
 
 	// HealUncommittedScan will only pick objects that are dangling (uncommitted objects in the namespace without quorum)
 	HealUncommittedScan


### PR DESCRIPTION
Tried to build eos with latest code
<img width="1547" height="287" alt="Screenshot from 2025-08-11 10-58-15" src="https://github.com/user-attachments/assets/da620284-174c-496b-9029-02f4d8a863b0" />

pr changes const type from untyped int to HealScanMode