### PR TITLE
Add parquet tags to API log struct

### DIFF
--- a/log/api.go
+++ b/log/api.go
@@ -53,43 +53,43 @@ const (
 
 // API represents the api event
 type API struct {
-	Version   string            `json:"version"`
-	Time      time.Time         `json:"time"`
-	Node      string            `json:"node,omitempty"`
-	Origin    Origin            `json:"origin,omitempty"`
-	Type      APIType           `json:"type,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Bucket    string            `json:"bucket,omitempty"`
-	Object    string            `json:"object,omitempty"`
-	VersionID string            `json:"versionId,omitempty"`
-	Tags      map[string]string `json:"tags,omitempty"`
-	CallInfo  *CallInfo         `json:"callInfo,omitempty"`
+	Version   string            `json:"version" parquet:"version"`
+	Time      time.Time         `json:"time" parquet:"time,timestamp(microsecond)"`
+	Node      string            `json:"node,omitempty" parquet:"node,optional"`
+	Origin    Origin            `json:"origin,omitempty" parquet:"origin,optional"`
+	Type      APIType           `json:"type,omitempty" parquet:"type,optional"`
+	Name      string            `json:"name,omitempty" parquet:"name,optional"`
+	Bucket    string            `json:"bucket,omitempty" parquet:"bucket,optional"`
+	Object    string            `json:"object,omitempty" parquet:"object,optional"`
+	VersionID string            `json:"versionId,omitempty" parquet:"versionId,optional"`
+	Tags      map[string]string `json:"tags,omitempty" parquet:"tags,optional"`
+	CallInfo  *CallInfo         `json:"callInfo,omitempty" parquet:"callInfo,optional"`
 }
 
 // CallInfo represents the info for the external call
 type CallInfo struct {
-	HTTPStatusCode    int                    `json:"httpStatusCode,omitempty"`
-	InputBytes        int64                  `json:"rx,omitempty"`
-	OutputBytes       int64                  `json:"tx,omitempty"`
-	HeaderBytes       int64                  `json:"txHeaders,omitempty"`
-	TimeToFirstByte   string                 `json:"timeToFirstByte,omitempty"`
-	RequestReadTime   string                 `json:"requestReadTime,omitempty"`
-	ResponseWriteTime string                 `json:"responseWriteTime,omitempty"`
-	RequestTime       string                 `json:"requestTime,omitempty"`
-	TimeToResponse    string                 `json:"timeToResponse,omitempty"`
-	ReadBlocked       string                 `json:"readBlocked,omitempty"`
-	WriteBlocked      string                 `json:"writeBlocked,omitempty"`
-	SourceHost        string                 `json:"sourceHost,omitempty"`
-	RequestID         string                 `json:"requestID,omitempty"`
-	UserAgent         string                 `json:"userAgent,omitempty"`
-	ReqPath           string                 `json:"requestPath,omitempty"`
-	ReqHost           string                 `json:"requestHost,omitempty"`
-	ReqClaims         map[string]interface{} `json:"requestClaims,omitempty"`
-	ReqQuery          map[string]string      `json:"requestQuery,omitempty"`
-	ReqHeader         map[string]string      `json:"requestHeader,omitempty"`
-	RespHeader        map[string]string      `json:"responseHeader,omitempty"`
-	AccessKey         string                 `json:"accessKey,omitempty"`
-	ParentUser        string                 `json:"parentUser,omitempty"`
+	HTTPStatusCode    int               `json:"httpStatusCode,omitempty" parquet:"httpStatusCode,optional"`
+	InputBytes        int64             `json:"rx,omitempty" parquet:"inputBytes,optional"`
+	OutputBytes       int64             `json:"tx,omitempty" parquet:"outputBytes,optional"`
+	HeaderBytes       int64             `json:"txHeaders,omitempty" parquet:"headerBytes,optional"`
+	TimeToFirstByte   string            `json:"timeToFirstByte,omitempty" parquet:"timeToFirstByte,optional"`
+	RequestReadTime   string            `json:"requestReadTime,omitempty" parquet:"requestReadTime,optional"`
+	ResponseWriteTime string            `json:"responseWriteTime,omitempty" parquet:"responseWriteTime,optional"`
+	RequestTime       string            `json:"requestTime,omitempty" parquet:"requestTime,optional"`
+	TimeToResponse    string            `json:"timeToResponse,omitempty" parquet:"timeToResponse,optional"`
+	ReadBlocked       string            `json:"readBlocked,omitempty" parquet:"readBlocked,optional"`
+	WriteBlocked      string            `json:"writeBlocked,omitempty" parquet:"writeBlocked,optional"`
+	SourceHost        string            `json:"sourceHost,omitempty" parquet:"sourceHost,optional"`
+	RequestID         string            `json:"requestID,omitempty" parquet:"requestId,optional"`
+	UserAgent         string            `json:"userAgent,omitempty" parquet:"userAgent,optional"`
+	ReqPath           string            `json:"requestPath,omitempty" parquet:"reqPath,optional"`
+	ReqHost           string            `json:"requestHost,omitempty" parquet:"reqHost,optional"`
+	ReqClaims         map[string]string `json:"requestClaims,omitempty" parquet:"reqClaims,optional"`
+	ReqQuery          map[string]string `json:"requestQuery,omitempty" parquet:"reqQuery,optional"`
+	ReqHeader         map[string]string `json:"requestHeader,omitempty" parquet:"reqHeader,optional"`
+	RespHeader        map[string]string `json:"responseHeader,omitempty" parquet:"respHeader,optional"`
+	AccessKey         string            `json:"accessKey,omitempty" parquet:"accessKey,optional"`
+	ParentUser        string            `json:"parentUser,omitempty" parquet:"parentUser,optional"`
 }
 
 // String provides a canonical representation for API
@@ -132,7 +132,7 @@ func (c CallInfo) String() string {
 		toString("userAgent", c.UserAgent),
 		toString("requestPath", c.ReqPath),
 		toString("requestHost", c.ReqHost),
-		toInterfaceMap("requestClaims", c.ReqClaims),
+		toMap("requestClaims", c.ReqClaims),
 		toMap("requestQuery", c.ReqQuery),
 		toMap("requestHeader", c.ReqHeader),
 		toMap("responseHeader", c.RespHeader),

--- a/log/api_gen.go
+++ b/log/api_gen.go
@@ -888,7 +888,7 @@ func (z *CallInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			if z.ReqClaims == nil {
-				z.ReqClaims = make(map[string]interface{}, zb0002)
+				z.ReqClaims = make(map[string]string, zb0002)
 			} else if len(z.ReqClaims) > 0 {
 				clear(z.ReqClaims)
 			}
@@ -900,8 +900,8 @@ func (z *CallInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 					err = msgp.WrapError(err, "ReqClaims")
 					return
 				}
-				var za0002 interface{}
-				za0002, err = dc.ReadIntf()
+				var za0002 string
+				za0002, err = dc.ReadString()
 				if err != nil {
 					err = msgp.WrapError(err, "ReqClaims", za0001)
 					return
@@ -1401,7 +1401,7 @@ func (z *CallInfo) EncodeMsg(en *msgp.Writer) (err error) {
 					err = msgp.WrapError(err, "ReqClaims")
 					return
 				}
-				err = en.WriteIntf(za0002)
+				err = en.WriteString(za0002)
 				if err != nil {
 					err = msgp.WrapError(err, "ReqClaims", za0001)
 					return
@@ -1694,11 +1694,7 @@ func (z *CallInfo) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendMapHeader(o, uint32(len(z.ReqClaims)))
 			for za0001, za0002 := range z.ReqClaims {
 				o = msgp.AppendString(o, za0001)
-				o, err = msgp.AppendIntf(o, za0002)
-				if err != nil {
-					err = msgp.WrapError(err, "ReqClaims", za0001)
-					return
-				}
+				o = msgp.AppendString(o, za0002)
 			}
 		}
 		if (zb0001Mask & 0x20000) == 0 { // if not omitted
@@ -1882,12 +1878,12 @@ func (z *CallInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			if z.ReqClaims == nil {
-				z.ReqClaims = make(map[string]interface{}, zb0002)
+				z.ReqClaims = make(map[string]string, zb0002)
 			} else if len(z.ReqClaims) > 0 {
 				clear(z.ReqClaims)
 			}
 			for zb0002 > 0 {
-				var za0002 interface{}
+				var za0002 string
 				zb0002--
 				var za0001 string
 				za0001, bts, err = msgp.ReadStringBytes(bts)
@@ -1895,7 +1891,7 @@ func (z *CallInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "ReqClaims")
 					return
 				}
-				za0002, bts, err = msgp.ReadIntfBytes(bts)
+				za0002, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReqClaims", za0001)
 					return
@@ -2091,7 +2087,7 @@ func (z *CallInfo) Msgsize() (s int) {
 	if z.ReqClaims != nil {
 		for za0001, za0002 := range z.ReqClaims {
 			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + msgp.GuessSize(za0002)
+			s += msgp.StringPrefixSize + len(za0001) + msgp.StringPrefixSize + len(za0002)
 		}
 	}
 	s += 13 + msgp.MapHeaderSize

--- a/log/helper.go
+++ b/log/helper.go
@@ -37,20 +37,6 @@ func stringifyMap(m map[string]string) string {
 	return strings.Join(pairs, ",")
 }
 
-// stringifyInterfaceMap sorts and joins a map[string]interface{} as "k1=v1,k2=v2".
-// (Uses fmt.Sprint to stringify values.)
-func stringifyInterfaceMap(m map[string]interface{}) string {
-	if len(m) == 0 {
-		return ""
-	}
-	pairs := make([]string, 0, len(m))
-	for k, v := range m {
-		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
-	}
-	slices.Sort(pairs)
-	return strings.Join(pairs, ",")
-}
-
 func toString(key, value string) string {
 	if value == "" {
 		return ""
@@ -84,13 +70,6 @@ func toMap(key string, m map[string]string) string {
 		return ""
 	}
 	return fmt.Sprintf("%s={%s}", key, stringifyMap(m))
-}
-
-func toInterfaceMap(key string, m map[string]interface{}) string {
-	if len(m) == 0 {
-		return ""
-	}
-	return fmt.Sprintf("%s={%s}", key, stringifyInterfaceMap(m))
 }
 
 // filterAndSort removes empty entries and sorts.


### PR DESCRIPTION
Add parquet struct tags to API and CallInfo types to enable Parquet file serialization for API logs.