### PR TITLE
fix: telemetry error parsing

### DIFF
--- a/opentelemetry.go
+++ b/opentelemetry.go
@@ -87,7 +87,6 @@ func (adm AdminClient) ServiceTelemetryStream(ctx context.Context, opts ServiceT
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		closeResponse(resp)
 		return nil, httpRespToErrorResponse(resp)
 	}
 


### PR DESCRIPTION
remove redundent closeResponse (causing draining of data before reading) since it's already present in httpRespToErrorResponse

causing:

Unable to start telemetry stream. Failed to parse server response (unexpected end of JSON input):.