### PR TITLE
 Add ChangeOwnPassword method for self-service password changes     

### DIFF
--- a/user-commands.go
+++ b/user-commands.go
@@ -349,11 +349,11 @@ func (adm *AdminClient) ChangeMyPassword(ctx context.Context, newSecretKey strin
 	}
 
 	reqData := requestData{
-		relPath: adminAPIPrefix + "/change-own-password",
+		relPath: adminAPIPrefix + "/change-my-password",
 		content: encData,
 	}
 
-	// Execute POST on /minio/admin/v3/change-own-password
+	// Execute POST on /minio/admin/v3/change-my-password
 	resp, err := adm.executeMethod(ctx, http.MethodPost, reqData)
 	defer closeResponse(resp)
 	if err != nil {


### PR DESCRIPTION
 ## Summary                                                                                            
  - Add `ChangeOwnPassword` method to allow users to change their own password                          
  - This endpoint bypasses IAM policy checks, enabling password changes even with explicit deny on      
  `admin:CreateUser`                                                                                    
                                                                                                        
  ## Motivation                                                                                         
  Previously, changing a user's password required the `admin:CreateUser` permission via                 
  `SetUser`/`AddUser`. This made it impossible for users to change their own password if they had an    
  explicit deny on that action. The new dedicated endpoint allows self-service password changes without 
  elevated permissions.                        