### PR TITLE
Add Tables admin tracing support

### DIFF
--- a/service-commands.go
+++ b/service-commands.go
@@ -161,6 +161,7 @@ type ServiceTraceOpts struct {
 	BatchReplication  bool
 	BatchKeyRotation  bool
 	BatchExpire       bool
+	Tables            bool
 	BatchAll          bool
 	Rebalance         bool
 	ReplicationResync bool
@@ -190,6 +191,7 @@ func (t ServiceTraceOpts) TraceTypes() TraceType {
 	tt.SetIf(t.BatchAll || t.BatchExpire, TraceBatchExpire)
 
 	tt.SetIf(t.Rebalance, TraceRebalance)
+	tt.SetIf(t.Tables, TraceTables)
 	tt.SetIf(t.ReplicationResync, TraceReplicationResync)
 	tt.SetIf(t.Bootstrap, TraceBootstrap)
 	tt.SetIf(t.FTP, TraceFTP)
@@ -217,6 +219,7 @@ func (t ServiceTraceOpts) AddParams(u url.Values) {
 	u.Set("batch-keyrotation", strconv.FormatBool(t.BatchAll || t.BatchKeyRotation))
 	u.Set("batch-expire", strconv.FormatBool(t.BatchAll || t.BatchExpire))
 	u.Set("rebalance", strconv.FormatBool(t.Rebalance))
+	u.Set("tables", strconv.FormatBool(t.Tables))
 	u.Set("replication-resync", strconv.FormatBool(t.ReplicationResync))
 	u.Set("bootstrap", strconv.FormatBool(t.Bootstrap))
 	u.Set("ftp", strconv.FormatBool(t.FTP))
@@ -236,6 +239,7 @@ func (t *ServiceTraceOpts) ParseParams(r *http.Request) (err error) {
 	t.BatchKeyRotation = r.Form.Get("batch-keyrotation") == "true"
 	t.BatchExpire = r.Form.Get("batch-expire") == "true"
 	t.Rebalance = r.Form.Get("rebalance") == "true"
+	t.Tables = r.Form.Get("tables") == "true"
 	t.Storage = r.Form.Get("storage") == "true"
 	t.Internal = r.Form.Get("internal") == "true"
 	t.OnlyErrors = r.Form.Get("err") == "true"

--- a/service-commands_test.go
+++ b/service-commands_test.go
@@ -1,0 +1,46 @@
+// MinIO, Inc. CONFIDENTIAL
+//
+// [2014] - [2025] MinIO, Inc. All Rights Reserved.
+//
+// NOTICE:  All information contained herein is, and remains the property
+// of MinIO, Inc and its suppliers, if any.  The intellectual and technical
+// concepts contained herein are proprietary to MinIO, Inc and its suppliers
+// and may be covered by U.S. and Foreign Patents, patents in process, and are
+// protected by trade secret or copyright law. Dissemination of this information
+// or reproduction of this material is strictly forbidden unless prior written
+// permission is obtained from MinIO, Inc.
+
+package madmin
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestServiceTraceOptsTables(t *testing.T) {
+	opts := ServiceTraceOpts{Tables: true}
+	if got := opts.TraceTypes(); !got.Contains(TraceTables) {
+		t.Fatalf("TraceTypes() missing TraceTables: got %v", got)
+	}
+
+	vals := make(url.Values)
+	opts.AddParams(vals)
+	if got := vals.Get("tables"); got != "true" {
+		t.Fatalf("AddParams() tables flag = %q, want true", got)
+	}
+
+	req := httptest.NewRequest("GET", "/minio/admin/v3/trace?tables=true", nil)
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("ParseForm() returned error = %v", err)
+	}
+
+	var parsed ServiceTraceOpts
+	if err := parsed.ParseParams(req); err != nil {
+		t.Fatalf("ParseParams() returned error = %v", err)
+	}
+
+	if !parsed.Tables {
+		t.Fatalf("ParseParams() did not set Tables flag")
+	}
+}


### PR DESCRIPTION
Add TraceTables trace type and ServiceTraceOpts.Tables field to enable tracing of Iceberg Tables API operations.