### PR TITLE
Add APIVersion field to ServerInfo

### DIFF
--- a/health.go
+++ b/health.go
@@ -1293,6 +1293,7 @@ type ServerInfo struct {
 	MinioEnvVars   map[string]string `json:"minio_env_vars,omitempty"`
 	Edition        string            `json:"edition"`
 	License        *LicenseInfo      `json:"license,omitempty"`
+	APIVersion     *APIVersion       `json:"api_version,omitempty"`
 }
 
 // MinioInfo contains MinIO server and object storage information.


### PR DESCRIPTION
Add optional APIVersion field to ServerInfo struct for health diagnostics, enabling per-server backend version tracking to detect incompatible/unsupported versions across cluster nodes.