### PR TITLE
Fix IAM fix

### DIFF
--- a/iam-migrate.go
+++ b/iam-migrate.go
@@ -91,9 +91,9 @@ type IAMErrEntity struct {
 	Name string `json:"name,omitempty"`
 	// Actual error (incorrect for JSON)
 	// Deprecated: Use Err instead
-	Error error `json:"error,omitempty"`
+	Error error `json:"-"`
 	// Actual error
-	Err string `json:"err,omitempty"`
+	Err string `json:"error,omitempty"`
 }
 
 // IAMErrPolicyEntity - represents errored out IAM policies
@@ -104,9 +104,9 @@ type IAMErrPolicyEntity struct {
 	Policies []string `json:"policies,omitempty"`
 	// Actual error (incorrect for JSON)
 	// Deprecated: Use Err instead
-	Error error `json:"error,omitempty"`
+	Error error `json:"-"`
 	// Actual error
-	Err string `json:"err,omitempty"`
+	Err string `json:"error,omitempty"`
 }
 
 // ExportIAM makes an admin call to export IAM data


### PR DESCRIPTION
https://github.com/minio/madmin-go/pull/500 renamed the wrong field. This will be a breaking change.

Instead keep `error` for non-deprecated field and don't json en/decode the interface field.