### PR TITLE
feat: add BatchJobStatusCanceled status type

### DIFF
--- a/batch-job.go
+++ b/batch-job.go
@@ -47,6 +47,7 @@ const (
 const (
 	BatchJobStatusCompleted  BatchJobStatusType = "completed"
 	BatchJobStatusFailed     BatchJobStatusType = "failed"
+	BatchJobStatusCanceled   BatchJobStatusType = "canceled"
 	BatchJobStatusInProgress BatchJobStatusType = "in-progress"
 	BatchJobStatusUnknown    BatchJobStatusType = "unknown"
 )


### PR DESCRIPTION
## Description

Add `BatchJobStatusCanceled` to the `BatchJobStatusType` constants so that
the server can surface a distinct canceled status for batch jobs in the
`ListBatchJobs` and `BatchJobStatus` API responses.

## Motivation and Context

Fixes miniohq/eos#3481. Canceled batch jobs currently disappear from all
APIs immediately after cancellation because no "canceled" status constant
existed in the client library. The server-side fix persists the final
canceled report and returns this status; the client needs the constant to
interpret and display it correctly.

## How to test this PR?

- Start a long-running batch job
- Cancel it with `mc batch cancel`
- Run `mc batch list` and `mc batch status <id>` — both should show
  `canceled` status

## Types of changes
- [x] New feature (non-breaking change which adds functionality)