### PR TITLE
Add MinioCommitID to ClusterRegistrationInfo

### DIFF
--- a/register.go
+++ b/register.go
@@ -35,6 +35,7 @@ type ClusterRegistrationInfo struct {
 	// Intended to be extensible i.e. more fields will be added as and when required
 	Info struct {
 		MinioVersion    string `json:"minio_version"`
+		MinioCommitID   string `json:"minio_commit_id,omitempty"`
 		NoOfServerPools int    `json:"no_of_server_pools"`
 		NoOfServers     int    `json:"no_of_servers"`
 		NoOfDrives      int    `json:"no_of_drives"`


### PR DESCRIPTION
Add `MinioCommitID` field to `ClusterRegistrationInfo` to include commit hash when registering clusters with SUBNET
Ref: https://github.com/miniohq/subnet/issues/6106