### PR TITLE
Fix error handling in ServerHealthInfo

### DIFF
--- a/health.go
+++ b/health.go
@@ -1491,9 +1491,7 @@ func (adm *AdminClient) ServerHealthInfo(ctx context.Context, types []HealthData
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		err = httpRespToErrorResponse(resp)
-		closeResponse(resp)
-		return nil, "", err
+		return nil, "", httpRespToErrorResponse(resp)
 	}
 
 	decoder := json.NewDecoder(resp.Body)


### PR DESCRIPTION
Read the error response before closing the HTTP response body. Previously, closeResponse(resp) was called before
httpRespToErrorResponse(resp), causing the error message from the server to be lost since the body was already closed.