### PR TITLE
add functions for enabling the builtin KMS and rotating keys

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,8 @@ linters:
         text: error strings should not be capitalized or end with punctuation or a newline
       - path: (.+)\.go$
         text: don't use ALL_CAPS in Go names
+      - path: (.+)\.go$
+        text: "var-naming: avoid package names that conflict with Go standard library package names"
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION
This commit adds two methods:
```
- EnableKMS  // Enables the builtin KMS on a MinIO cluster
- RotateKey  // Creates a new key version
```

It also adds a `KeyVersion` field to the `KMSKeyStatus` struct.