### PR TITLE
Add Healing realtime metrics

### DIFF
--- a/heal-commands.go
+++ b/heal-commands.go
@@ -112,7 +112,7 @@ type HealTaskStatus struct {
 
 // HealItemType - specify the type of heal operation in a healing
 // result
-type HealItemType string
+type HealItemType = string
 
 // HealItemType constants
 const (

--- a/heal-commands_gen.go
+++ b/heal-commands_gen.go
@@ -725,58 +725,6 @@ func (z HealDriveInfo) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *HealItemType) DecodeMsg(dc *msgp.Reader) (err error) {
-	{
-		var zb0001 string
-		zb0001, err = dc.ReadString()
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		(*z) = HealItemType(zb0001)
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z HealItemType) EncodeMsg(en *msgp.Writer) (err error) {
-	err = en.WriteString(string(z))
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z HealItemType) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	o = msgp.AppendString(o, string(z))
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *HealItemType) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	{
-		var zb0001 string
-		zb0001, bts, err = msgp.ReadStringBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		(*z) = HealItemType(zb0001)
-	}
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z HealItemType) Msgsize() (s int) {
-	s = msgp.StringPrefixSize + len(string(z))
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
 func (z *HealOpts) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field

--- a/metrics.go
+++ b/metrics.go
@@ -2712,12 +2712,12 @@ const (
 type HealError = string
 
 const (
-	HealErrCorrupt     HealError = "corrupt"
-	HealErrMissing     HealError = "missing"
-	HealErrOffline     HealError = "offline"
-	HealErrTimeout     HealError = "timeout"
-	HealErrPermission  HealError = "permission"
-	HealErrChecksum    HealError = "checksum"
+	HealErrCorrupt         HealError = "corrupt"
+	HealErrMissing         HealError = "missing"
+	HealErrOffline         HealError = "offline"
+	HealErrTimeout         HealError = "timeout"
+	HealErrPermission      HealError = "permission"
+	HealErrChecksum        HealError = "checksum"
 	HealErrReadQuorum      HealError = "read-quorum"
 	HealErrWriteQuorum     HealError = "write-quorum"
 	HealErrWarmTierUnreach HealError = "warm-tier-unreachable"
@@ -2727,10 +2727,20 @@ const (
 // HealingCounts contains aggregate healing counters.
 // Also serves as the segment type for SegmentedHealingStats.
 type HealingCounts struct {
-	Started        int64 `json:"started,omitempty"`
-	Completed      int64 `json:"completed,omitempty"`
-	Failed         int64 `json:"failed,omitempty"`
-	Bytes          int64 `json:"bytes,omitempty"`
+	Started   int64 `json:"started,omitempty"`
+	Completed int64 `json:"completed,omitempty"`
+	Failed    int64 `json:"failed,omitempty"`
+
+	// Healed is the subset of Completed where drives were actually repaired.
+	Healed int64 `json:"healed,omitempty"`
+
+	// BytesHealed is the total size of objects where drives were actually repaired.
+	BytesHealed int64 `json:"bytes_healed,omitempty"`
+
+	// Bytes is the total size of all objects submitted for heal checks.
+	Bytes int64 `json:"bytes,omitempty"`
+
+	// BytesCompleted is the total size of objects that completed healing without error.
 	BytesCompleted int64 `json:"bytes_completed,omitempty"`
 
 	// AccTime is accumulated wall-clock time of completed heal operations in seconds.
@@ -2756,6 +2766,8 @@ func (h *HealingCounts) Add(other *HealingCounts) {
 	h.Started += other.Started
 	h.Completed += other.Completed
 	h.Failed += other.Failed
+	h.Healed += other.Healed
+	h.BytesHealed += other.BytesHealed
 	h.Bytes += other.Bytes
 	h.BytesCompleted += other.BytesCompleted
 	h.AccTime += other.AccTime

--- a/metrics.go
+++ b/metrics.go
@@ -41,6 +41,8 @@ import (
 
 //go:generate msgp -unexported -d clearomitted -d "tag json" -d "timezone utc" -d "maps binkeys" -file $GOFILE
 
+//msgp:replace HealItemType with:string
+
 // MetricType is a bitfield representation of different metric types.
 type MetricType uint32
 
@@ -61,6 +63,7 @@ const (
 	MetricsAPI
 	MetricsReplication
 	MetricsProcess
+	MetricsHealing
 
 	// MetricsAll must be last.
 	// Enables all metrics.
@@ -96,6 +99,7 @@ func (m MetricType) String() string {
 	addIf(m.Contains(MetricsAPI), "API")
 	addIf(m.Contains(MetricsReplication), "Replication")
 	addIf(m.Contains(MetricsProcess), "Process")
+	addIf(m.Contains(MetricsHealing), "Healing")
 	return b.String()
 }
 
@@ -362,6 +366,7 @@ type Metrics struct {
 	API         *APIMetrics         `json:"api,omitempty"`
 	Replication *ReplicationMetrics `json:"replication,omitempty"`
 	Process     *ProcessMetrics     `json:"process,omitempty"`
+	Healing     *HealingMetrics     `json:"healing,omitempty"`
 }
 
 // Merge other into r.
@@ -425,6 +430,10 @@ func (r *Metrics) Merge(other *Metrics) {
 		r.Process = &ProcessMetrics{}
 	}
 	r.Process.Merge(other.Process)
+	if r.Healing == nil && other.Healing != nil {
+		r.Healing = &HealingMetrics{}
+	}
+	r.Healing.Merge(other.Healing)
 }
 
 // ScannerMetrics contains scanner information.
@@ -2686,3 +2695,171 @@ func (p *ProcessSegment) Add(other *ProcessSegment) {
 
 // SegmentedProcessMetrics are time-segmented process metrics.
 type SegmentedProcessMetrics = Segmented[ProcessSegment, *ProcessSegment]
+
+// HealOrigin identifies the subsystem that triggered a healing operation.
+type HealOrigin = string
+
+const (
+	HealOriginScanner     HealOrigin = "scanner"
+	HealOriginReadRepair  HealOrigin = "read-repair"
+	HealOriginDiskReplace HealOrigin = "disk-replace"
+	HealOriginDiskOffline HealOrigin = "disk-offline"
+	HealOriginManual      HealOrigin = "manual"
+	HealOriginCrossPool   HealOrigin = "cross-pool"
+)
+
+// HealError classifies healing failure reasons.
+type HealError = string
+
+const (
+	HealErrCorrupt     HealError = "corrupt"
+	HealErrMissing     HealError = "missing"
+	HealErrOffline     HealError = "offline"
+	HealErrTimeout     HealError = "timeout"
+	HealErrPermission  HealError = "permission"
+	HealErrChecksum    HealError = "checksum"
+	HealErrReadQuorum      HealError = "read-quorum"
+	HealErrWriteQuorum     HealError = "write-quorum"
+	HealErrWarmTierUnreach HealError = "warm-tier-unreachable"
+	HealErrWarmTierMissing HealError = "warm-tier-missing"
+)
+
+// HealingCounts contains aggregate healing counters.
+// Also serves as the segment type for SegmentedHealingStats.
+type HealingCounts struct {
+	Started        int64 `json:"started,omitempty"`
+	Completed      int64 `json:"completed,omitempty"`
+	Failed         int64 `json:"failed,omitempty"`
+	Bytes          int64 `json:"bytes,omitempty"`
+	BytesCompleted int64 `json:"bytes_completed,omitempty"`
+
+	// AccTime is accumulated wall-clock time of completed heal operations in seconds.
+	// Divide by Completed to get average duration.
+	AccTime float64 `json:"acc_time_secs,omitempty"`
+
+	// Dangling is the number of dangling objects detected and cleaned up.
+	Dangling int64 `json:"dangling,omitempty"`
+
+	// WarmTierChecks is the number of warm-tier validation checks performed.
+	WarmTierChecks int64 `json:"warm_tier_checks,omitempty"`
+
+	ByOrigin map[HealOrigin]int64   `json:"by_origin,omitempty"`
+	ByType   map[HealItemType]int64 `json:"by_type,omitempty"`
+	ByError  map[HealError]int64    `json:"by_error,omitempty"`
+}
+
+// Add other into h. Implements Segmenter[HealingCounts].
+func (h *HealingCounts) Add(other *HealingCounts) {
+	if other == nil {
+		return
+	}
+	h.Started += other.Started
+	h.Completed += other.Completed
+	h.Failed += other.Failed
+	h.Bytes += other.Bytes
+	h.BytesCompleted += other.BytesCompleted
+	h.AccTime += other.AccTime
+	h.Dangling += other.Dangling
+	h.WarmTierChecks += other.WarmTierChecks
+
+	if len(other.ByOrigin) > 0 {
+		if h.ByOrigin == nil {
+			h.ByOrigin = make(map[HealOrigin]int64, len(other.ByOrigin))
+		}
+		for k, v := range other.ByOrigin {
+			h.ByOrigin[k] += v
+		}
+	}
+	if len(other.ByType) > 0 {
+		if h.ByType == nil {
+			h.ByType = make(map[HealItemType]int64, len(other.ByType))
+		}
+		for k, v := range other.ByType {
+			h.ByType[k] += v
+		}
+	}
+	if len(other.ByError) > 0 {
+		if h.ByError == nil {
+			h.ByError = make(map[HealError]int64, len(other.ByError))
+		}
+		for k, v := range other.ByError {
+			h.ByError[k] += v
+		}
+	}
+}
+
+// SegmentedHealingStats are time-segmented healing metrics.
+type SegmentedHealingStats = Segmented[HealingCounts, *HealingCounts]
+
+// HealBucketStats tracks healing outcomes for a single bucket.
+type HealBucketStats struct {
+	Started   int64 `json:"started,omitempty"`
+	Completed int64 `json:"completed,omitempty"`
+	Failed    int64 `json:"failed,omitempty"`
+}
+
+// Add other into h.
+func (h *HealBucketStats) Add(other *HealBucketStats) {
+	if other == nil {
+		return
+	}
+	h.Started += other.Started
+	h.Completed += other.Completed
+	h.Failed += other.Failed
+}
+
+// HealingMetrics contains distributed healing metrics across all nodes.
+type HealingMetrics struct {
+	CollectedAt time.Time `json:"collected"`
+	Nodes       int       `json:"nodes"`
+
+	LastMinute HealingCounts          `json:"last_minute,omitempty"`
+	LastHour   HealingCounts          `json:"last_hour,omitempty"`
+	LastDay    *SegmentedHealingStats `json:"last_day,omitempty"`
+	SinceStart HealingCounts          `json:"since_start,omitempty"`
+
+	BucketsLastMinute map[string]HealBucketStats `json:"buckets_last_minute,omitempty"`
+	BucketsLastHour   map[string]HealBucketStats `json:"buckets_last_hour,omitempty"`
+}
+
+// Merge other into m.
+func (m *HealingMetrics) Merge(other *HealingMetrics) {
+	if m == nil || other == nil {
+		return
+	}
+	if m.CollectedAt.Before(other.CollectedAt) {
+		m.CollectedAt = other.CollectedAt
+	}
+	m.Nodes += other.Nodes
+	m.LastMinute.Add(&other.LastMinute)
+	m.LastHour.Add(&other.LastHour)
+	m.SinceStart.Add(&other.SinceStart)
+
+	if other.LastDay != nil {
+		if m.LastDay == nil {
+			m.LastDay = new(SegmentedHealingStats)
+		}
+		m.LastDay.Add(other.LastDay)
+	}
+
+	if len(other.BucketsLastMinute) > 0 {
+		if m.BucketsLastMinute == nil {
+			m.BucketsLastMinute = make(map[string]HealBucketStats, len(other.BucketsLastMinute))
+		}
+		for k, v := range other.BucketsLastMinute {
+			dst := m.BucketsLastMinute[k]
+			dst.Add(&v)
+			m.BucketsLastMinute[k] = dst
+		}
+	}
+	if len(other.BucketsLastHour) > 0 {
+		if m.BucketsLastHour == nil {
+			m.BucketsLastHour = make(map[string]HealBucketStats, len(other.BucketsLastHour))
+		}
+		for k, v := range other.BucketsLastHour {
+			dst := m.BucketsLastHour[k]
+			dst.Add(&v)
+			m.BucketsLastHour[k] = dst
+		}
+	}
+}

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -10123,7 +10123,7 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 11 bits */
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -10154,41 +10154,55 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x4
+		case "healed":
+			z.Healed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Healed")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "bytes_healed":
+			z.BytesHealed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesHealed")
+				return
+			}
+			zb0001Mask |= 0x10
 		case "bytes":
 			z.Bytes, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Bytes")
 				return
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x20
 		case "bytes_completed":
 			z.BytesCompleted, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "BytesCompleted")
 				return
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x40
 		case "acc_time_secs":
 			z.AccTime, err = dc.ReadFloat64()
 			if err != nil {
 				err = msgp.WrapError(err, "AccTime")
 				return
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x80
 		case "dangling":
 			z.Dangling, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Dangling")
 				return
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x100
 		case "warm_tier_checks":
 			z.WarmTierChecks, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "WarmTierChecks")
 				return
 			}
-			zb0001Mask |= 0x80
+			zb0001Mask |= 0x200
 		case "by_origin":
 			var zb0002 uint32
 			zb0002, err = dc.ReadMapHeader()
@@ -10221,7 +10235,7 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.ByOrigin[za0001] = za0002
 			}
-			zb0001Mask |= 0x100
+			zb0001Mask |= 0x400
 		case "by_type":
 			var zb0004 uint32
 			zb0004, err = dc.ReadMapHeader()
@@ -10254,7 +10268,7 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.ByType[za0003] = za0004
 			}
-			zb0001Mask |= 0x200
+			zb0001Mask |= 0x800
 		case "by_error":
 			var zb0006 uint32
 			zb0006, err = dc.ReadMapHeader()
@@ -10287,7 +10301,7 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.ByError[za0005] = za0006
 			}
-			zb0001Mask |= 0x400
+			zb0001Mask |= 0x1000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -10297,7 +10311,7 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7ff {
+	if zb0001Mask != 0x1fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Started = 0
 		}
@@ -10308,27 +10322,33 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.Failed = 0
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.Bytes = 0
+			z.Healed = 0
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.BytesCompleted = 0
+			z.BytesHealed = 0
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.AccTime = 0
+			z.Bytes = 0
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.Dangling = 0
+			z.BytesCompleted = 0
 		}
 		if (zb0001Mask & 0x80) == 0 {
-			z.WarmTierChecks = 0
+			z.AccTime = 0
 		}
 		if (zb0001Mask & 0x100) == 0 {
-			z.ByOrigin = nil
+			z.Dangling = 0
 		}
 		if (zb0001Mask & 0x200) == 0 {
-			z.ByType = nil
+			z.WarmTierChecks = 0
 		}
 		if (zb0001Mask & 0x400) == 0 {
+			z.ByOrigin = nil
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.ByType = nil
+		}
+		if (zb0001Mask & 0x1000) == 0 {
 			z.ByError = nil
 		}
 	}
@@ -10338,8 +10358,8 @@ func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(11)
-	var zb0001Mask uint16 /* 11 bits */
+	zb0001Len := uint32(13)
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	if z.Started == 0 {
 		zb0001Len--
@@ -10353,37 +10373,45 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Bytes == 0 {
+	if z.Healed == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.BytesCompleted == 0 {
+	if z.BytesHealed == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.AccTime == 0 {
+	if z.Bytes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.Dangling == 0 {
+	if z.BytesCompleted == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.WarmTierChecks == 0 {
+	if z.AccTime == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.ByOrigin == nil {
+	if z.Dangling == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.ByType == nil {
+	if z.WarmTierChecks == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.ByError == nil {
+	if z.ByOrigin == nil {
 		zb0001Len--
 		zb0001Mask |= 0x400
+	}
+	if z.ByType == nil {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.ByError == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1000
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -10430,6 +10458,30 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "healed"
+			err = en.Append(0xa6, 0x68, 0x65, 0x61, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Healed)
+			if err != nil {
+				err = msgp.WrapError(err, "Healed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "bytes_healed"
+			err = en.Append(0xac, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x68, 0x65, 0x61, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.BytesHealed)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesHealed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
 			// write "bytes"
 			err = en.Append(0xa5, 0x62, 0x79, 0x74, 0x65, 0x73)
 			if err != nil {
@@ -10441,7 +10493,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not omitted
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// write "bytes_completed"
 			err = en.Append(0xaf, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
 			if err != nil {
@@ -10453,7 +10505,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// write "acc_time_secs"
 			err = en.Append(0xad, 0x61, 0x63, 0x63, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x5f, 0x73, 0x65, 0x63, 0x73)
 			if err != nil {
@@ -10465,7 +10517,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// write "dangling"
 			err = en.Append(0xa8, 0x64, 0x61, 0x6e, 0x67, 0x6c, 0x69, 0x6e, 0x67)
 			if err != nil {
@@ -10477,7 +10529,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// write "warm_tier_checks"
 			err = en.Append(0xb0, 0x77, 0x61, 0x72, 0x6d, 0x5f, 0x74, 0x69, 0x65, 0x72, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x73)
 			if err != nil {
@@ -10489,7 +10541,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// write "by_origin"
 			err = en.Append(0xa9, 0x62, 0x79, 0x5f, 0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e)
 			if err != nil {
@@ -10513,7 +10565,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
 			// write "by_type"
 			err = en.Append(0xa7, 0x62, 0x79, 0x5f, 0x74, 0x79, 0x70, 0x65)
 			if err != nil {
@@ -10537,7 +10589,7 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x400) == 0 { // if not omitted
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// write "by_error"
 			err = en.Append(0xa8, 0x62, 0x79, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
 			if err != nil {
@@ -10569,8 +10621,8 @@ func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(11)
-	var zb0001Mask uint16 /* 11 bits */
+	zb0001Len := uint32(13)
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	if z.Started == 0 {
 		zb0001Len--
@@ -10584,37 +10636,45 @@ func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Bytes == 0 {
+	if z.Healed == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.BytesCompleted == 0 {
+	if z.BytesHealed == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.AccTime == 0 {
+	if z.Bytes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.Dangling == 0 {
+	if z.BytesCompleted == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.WarmTierChecks == 0 {
+	if z.AccTime == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.ByOrigin == nil {
+	if z.Dangling == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.ByType == nil {
+	if z.WarmTierChecks == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.ByError == nil {
+	if z.ByOrigin == nil {
 		zb0001Len--
 		zb0001Mask |= 0x400
+	}
+	if z.ByType == nil {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.ByError == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -10637,31 +10697,41 @@ func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendInt64(o, z.Failed)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "healed"
+			o = append(o, 0xa6, 0x68, 0x65, 0x61, 0x6c, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Healed)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "bytes_healed"
+			o = append(o, 0xac, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x68, 0x65, 0x61, 0x6c, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.BytesHealed)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
 			// string "bytes"
 			o = append(o, 0xa5, 0x62, 0x79, 0x74, 0x65, 0x73)
 			o = msgp.AppendInt64(o, z.Bytes)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not omitted
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// string "bytes_completed"
 			o = append(o, 0xaf, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
 			o = msgp.AppendInt64(o, z.BytesCompleted)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// string "acc_time_secs"
 			o = append(o, 0xad, 0x61, 0x63, 0x63, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x5f, 0x73, 0x65, 0x63, 0x73)
 			o = msgp.AppendFloat64(o, z.AccTime)
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// string "dangling"
 			o = append(o, 0xa8, 0x64, 0x61, 0x6e, 0x67, 0x6c, 0x69, 0x6e, 0x67)
 			o = msgp.AppendInt64(o, z.Dangling)
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// string "warm_tier_checks"
 			o = append(o, 0xb0, 0x77, 0x61, 0x72, 0x6d, 0x5f, 0x74, 0x69, 0x65, 0x72, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x73)
 			o = msgp.AppendInt64(o, z.WarmTierChecks)
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// string "by_origin"
 			o = append(o, 0xa9, 0x62, 0x79, 0x5f, 0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e)
 			o = msgp.AppendMapHeader(o, uint32(len(z.ByOrigin)))
@@ -10670,7 +10740,7 @@ func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendInt64(o, za0002)
 			}
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
 			// string "by_type"
 			o = append(o, 0xa7, 0x62, 0x79, 0x5f, 0x74, 0x79, 0x70, 0x65)
 			o = msgp.AppendMapHeader(o, uint32(len(z.ByType)))
@@ -10679,7 +10749,7 @@ func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendInt64(o, za0004)
 			}
 		}
-		if (zb0001Mask & 0x400) == 0 { // if not omitted
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// string "by_error"
 			o = append(o, 0xa8, 0x62, 0x79, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
 			o = msgp.AppendMapHeader(o, uint32(len(z.ByError)))
@@ -10702,7 +10772,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 11 bits */
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -10733,41 +10803,55 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x4
+		case "healed":
+			z.Healed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Healed")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "bytes_healed":
+			z.BytesHealed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesHealed")
+				return
+			}
+			zb0001Mask |= 0x10
 		case "bytes":
 			z.Bytes, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Bytes")
 				return
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x20
 		case "bytes_completed":
 			z.BytesCompleted, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "BytesCompleted")
 				return
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x40
 		case "acc_time_secs":
 			z.AccTime, bts, err = msgp.ReadFloat64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "AccTime")
 				return
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x80
 		case "dangling":
 			z.Dangling, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Dangling")
 				return
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x100
 		case "warm_tier_checks":
 			z.WarmTierChecks, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "WarmTierChecks")
 				return
 			}
-			zb0001Mask |= 0x80
+			zb0001Mask |= 0x200
 		case "by_origin":
 			var zb0002 uint32
 			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -10800,7 +10884,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.ByOrigin[za0001] = za0002
 			}
-			zb0001Mask |= 0x100
+			zb0001Mask |= 0x400
 		case "by_type":
 			var zb0004 uint32
 			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -10833,7 +10917,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.ByType[za0003] = za0004
 			}
-			zb0001Mask |= 0x200
+			zb0001Mask |= 0x800
 		case "by_error":
 			var zb0006 uint32
 			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -10866,7 +10950,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.ByError[za0005] = za0006
 			}
-			zb0001Mask |= 0x400
+			zb0001Mask |= 0x1000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -10876,7 +10960,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7ff {
+	if zb0001Mask != 0x1fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Started = 0
 		}
@@ -10887,27 +10971,33 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.Failed = 0
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.Bytes = 0
+			z.Healed = 0
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.BytesCompleted = 0
+			z.BytesHealed = 0
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.AccTime = 0
+			z.Bytes = 0
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.Dangling = 0
+			z.BytesCompleted = 0
 		}
 		if (zb0001Mask & 0x80) == 0 {
-			z.WarmTierChecks = 0
+			z.AccTime = 0
 		}
 		if (zb0001Mask & 0x100) == 0 {
-			z.ByOrigin = nil
+			z.Dangling = 0
 		}
 		if (zb0001Mask & 0x200) == 0 {
-			z.ByType = nil
+			z.WarmTierChecks = 0
 		}
 		if (zb0001Mask & 0x400) == 0 {
+			z.ByOrigin = nil
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.ByType = nil
+		}
+		if (zb0001Mask & 0x1000) == 0 {
 			z.ByError = nil
 		}
 	}
@@ -10917,7 +11007,7 @@ func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *HealingCounts) Msgsize() (s int) {
-	s = 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size + 6 + msgp.Int64Size + 16 + msgp.Int64Size + 14 + msgp.Float64Size + 9 + msgp.Int64Size + 17 + msgp.Int64Size + 10 + msgp.MapHeaderSize
+	s = 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size + 7 + msgp.Int64Size + 13 + msgp.Int64Size + 6 + msgp.Int64Size + 16 + msgp.Int64Size + 14 + msgp.Float64Size + 9 + msgp.Int64Size + 17 + msgp.Int64Size + 10 + msgp.MapHeaderSize
 	if z.ByOrigin != nil {
 		for za0001, za0002 := range z.ByOrigin {
 			_ = za0002

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -9870,6 +9870,2052 @@ func (z *ExpirationInfo) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *HealBucketStats) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "started":
+			z.Started, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "completed":
+			z.Completed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "failed":
+			z.Failed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+			zb0001Mask |= 0x4
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Started = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Completed = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Failed = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z HealBucketStats) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	if z.Started == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Completed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Failed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "started"
+			err = en.Append(0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Started)
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "completed"
+			err = en.Append(0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Completed)
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "failed"
+			err = en.Append(0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Failed)
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z HealBucketStats) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	if z.Started == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Completed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Failed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "started"
+			o = append(o, 0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Started)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "completed"
+			o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Completed)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "failed"
+			o = append(o, 0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Failed)
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *HealBucketStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "started":
+			z.Started, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "completed":
+			z.Completed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "failed":
+			z.Failed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+			zb0001Mask |= 0x4
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Started = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Completed = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Failed = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z HealBucketStats) Msgsize() (s int) {
+	s = 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *HealingCounts) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "started":
+			z.Started, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "completed":
+			z.Completed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "failed":
+			z.Failed, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "bytes":
+			z.Bytes, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Bytes")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "bytes_completed":
+			z.BytesCompleted, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesCompleted")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "acc_time_secs":
+			z.AccTime, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "AccTime")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "dangling":
+			z.Dangling, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Dangling")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "warm_tier_checks":
+			z.WarmTierChecks, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "WarmTierChecks")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "by_origin":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByOrigin")
+				return
+			}
+			if z.ByOrigin == nil {
+				z.ByOrigin = make(map[HealOrigin]int64, zb0002)
+			} else if len(z.ByOrigin) > 0 {
+				clear(z.ByOrigin)
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 HealOrigin
+				{
+					var zb0003 string
+					zb0003, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "ByOrigin", za0001)
+						return
+					}
+					za0001 = HealOrigin(zb0003)
+				}
+				var za0002 int64
+				za0002, err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "ByOrigin", za0001)
+					return
+				}
+				z.ByOrigin[za0001] = za0002
+			}
+			zb0001Mask |= 0x100
+		case "by_type":
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByType")
+				return
+			}
+			if z.ByType == nil {
+				z.ByType = make(map[HealItemType]int64, zb0004)
+			} else if len(z.ByType) > 0 {
+				clear(z.ByType)
+			}
+			for zb0004 > 0 {
+				zb0004--
+				var za0003 HealItemType
+				{
+					var zb0005 string
+					zb0005, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "ByType", za0003)
+						return
+					}
+					za0003 = HealItemType(zb0005)
+				}
+				var za0004 int64
+				za0004, err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "ByType", za0003)
+					return
+				}
+				z.ByType[za0003] = za0004
+			}
+			zb0001Mask |= 0x200
+		case "by_error":
+			var zb0006 uint32
+			zb0006, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByError")
+				return
+			}
+			if z.ByError == nil {
+				z.ByError = make(map[HealError]int64, zb0006)
+			} else if len(z.ByError) > 0 {
+				clear(z.ByError)
+			}
+			for zb0006 > 0 {
+				zb0006--
+				var za0005 HealError
+				{
+					var zb0007 string
+					zb0007, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "ByError", za0005)
+						return
+					}
+					za0005 = HealError(zb0007)
+				}
+				var za0006 int64
+				za0006, err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "ByError", za0005)
+					return
+				}
+				z.ByError[za0005] = za0006
+			}
+			zb0001Mask |= 0x400
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7ff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Started = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Completed = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Failed = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.Bytes = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.BytesCompleted = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.AccTime = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.Dangling = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.WarmTierChecks = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.ByOrigin = nil
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.ByType = nil
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.ByError = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *HealingCounts) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(11)
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	if z.Started == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Completed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Failed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.Bytes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.BytesCompleted == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.AccTime == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.Dangling == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.WarmTierChecks == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.ByOrigin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.ByType == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.ByError == nil {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "started"
+			err = en.Append(0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Started)
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "completed"
+			err = en.Append(0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Completed)
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "failed"
+			err = en.Append(0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Failed)
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "bytes"
+			err = en.Append(0xa5, 0x62, 0x79, 0x74, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Bytes)
+			if err != nil {
+				err = msgp.WrapError(err, "Bytes")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "bytes_completed"
+			err = en.Append(0xaf, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.BytesCompleted)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesCompleted")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "acc_time_secs"
+			err = en.Append(0xad, 0x61, 0x63, 0x63, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x5f, 0x73, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.AccTime)
+			if err != nil {
+				err = msgp.WrapError(err, "AccTime")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "dangling"
+			err = en.Append(0xa8, 0x64, 0x61, 0x6e, 0x67, 0x6c, 0x69, 0x6e, 0x67)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Dangling)
+			if err != nil {
+				err = msgp.WrapError(err, "Dangling")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "warm_tier_checks"
+			err = en.Append(0xb0, 0x77, 0x61, 0x72, 0x6d, 0x5f, 0x74, 0x69, 0x65, 0x72, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.WarmTierChecks)
+			if err != nil {
+				err = msgp.WrapError(err, "WarmTierChecks")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "by_origin"
+			err = en.Append(0xa9, 0x62, 0x79, 0x5f, 0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.ByOrigin)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByOrigin")
+				return
+			}
+			for za0001, za0002 := range z.ByOrigin {
+				err = en.WriteString(string(za0001))
+				if err != nil {
+					err = msgp.WrapError(err, "ByOrigin", za0001)
+					return
+				}
+				err = en.WriteInt64(za0002)
+				if err != nil {
+					err = msgp.WrapError(err, "ByOrigin", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "by_type"
+			err = en.Append(0xa7, 0x62, 0x79, 0x5f, 0x74, 0x79, 0x70, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.ByType)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByType")
+				return
+			}
+			for za0003, za0004 := range z.ByType {
+				err = en.WriteString(string(za0003))
+				if err != nil {
+					err = msgp.WrapError(err, "ByType", za0003)
+					return
+				}
+				err = en.WriteInt64(za0004)
+				if err != nil {
+					err = msgp.WrapError(err, "ByType", za0003)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// write "by_error"
+			err = en.Append(0xa8, 0x62, 0x79, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.ByError)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByError")
+				return
+			}
+			for za0005, za0006 := range z.ByError {
+				err = en.WriteString(string(za0005))
+				if err != nil {
+					err = msgp.WrapError(err, "ByError", za0005)
+					return
+				}
+				err = en.WriteInt64(za0006)
+				if err != nil {
+					err = msgp.WrapError(err, "ByError", za0005)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *HealingCounts) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(11)
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	if z.Started == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Completed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Failed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.Bytes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.BytesCompleted == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.AccTime == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.Dangling == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.WarmTierChecks == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.ByOrigin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.ByType == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.ByError == nil {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "started"
+			o = append(o, 0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Started)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "completed"
+			o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Completed)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "failed"
+			o = append(o, 0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.Failed)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "bytes"
+			o = append(o, 0xa5, 0x62, 0x79, 0x74, 0x65, 0x73)
+			o = msgp.AppendInt64(o, z.Bytes)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "bytes_completed"
+			o = append(o, 0xaf, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+			o = msgp.AppendInt64(o, z.BytesCompleted)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "acc_time_secs"
+			o = append(o, 0xad, 0x61, 0x63, 0x63, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x5f, 0x73, 0x65, 0x63, 0x73)
+			o = msgp.AppendFloat64(o, z.AccTime)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "dangling"
+			o = append(o, 0xa8, 0x64, 0x61, 0x6e, 0x67, 0x6c, 0x69, 0x6e, 0x67)
+			o = msgp.AppendInt64(o, z.Dangling)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "warm_tier_checks"
+			o = append(o, 0xb0, 0x77, 0x61, 0x72, 0x6d, 0x5f, 0x74, 0x69, 0x65, 0x72, 0x5f, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x73)
+			o = msgp.AppendInt64(o, z.WarmTierChecks)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "by_origin"
+			o = append(o, 0xa9, 0x62, 0x79, 0x5f, 0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e)
+			o = msgp.AppendMapHeader(o, uint32(len(z.ByOrigin)))
+			for za0001, za0002 := range z.ByOrigin {
+				o = msgp.AppendString(o, string(za0001))
+				o = msgp.AppendInt64(o, za0002)
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "by_type"
+			o = append(o, 0xa7, 0x62, 0x79, 0x5f, 0x74, 0x79, 0x70, 0x65)
+			o = msgp.AppendMapHeader(o, uint32(len(z.ByType)))
+			for za0003, za0004 := range z.ByType {
+				o = msgp.AppendString(o, string(za0003))
+				o = msgp.AppendInt64(o, za0004)
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// string "by_error"
+			o = append(o, 0xa8, 0x62, 0x79, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
+			o = msgp.AppendMapHeader(o, uint32(len(z.ByError)))
+			for za0005, za0006 := range z.ByError {
+				o = msgp.AppendString(o, string(za0005))
+				o = msgp.AppendInt64(o, za0006)
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *HealingCounts) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "started":
+			z.Started, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Started")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "completed":
+			z.Completed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Completed")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "failed":
+			z.Failed, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Failed")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "bytes":
+			z.Bytes, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Bytes")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "bytes_completed":
+			z.BytesCompleted, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesCompleted")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "acc_time_secs":
+			z.AccTime, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AccTime")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "dangling":
+			z.Dangling, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Dangling")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "warm_tier_checks":
+			z.WarmTierChecks, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "WarmTierChecks")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "by_origin":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByOrigin")
+				return
+			}
+			if z.ByOrigin == nil {
+				z.ByOrigin = make(map[HealOrigin]int64, zb0002)
+			} else if len(z.ByOrigin) > 0 {
+				clear(z.ByOrigin)
+			}
+			for zb0002 > 0 {
+				var za0002 int64
+				zb0002--
+				var za0001 HealOrigin
+				{
+					var zb0003 string
+					zb0003, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ByOrigin", za0001)
+						return
+					}
+					za0001 = HealOrigin(zb0003)
+				}
+				za0002, bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByOrigin", za0001)
+					return
+				}
+				z.ByOrigin[za0001] = za0002
+			}
+			zb0001Mask |= 0x100
+		case "by_type":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByType")
+				return
+			}
+			if z.ByType == nil {
+				z.ByType = make(map[HealItemType]int64, zb0004)
+			} else if len(z.ByType) > 0 {
+				clear(z.ByType)
+			}
+			for zb0004 > 0 {
+				var za0004 int64
+				zb0004--
+				var za0003 HealItemType
+				{
+					var zb0005 string
+					zb0005, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ByType", za0003)
+						return
+					}
+					za0003 = HealItemType(zb0005)
+				}
+				za0004, bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByType", za0003)
+					return
+				}
+				z.ByType[za0003] = za0004
+			}
+			zb0001Mask |= 0x200
+		case "by_error":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByError")
+				return
+			}
+			if z.ByError == nil {
+				z.ByError = make(map[HealError]int64, zb0006)
+			} else if len(z.ByError) > 0 {
+				clear(z.ByError)
+			}
+			for zb0006 > 0 {
+				var za0006 int64
+				zb0006--
+				var za0005 HealError
+				{
+					var zb0007 string
+					zb0007, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ByError", za0005)
+						return
+					}
+					za0005 = HealError(zb0007)
+				}
+				za0006, bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByError", za0005)
+					return
+				}
+				z.ByError[za0005] = za0006
+			}
+			zb0001Mask |= 0x400
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7ff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Started = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Completed = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Failed = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.Bytes = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.BytesCompleted = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.AccTime = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.Dangling = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.WarmTierChecks = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.ByOrigin = nil
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.ByType = nil
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.ByError = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *HealingCounts) Msgsize() (s int) {
+	s = 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size + 6 + msgp.Int64Size + 16 + msgp.Int64Size + 14 + msgp.Float64Size + 9 + msgp.Int64Size + 17 + msgp.Int64Size + 10 + msgp.MapHeaderSize
+	if z.ByOrigin != nil {
+		for za0001, za0002 := range z.ByOrigin {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(string(za0001)) + msgp.Int64Size
+		}
+	}
+	s += 8 + msgp.MapHeaderSize
+	if z.ByType != nil {
+		for za0003, za0004 := range z.ByType {
+			_ = za0004
+			s += msgp.StringPrefixSize + len(string(za0003)) + msgp.Int64Size
+		}
+	}
+	s += 9 + msgp.MapHeaderSize
+	if z.ByError != nil {
+		for za0005, za0006 := range z.ByError {
+			_ = za0006
+			s += msgp.StringPrefixSize + len(string(za0005)) + msgp.Int64Size
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *HealingMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "collected":
+			z.CollectedAt, err = dc.ReadTimeUTC()
+			if err != nil {
+				err = msgp.WrapError(err, "CollectedAt")
+				return
+			}
+		case "nodes":
+			z.Nodes, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "Nodes")
+				return
+			}
+		case "last_minute":
+			err = z.LastMinute.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "LastMinute")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "last_hour":
+			err = z.LastHour.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "LastHour")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "last_day":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedHealingStats)
+				}
+				err = (*Segmented[HealingCounts, *HealingCounts])(z.LastDay).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "since_start":
+			err = z.SinceStart.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "SinceStart")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "buckets_last_minute":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastMinute")
+				return
+			}
+			if z.BucketsLastMinute == nil {
+				z.BucketsLastMinute = make(map[string]HealBucketStats, zb0002)
+			} else if len(z.BucketsLastMinute) > 0 {
+				clear(z.BucketsLastMinute)
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastMinute")
+					return
+				}
+				var za0002 HealBucketStats
+				var zb0003 uint32
+				zb0003, err = dc.ReadMapHeader()
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+					return
+				}
+				var zb0003Mask uint8 /* 3 bits */
+				_ = zb0003Mask
+				for zb0003 > 0 {
+					zb0003--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "started":
+						za0002.Started, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Started")
+							return
+						}
+						zb0003Mask |= 0x1
+					case "completed":
+						za0002.Completed, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Completed")
+							return
+						}
+						zb0003Mask |= 0x2
+					case "failed":
+						za0002.Failed, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Failed")
+							return
+						}
+						zb0003Mask |= 0x4
+					default:
+						err = dc.Skip()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if zb0003Mask != 0x7 {
+					if (zb0003Mask & 0x1) == 0 {
+						za0002.Started = 0
+					}
+					if (zb0003Mask & 0x2) == 0 {
+						za0002.Completed = 0
+					}
+					if (zb0003Mask & 0x4) == 0 {
+						za0002.Failed = 0
+					}
+				}
+				z.BucketsLastMinute[za0001] = za0002
+			}
+			zb0001Mask |= 0x10
+		case "buckets_last_hour":
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastHour")
+				return
+			}
+			if z.BucketsLastHour == nil {
+				z.BucketsLastHour = make(map[string]HealBucketStats, zb0004)
+			} else if len(z.BucketsLastHour) > 0 {
+				clear(z.BucketsLastHour)
+			}
+			for zb0004 > 0 {
+				zb0004--
+				var za0003 string
+				za0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastHour")
+					return
+				}
+				var za0004 HealBucketStats
+				var zb0005 uint32
+				zb0005, err = dc.ReadMapHeader()
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastHour", za0003)
+					return
+				}
+				var zb0005Mask uint8 /* 3 bits */
+				_ = zb0005Mask
+				for zb0005 > 0 {
+					zb0005--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						err = msgp.WrapError(err, "BucketsLastHour", za0003)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "started":
+						za0004.Started, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Started")
+							return
+						}
+						zb0005Mask |= 0x1
+					case "completed":
+						za0004.Completed, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Completed")
+							return
+						}
+						zb0005Mask |= 0x2
+					case "failed":
+						za0004.Failed, err = dc.ReadInt64()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Failed")
+							return
+						}
+						zb0005Mask |= 0x4
+					default:
+						err = dc.Skip()
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003)
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if zb0005Mask != 0x7 {
+					if (zb0005Mask & 0x1) == 0 {
+						za0004.Started = 0
+					}
+					if (zb0005Mask & 0x2) == 0 {
+						za0004.Completed = 0
+					}
+					if (zb0005Mask & 0x4) == 0 {
+						za0004.Failed = 0
+					}
+				}
+				z.BucketsLastHour[za0003] = za0004
+			}
+			zb0001Mask |= 0x20
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.LastMinute = HealingCounts{}
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastHour = HealingCounts{}
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.SinceStart = HealingCounts{}
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.BucketsLastMinute = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.BucketsLastHour = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *HealingMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
+	_ = zb0001Mask
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.BucketsLastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.BucketsLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// write "collected"
+		err = en.Append(0xa9, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x65, 0x64)
+		if err != nil {
+			return
+		}
+		err = en.WriteTime(z.CollectedAt)
+		if err != nil {
+			err = msgp.WrapError(err, "CollectedAt")
+			return
+		}
+		// write "nodes"
+		err = en.Append(0xa5, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.Nodes)
+		if err != nil {
+			err = msgp.WrapError(err, "Nodes")
+			return
+		}
+		// write "last_minute"
+		err = en.Append(0xab, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x6d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+		if err != nil {
+			return
+		}
+		err = z.LastMinute.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "LastMinute")
+			return
+		}
+		// write "last_hour"
+		err = en.Append(0xa9, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x68, 0x6f, 0x75, 0x72)
+		if err != nil {
+			return
+		}
+		err = z.LastHour.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "LastHour")
+			return
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "last_day"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x64, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[HealingCounts, *HealingCounts])(z.LastDay).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		// write "since_start"
+		err = en.Append(0xab, 0x73, 0x69, 0x6e, 0x63, 0x65, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74)
+		if err != nil {
+			return
+		}
+		err = z.SinceStart.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "SinceStart")
+			return
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "buckets_last_minute"
+			err = en.Append(0xb3, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x5f, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x6d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.BucketsLastMinute)))
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastMinute")
+				return
+			}
+			for za0001, za0002 := range z.BucketsLastMinute {
+				err = en.WriteString(za0001)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastMinute")
+					return
+				}
+				// check for omitted fields
+				zb0002Len := uint32(3)
+				var zb0002Mask uint8 /* 3 bits */
+				_ = zb0002Mask
+				if za0002.Started == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				if za0002.Completed == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x2
+				}
+				if za0002.Failed == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x4
+				}
+				// variable map header, size zb0002Len
+				err = en.Append(0x80 | uint8(zb0002Len))
+				if err != nil {
+					return
+				}
+
+				// skip if no fields are to be emitted
+				if zb0002Len != 0 {
+					if (zb0002Mask & 0x1) == 0 { // if not omitted
+						// write "started"
+						err = en.Append(0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0002.Started)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Started")
+							return
+						}
+					}
+					if (zb0002Mask & 0x2) == 0 { // if not omitted
+						// write "completed"
+						err = en.Append(0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0002.Completed)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Completed")
+							return
+						}
+					}
+					if (zb0002Mask & 0x4) == 0 { // if not omitted
+						// write "failed"
+						err = en.Append(0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0002.Failed)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Failed")
+							return
+						}
+					}
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "buckets_last_hour"
+			err = en.Append(0xb1, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x5f, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x68, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.BucketsLastHour)))
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastHour")
+				return
+			}
+			for za0003, za0004 := range z.BucketsLastHour {
+				err = en.WriteString(za0003)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastHour")
+					return
+				}
+				// check for omitted fields
+				zb0003Len := uint32(3)
+				var zb0003Mask uint8 /* 3 bits */
+				_ = zb0003Mask
+				if za0004.Started == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x1
+				}
+				if za0004.Completed == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x2
+				}
+				if za0004.Failed == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x4
+				}
+				// variable map header, size zb0003Len
+				err = en.Append(0x80 | uint8(zb0003Len))
+				if err != nil {
+					return
+				}
+
+				// skip if no fields are to be emitted
+				if zb0003Len != 0 {
+					if (zb0003Mask & 0x1) == 0 { // if not omitted
+						// write "started"
+						err = en.Append(0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0004.Started)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Started")
+							return
+						}
+					}
+					if (zb0003Mask & 0x2) == 0 { // if not omitted
+						// write "completed"
+						err = en.Append(0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0004.Completed)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Completed")
+							return
+						}
+					}
+					if (zb0003Mask & 0x4) == 0 { // if not omitted
+						// write "failed"
+						err = en.Append(0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+						if err != nil {
+							return
+						}
+						err = en.WriteInt64(za0004.Failed)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Failed")
+							return
+						}
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *HealingMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
+	_ = zb0001Mask
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.BucketsLastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.BucketsLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// string "collected"
+		o = append(o, 0xa9, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x65, 0x64)
+		o = msgp.AppendTime(o, z.CollectedAt)
+		// string "nodes"
+		o = append(o, 0xa5, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+		o = msgp.AppendInt(o, z.Nodes)
+		// string "last_minute"
+		o = append(o, 0xab, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x6d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+		o, err = z.LastMinute.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "LastMinute")
+			return
+		}
+		// string "last_hour"
+		o = append(o, 0xa9, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x68, 0x6f, 0x75, 0x72)
+		o, err = z.LastHour.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "LastHour")
+			return
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "last_day"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x64, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[HealingCounts, *HealingCounts])(z.LastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		// string "since_start"
+		o = append(o, 0xab, 0x73, 0x69, 0x6e, 0x63, 0x65, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74)
+		o, err = z.SinceStart.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "SinceStart")
+			return
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "buckets_last_minute"
+			o = append(o, 0xb3, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x5f, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x6d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			o = msgp.AppendMapHeader(o, uint32(len(z.BucketsLastMinute)))
+			for za0001, za0002 := range z.BucketsLastMinute {
+				o = msgp.AppendString(o, za0001)
+				// check for omitted fields
+				zb0002Len := uint32(3)
+				var zb0002Mask uint8 /* 3 bits */
+				_ = zb0002Mask
+				if za0002.Started == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				if za0002.Completed == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x2
+				}
+				if za0002.Failed == 0 {
+					zb0002Len--
+					zb0002Mask |= 0x4
+				}
+				// variable map header, size zb0002Len
+				o = append(o, 0x80|uint8(zb0002Len))
+
+				// skip if no fields are to be emitted
+				if zb0002Len != 0 {
+					if (zb0002Mask & 0x1) == 0 { // if not omitted
+						// string "started"
+						o = append(o, 0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0002.Started)
+					}
+					if (zb0002Mask & 0x2) == 0 { // if not omitted
+						// string "completed"
+						o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0002.Completed)
+					}
+					if (zb0002Mask & 0x4) == 0 { // if not omitted
+						// string "failed"
+						o = append(o, 0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0002.Failed)
+					}
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "buckets_last_hour"
+			o = append(o, 0xb1, 0x62, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x5f, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x68, 0x6f, 0x75, 0x72)
+			o = msgp.AppendMapHeader(o, uint32(len(z.BucketsLastHour)))
+			for za0003, za0004 := range z.BucketsLastHour {
+				o = msgp.AppendString(o, za0003)
+				// check for omitted fields
+				zb0003Len := uint32(3)
+				var zb0003Mask uint8 /* 3 bits */
+				_ = zb0003Mask
+				if za0004.Started == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x1
+				}
+				if za0004.Completed == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x2
+				}
+				if za0004.Failed == 0 {
+					zb0003Len--
+					zb0003Mask |= 0x4
+				}
+				// variable map header, size zb0003Len
+				o = append(o, 0x80|uint8(zb0003Len))
+
+				// skip if no fields are to be emitted
+				if zb0003Len != 0 {
+					if (zb0003Mask & 0x1) == 0 { // if not omitted
+						// string "started"
+						o = append(o, 0xa7, 0x73, 0x74, 0x61, 0x72, 0x74, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0004.Started)
+					}
+					if (zb0003Mask & 0x2) == 0 { // if not omitted
+						// string "completed"
+						o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0004.Completed)
+					}
+					if (zb0003Mask & 0x4) == 0 { // if not omitted
+						// string "failed"
+						o = append(o, 0xa6, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+						o = msgp.AppendInt64(o, za0004.Failed)
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *HealingMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "collected":
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CollectedAt")
+				return
+			}
+		case "nodes":
+			z.Nodes, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Nodes")
+				return
+			}
+		case "last_minute":
+			bts, err = z.LastMinute.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LastMinute")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "last_hour":
+			bts, err = z.LastHour.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LastHour")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "last_day":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedHealingStats)
+				}
+				bts, err = (*Segmented[HealingCounts, *HealingCounts])(z.LastDay).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "since_start":
+			bts, err = z.SinceStart.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SinceStart")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "buckets_last_minute":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastMinute")
+				return
+			}
+			if z.BucketsLastMinute == nil {
+				z.BucketsLastMinute = make(map[string]HealBucketStats, zb0002)
+			} else if len(z.BucketsLastMinute) > 0 {
+				clear(z.BucketsLastMinute)
+			}
+			for zb0002 > 0 {
+				var za0002 HealBucketStats
+				zb0002--
+				var za0001 string
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastMinute")
+					return
+				}
+				var zb0003 uint32
+				zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+					return
+				}
+				var zb0003Mask uint8 /* 3 bits */
+				_ = zb0003Mask
+				for zb0003 > 0 {
+					zb0003--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "started":
+						za0002.Started, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Started")
+							return
+						}
+						zb0003Mask |= 0x1
+					case "completed":
+						za0002.Completed, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Completed")
+							return
+						}
+						zb0003Mask |= 0x2
+					case "failed":
+						za0002.Failed, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001, "Failed")
+							return
+						}
+						zb0003Mask |= 0x4
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastMinute", za0001)
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if zb0003Mask != 0x7 {
+					if (zb0003Mask & 0x1) == 0 {
+						za0002.Started = 0
+					}
+					if (zb0003Mask & 0x2) == 0 {
+						za0002.Completed = 0
+					}
+					if (zb0003Mask & 0x4) == 0 {
+						za0002.Failed = 0
+					}
+				}
+				z.BucketsLastMinute[za0001] = za0002
+			}
+			zb0001Mask |= 0x10
+		case "buckets_last_hour":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BucketsLastHour")
+				return
+			}
+			if z.BucketsLastHour == nil {
+				z.BucketsLastHour = make(map[string]HealBucketStats, zb0004)
+			} else if len(z.BucketsLastHour) > 0 {
+				clear(z.BucketsLastHour)
+			}
+			for zb0004 > 0 {
+				var za0004 HealBucketStats
+				zb0004--
+				var za0003 string
+				za0003, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastHour")
+					return
+				}
+				var zb0005 uint32
+				zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BucketsLastHour", za0003)
+					return
+				}
+				var zb0005Mask uint8 /* 3 bits */
+				_ = zb0005Mask
+				for zb0005 > 0 {
+					zb0005--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "BucketsLastHour", za0003)
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "started":
+						za0004.Started, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Started")
+							return
+						}
+						zb0005Mask |= 0x1
+					case "completed":
+						za0004.Completed, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Completed")
+							return
+						}
+						zb0005Mask |= 0x2
+					case "failed":
+						za0004.Failed, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003, "Failed")
+							return
+						}
+						zb0005Mask |= 0x4
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "BucketsLastHour", za0003)
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if zb0005Mask != 0x7 {
+					if (zb0005Mask & 0x1) == 0 {
+						za0004.Started = 0
+					}
+					if (zb0005Mask & 0x2) == 0 {
+						za0004.Completed = 0
+					}
+					if (zb0005Mask & 0x4) == 0 {
+						za0004.Failed = 0
+					}
+				}
+				z.BucketsLastHour[za0003] = za0004
+			}
+			zb0001Mask |= 0x20
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.LastMinute = HealingCounts{}
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastHour = HealingCounts{}
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.SinceStart = HealingCounts{}
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.BucketsLastMinute = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.BucketsLastHour = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *HealingMetrics) Msgsize() (s int) {
+	s = 1 + 10 + msgp.TimeSize + 6 + msgp.IntSize + 12 + z.LastMinute.Msgsize() + 10 + z.LastHour.Msgsize() + 9
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[HealingCounts, *HealingCounts])(z.LastDay).Msgsize()
+	}
+	s += 12 + z.SinceStart.Msgsize() + 20 + msgp.MapHeaderSize
+	if z.BucketsLastMinute != nil {
+		for za0001, za0002 := range z.BucketsLastMinute {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size
+		}
+	}
+	s += 18 + msgp.MapHeaderSize
+	if z.BucketsLastHour != nil {
+		for za0003, za0004 := range z.BucketsLastHour {
+			_ = za0004
+			s += msgp.StringPrefixSize + len(za0003) + 1 + 8 + msgp.Int64Size + 10 + msgp.Int64Size + 7 + msgp.Int64Size
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *InterfaceStats) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -12224,7 +14270,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 13 bits */
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -12481,6 +14527,25 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x1000
+		case "healing":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Healing")
+					return
+				}
+				z.Healing = nil
+			} else {
+				if z.Healing == nil {
+					z.Healing = new(HealingMetrics)
+				}
+				err = z.Healing.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Healing")
+					return
+				}
+			}
+			zb0001Mask |= 0x2000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -12490,7 +14555,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1fff {
+	if zb0001Mask != 0x3fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -12530,6 +14595,9 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x1000) == 0 {
 			z.Process = nil
 		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.Healing = nil
+		}
 	}
 	return
 }
@@ -12537,8 +14605,8 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(13)
-	var zb0001Mask uint16 /* 13 bits */
+	zb0001Len := uint32(14)
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -12591,6 +14659,10 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.Process == nil {
 		zb0001Len--
 		zb0001Mask |= 0x1000
+	}
+	if z.Healing == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -12847,6 +14919,25 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// write "healing"
+			err = en.Append(0xa7, 0x68, 0x65, 0x61, 0x6c, 0x69, 0x6e, 0x67)
+			if err != nil {
+				return
+			}
+			if z.Healing == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.Healing.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Healing")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -12855,8 +14946,8 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(13)
-	var zb0001Mask uint16 /* 13 bits */
+	zb0001Len := uint32(14)
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -12909,6 +15000,10 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.Process == nil {
 		zb0001Len--
 		zb0001Mask |= 0x1000
+	}
+	if z.Healing == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -13084,6 +15179,19 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// string "healing"
+			o = append(o, 0xa7, 0x68, 0x65, 0x61, 0x6c, 0x69, 0x6e, 0x67)
+			if z.Healing == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.Healing.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Healing")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -13098,7 +15206,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 13 bits */
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -13342,6 +15450,24 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x1000
+		case "healing":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Healing = nil
+			} else {
+				if z.Healing == nil {
+					z.Healing = new(HealingMetrics)
+				}
+				bts, err = z.Healing.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Healing")
+					return
+				}
+			}
+			zb0001Mask |= 0x2000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -13351,7 +15477,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1fff {
+	if zb0001Mask != 0x3fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -13390,6 +15516,9 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if (zb0001Mask & 0x1000) == 0 {
 			z.Process = nil
+		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.Healing = nil
 		}
 	}
 	o = bts
@@ -13475,6 +15604,12 @@ func (z *Metrics) Msgsize() (s int) {
 		s += msgp.NilSize
 	} else {
 		s += z.Process.Msgsize()
+	}
+	s += 8
+	if z.Healing == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.Healing.Msgsize()
 	}
 	return
 }

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -1478,6 +1478,345 @@ func BenchmarkDecodeExpirationInfo(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalHealBucketStats(t *testing.T) {
+	v := HealBucketStats{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgHealBucketStats(b *testing.B) {
+	v := HealBucketStats{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgHealBucketStats(b *testing.B) {
+	v := HealBucketStats{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalHealBucketStats(b *testing.B) {
+	v := HealBucketStats{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeHealBucketStats(t *testing.T) {
+	v := HealBucketStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeHealBucketStats Msgsize() is inaccurate")
+	}
+
+	vn := HealBucketStats{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeHealBucketStats(b *testing.B) {
+	v := HealBucketStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeHealBucketStats(b *testing.B) {
+	v := HealBucketStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalHealingCounts(t *testing.T) {
+	v := HealingCounts{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgHealingCounts(b *testing.B) {
+	v := HealingCounts{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgHealingCounts(b *testing.B) {
+	v := HealingCounts{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalHealingCounts(b *testing.B) {
+	v := HealingCounts{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeHealingCounts(t *testing.T) {
+	v := HealingCounts{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeHealingCounts Msgsize() is inaccurate")
+	}
+
+	vn := HealingCounts{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeHealingCounts(b *testing.B) {
+	v := HealingCounts{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeHealingCounts(b *testing.B) {
+	v := HealingCounts{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalHealingMetrics(t *testing.T) {
+	v := HealingMetrics{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgHealingMetrics(b *testing.B) {
+	v := HealingMetrics{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgHealingMetrics(b *testing.B) {
+	v := HealingMetrics{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalHealingMetrics(b *testing.B) {
+	v := HealingMetrics{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeHealingMetrics(t *testing.T) {
+	v := HealingMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeHealingMetrics Msgsize() is inaccurate")
+	}
+
+	vn := HealingMetrics{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeHealingMetrics(b *testing.B) {
+	v := HealingMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeHealingMetrics(b *testing.B) {
+	v := HealingMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalInterfaceStats(t *testing.T) {
 	v := InterfaceStats{}
 	bts, err := v.MarshalMsg(nil)

--- a/mnav/healing.go
+++ b/mnav/healing.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/minio/madmin-go/v4"
+)
+
+// HealingMetricsNode handles navigation for HealingMetrics.
+type HealingMetricsNode struct {
+	healing *madmin.HealingMetrics
+	parent  MetricNode
+	path    string
+}
+
+// NewHealingMetricsNode creates a new HealingMetricsNode.
+func NewHealingMetricsNode(healing *madmin.HealingMetrics, parent MetricNode, path string) *HealingMetricsNode {
+	return &HealingMetricsNode{healing: healing, parent: parent, path: path}
+}
+
+func (node *HealingMetricsNode) GetChildren() []MetricChild {
+	if node.healing == nil {
+		return []MetricChild{}
+	}
+	return []MetricChild{
+		{Name: "last_minute", Description: "Rolling 60-second totals"},
+		{Name: "last_hour", Description: "Rolling 60-minute totals"},
+		{Name: "last_day", Description: "Last 24h in 15-minute segments"},
+		{Name: "since_start", Description: "Accumulated all-time totals"},
+		{Name: "buckets_minute", Description: "Per-bucket outcomes (last minute)"},
+		{Name: "buckets_hour", Description: "Per-bucket outcomes (last hour)"},
+	}
+}
+
+func (node *HealingMetricsNode) GetLeafData() map[string]string {
+	if node.healing == nil {
+		return map[string]string{"Status": "No healing metrics available"}
+	}
+	h := node.healing
+	data := map[string]string{}
+
+	data["00:Nodes reporting"] = fmt.Sprintf("%d", h.Nodes)
+	data["01:Last updated"] = h.CollectedAt.Format("15:04:05")
+
+	// Last minute summary
+	lm := &h.LastMinute
+	if lm.Started > 0 {
+		data["03:Last minute"] = formatHealSummary(lm)
+	} else {
+		data["03:Last minute"] = "No activity"
+	}
+
+	// Last hour summary
+	lh := &h.LastHour
+	if lh.Started > 0 {
+		data["04:Last hour"] = formatHealSummary(lh)
+	} else {
+		data["04:Last hour"] = "No activity"
+	}
+
+	// Since start summary
+	ss := &h.SinceStart
+	if ss.Started > 0 {
+		data["05:All time"] = formatHealSummary(ss)
+	}
+
+	return data
+}
+
+func (node *HealingMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsHealing }
+func (node *HealingMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *HealingMetricsNode) GetParent() MetricNode              { return node.parent }
+func (node *HealingMetricsNode) GetPath() string                    { return node.path }
+func (node *HealingMetricsNode) ShouldPauseRefresh() bool           { return false }
+func (node *HealingMetricsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+
+func (node *HealingMetricsNode) GetChild(name string) (MetricNode, error) {
+	if node.healing == nil {
+		return nil, fmt.Errorf("no healing data available")
+	}
+	switch name {
+	case "last_minute":
+		return NewHealingCountsNode(&node.healing.LastMinute, node, node.path+"/last_minute"), nil
+	case "last_hour":
+		return NewHealingCountsNode(&node.healing.LastHour, node, node.path+"/last_hour"), nil
+	case "since_start":
+		return NewHealingCountsNode(&node.healing.SinceStart, node, node.path+"/since_start"), nil
+	case "last_day":
+		return NewHealingLastDayNode(node.healing.LastDay, node, node.path+"/last_day"), nil
+	case "buckets_minute":
+		return NewHealingBucketsNode(node.healing.BucketsLastMinute, node, node.path+"/buckets_minute"), nil
+	case "buckets_hour":
+		return NewHealingBucketsNode(node.healing.BucketsLastHour, node, node.path+"/buckets_hour"), nil
+	default:
+		return nil, fmt.Errorf("child not found: %s", name)
+	}
+}
+
+// HealingCountsNode displays a single HealingCounts snapshot.
+type HealingCountsNode struct {
+	counts *madmin.HealingCounts
+	parent MetricNode
+	path   string
+}
+
+// NewHealingCountsNode creates a new HealingCountsNode.
+func NewHealingCountsNode(counts *madmin.HealingCounts, parent MetricNode, path string) *HealingCountsNode {
+	return &HealingCountsNode{counts: counts, parent: parent, path: path}
+}
+
+func (node *HealingCountsNode) GetChildren() []MetricChild { return []MetricChild{} }
+
+func (node *HealingCountsNode) GetLeafData() map[string]string {
+	c := node.counts
+	if c == nil {
+		return map[string]string{"Status": "No data"}
+	}
+	data := map[string]string{}
+
+	data["00:Started"] = humanize.Comma(c.Started)
+	data["01:Completed"] = humanize.Comma(c.Completed)
+	data["02:Failed"] = humanize.Comma(c.Failed)
+	data["03:Bytes processed"] = humanize.Bytes(uint64(c.Bytes))
+	data["04:Bytes healed"] = humanize.Bytes(uint64(c.BytesCompleted))
+
+	if c.Completed > 0 && c.AccTime > 0 {
+		avg := c.AccTime / float64(c.Completed)
+		data["05:Avg heal time"] = fmt.Sprintf("%.2fms", avg*1000)
+		data["06:Total heal time"] = fmt.Sprintf("%.1fs", c.AccTime)
+	}
+
+	if c.Dangling > 0 {
+		data["07:Dangling cleaned"] = humanize.Comma(c.Dangling)
+	}
+	if c.WarmTierChecks > 0 {
+		data["08:Warm tier checks"] = humanize.Comma(c.WarmTierChecks)
+	}
+
+	if len(c.ByOrigin) > 0 {
+		for k, v := range c.ByOrigin {
+			data["10:Origin/"+k] = humanize.Comma(v)
+		}
+	}
+	if len(c.ByType) > 0 {
+		for k, v := range c.ByType {
+			data["11:Type/"+k] = humanize.Comma(v)
+		}
+	}
+	if len(c.ByError) > 0 {
+		for k, v := range c.ByError {
+			data["12:Error/"+k] = humanize.Comma(v)
+		}
+	}
+	return data
+}
+
+func (node *HealingCountsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsHealing }
+func (node *HealingCountsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *HealingCountsNode) GetParent() MetricNode              { return node.parent }
+func (node *HealingCountsNode) GetPath() string                    { return node.path }
+func (node *HealingCountsNode) ShouldPauseRefresh() bool           { return false }
+func (node *HealingCountsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+
+func (node *HealingCountsNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("healing counts is a leaf node")
+}
+
+// HealingLastDayNode navigates the 24h segmented healing data.
+type HealingLastDayNode struct {
+	lastDay *madmin.SegmentedHealingStats
+	parent  MetricNode
+	path    string
+}
+
+// NewHealingLastDayNode creates a new HealingLastDayNode.
+func NewHealingLastDayNode(lastDay *madmin.SegmentedHealingStats, parent MetricNode, path string) *HealingLastDayNode {
+	return &HealingLastDayNode{lastDay: lastDay, parent: parent, path: path}
+}
+
+func (node *HealingLastDayNode) GetChildren() []MetricChild {
+	if node.lastDay == nil || len(node.lastDay.Segments) == 0 {
+		return []MetricChild{}
+	}
+	children := []MetricChild{{Name: "total", Description: "Aggregated totals across all segments"}}
+	for i := len(node.lastDay.Segments) - 1; i >= 0; i-- {
+		seg := node.lastDay.Segments[i]
+		if seg.Started == 0 {
+			continue
+		}
+		segTime := node.lastDay.FirstTime.Add(time.Duration(i*node.lastDay.Interval) * time.Second)
+		name := segTime.UTC().Format("15:04Z")
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: fmt.Sprintf("%s started, %s completed", humanize.Comma(seg.Started), humanize.Comma(seg.Completed)),
+		})
+	}
+	return children
+}
+
+func (node *HealingLastDayNode) GetLeafData() map[string]string {
+	if node.lastDay == nil || len(node.lastDay.Segments) == 0 {
+		return map[string]string{"Status": "No last day statistics available"}
+	}
+	// Show totals across all segments
+	var total madmin.HealingCounts
+	for i := range node.lastDay.Segments {
+		total.Add(&node.lastDay.Segments[i])
+	}
+	data := map[string]string{
+		"00:Segments": fmt.Sprintf("%d (every %ds)", len(node.lastDay.Segments), node.lastDay.Interval),
+	}
+	if total.Started > 0 {
+		data["01:Total"] = formatHealSummary(&total)
+	}
+	return data
+}
+
+func (node *HealingLastDayNode) GetMetricType() madmin.MetricType { return madmin.MetricsHealing }
+func (node *HealingLastDayNode) GetMetricFlags() madmin.MetricFlags {
+	return madmin.MetricsDayStats
+}
+func (node *HealingLastDayNode) GetParent() MetricNode          { return node.parent }
+func (node *HealingLastDayNode) GetPath() string                { return node.path }
+func (node *HealingLastDayNode) ShouldPauseRefresh() bool       { return true }
+func (node *HealingLastDayNode) GetOpts() madmin.MetricsOptions { return getNodeOpts(node) }
+
+func (node *HealingLastDayNode) GetChild(name string) (MetricNode, error) {
+	if node.lastDay == nil {
+		return nil, fmt.Errorf("no last day data available")
+	}
+	if name == "total" {
+		var total madmin.HealingCounts
+		for i := range node.lastDay.Segments {
+			total.Add(&node.lastDay.Segments[i])
+		}
+		return NewHealingCountsNode(&total, node, node.path+"/total"), nil
+	}
+	for i := range node.lastDay.Segments {
+		segTime := node.lastDay.FirstTime.Add(time.Duration(i*node.lastDay.Interval) * time.Second)
+		if segTime.UTC().Format("15:04Z") == name {
+			return NewHealingCountsNode(&node.lastDay.Segments[i], node, node.path+"/"+name), nil
+		}
+	}
+	return nil, fmt.Errorf("segment not found: %s", name)
+}
+
+// HealingBucketsNode navigates per-bucket healing outcomes.
+type HealingBucketsNode struct {
+	buckets map[string]madmin.HealBucketStats
+	parent  MetricNode
+	path    string
+}
+
+// NewHealingBucketsNode creates a new HealingBucketsNode.
+func NewHealingBucketsNode(buckets map[string]madmin.HealBucketStats, parent MetricNode, path string) *HealingBucketsNode {
+	return &HealingBucketsNode{buckets: buckets, parent: parent, path: path}
+}
+
+func (node *HealingBucketsNode) GetChildren() []MetricChild {
+	if len(node.buckets) == 0 {
+		return []MetricChild{}
+	}
+	names := make([]string, 0, len(node.buckets))
+	for k := range node.buckets {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	children := make([]MetricChild, 0, len(names))
+	for _, name := range names {
+		bs := node.buckets[name]
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: fmt.Sprintf("%d started, %d ok, %d failed", bs.Started, bs.Completed, bs.Failed),
+		})
+	}
+	return children
+}
+
+func (node *HealingBucketsNode) GetLeafData() map[string]string {
+	if len(node.buckets) == 0 {
+		return map[string]string{"Status": "No per-bucket data"}
+	}
+	data := map[string]string{
+		"Buckets": fmt.Sprintf("%d", len(node.buckets)),
+	}
+	var totalStarted, totalCompleted, totalFailed int64
+	for _, bs := range node.buckets {
+		totalStarted += bs.Started
+		totalCompleted += bs.Completed
+		totalFailed += bs.Failed
+	}
+	data["Total started"] = humanize.Comma(totalStarted)
+	data["Total completed"] = humanize.Comma(totalCompleted)
+	if totalFailed > 0 {
+		data["Total failed"] = humanize.Comma(totalFailed)
+	}
+	return data
+}
+
+func (node *HealingBucketsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsHealing }
+func (node *HealingBucketsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *HealingBucketsNode) GetParent() MetricNode              { return node.parent }
+func (node *HealingBucketsNode) GetPath() string                    { return node.path }
+func (node *HealingBucketsNode) ShouldPauseRefresh() bool           { return false }
+func (node *HealingBucketsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+
+func (node *HealingBucketsNode) GetChild(name string) (MetricNode, error) {
+	bs, ok := node.buckets[name]
+	if !ok {
+		return nil, fmt.Errorf("bucket not found: %s", name)
+	}
+	return &HealingBucketLeafNode{
+		name: name, stats: &bs,
+		parent: node, path: node.path + "/" + name,
+	}, nil
+}
+
+// HealingBucketLeafNode displays stats for a single bucket.
+type HealingBucketLeafNode struct {
+	name   string
+	stats  *madmin.HealBucketStats
+	parent MetricNode
+	path   string
+}
+
+func (node *HealingBucketLeafNode) GetChildren() []MetricChild { return []MetricChild{} }
+
+func (node *HealingBucketLeafNode) GetLeafData() map[string]string {
+	return map[string]string{
+		"Bucket":    node.name,
+		"Started":   humanize.Comma(node.stats.Started),
+		"Completed": humanize.Comma(node.stats.Completed),
+		"Failed":    humanize.Comma(node.stats.Failed),
+	}
+}
+
+func (node *HealingBucketLeafNode) GetMetricType() madmin.MetricType   { return madmin.MetricsHealing }
+func (node *HealingBucketLeafNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *HealingBucketLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *HealingBucketLeafNode) GetPath() string                    { return node.path }
+func (node *HealingBucketLeafNode) ShouldPauseRefresh() bool           { return false }
+func (node *HealingBucketLeafNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+
+func (node *HealingBucketLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("bucket stats is a leaf node")
+}
+
+// formatHealSummary returns a one-line summary of a HealingCounts.
+func formatHealSummary(c *madmin.HealingCounts) string {
+	s := fmt.Sprintf("%s started, %s ok, %s failed, %s",
+		humanize.Comma(c.Started),
+		humanize.Comma(c.Completed),
+		humanize.Comma(c.Failed),
+		humanize.Bytes(uint64(c.BytesCompleted)))
+	if c.Completed > 0 && c.AccTime > 0 {
+		avg := c.AccTime / float64(c.Completed) * 1000
+		s += fmt.Sprintf(", %.1fms avg", avg)
+	}
+	return s
+}

--- a/mnav/healing.go
+++ b/mnav/healing.go
@@ -43,8 +43,8 @@ func (node *HealingMetricsNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 	return []MetricChild{
-		{Name: "last_minute", Description: "Rolling 60-second totals"},
-		{Name: "last_hour", Description: "Rolling 60-minute totals"},
+		{Name: "last_minute", Description: "Rolling 1 minute total"},
+		{Name: "last_hour", Description: "Rolling 1 hour total"},
 		{Name: "last_day", Description: "Last 24h in 15-minute segments"},
 		{Name: "since_start", Description: "Accumulated all-time totals"},
 		{Name: "buckets_minute", Description: "Per-bucket outcomes (last minute)"},
@@ -139,36 +139,38 @@ func (node *HealingCountsNode) GetLeafData() map[string]string {
 
 	data["00:Started"] = humanize.Comma(c.Started)
 	data["01:Completed"] = humanize.Comma(c.Completed)
-	data["02:Failed"] = humanize.Comma(c.Failed)
-	data["03:Bytes processed"] = humanize.Bytes(uint64(c.Bytes))
-	data["04:Bytes healed"] = humanize.Bytes(uint64(c.BytesCompleted))
+	data["02:Healed"] = humanize.Comma(c.Healed)
+	data["03:Failed"] = humanize.Comma(c.Failed)
+	data["04:Bytes processed"] = humanize.Bytes(uint64(c.Bytes))
+	data["05:Bytes completed"] = humanize.Bytes(uint64(c.BytesCompleted))
+	data["06:Bytes healed"] = humanize.Bytes(uint64(c.BytesHealed))
 
 	if c.Completed > 0 && c.AccTime > 0 {
 		avg := c.AccTime / float64(c.Completed)
-		data["05:Avg heal time"] = fmt.Sprintf("%.2fms", avg*1000)
-		data["06:Total heal time"] = fmt.Sprintf("%.1fs", c.AccTime)
+		data["07:Avg heal time"] = fmt.Sprintf("%.2fms", avg*1000)
+		data["08:Total heal time"] = fmt.Sprintf("%.1fs", c.AccTime)
 	}
 
 	if c.Dangling > 0 {
-		data["07:Dangling cleaned"] = humanize.Comma(c.Dangling)
+		data["09:Dangling cleaned"] = humanize.Comma(c.Dangling)
 	}
 	if c.WarmTierChecks > 0 {
-		data["08:Warm tier checks"] = humanize.Comma(c.WarmTierChecks)
+		data["10:Warm tier checks"] = humanize.Comma(c.WarmTierChecks)
 	}
 
 	if len(c.ByOrigin) > 0 {
 		for k, v := range c.ByOrigin {
-			data["10:Origin/"+k] = humanize.Comma(v)
+			data["20:Origin/"+k] = humanize.Comma(v)
 		}
 	}
 	if len(c.ByType) > 0 {
 		for k, v := range c.ByType {
-			data["11:Type/"+k] = humanize.Comma(v)
+			data["21:Type/"+k] = humanize.Comma(v)
 		}
 	}
 	if len(c.ByError) > 0 {
 		for k, v := range c.ByError {
-			data["12:Error/"+k] = humanize.Comma(v)
+			data["22:Error/"+k] = humanize.Comma(v)
 		}
 	}
 	return data
@@ -368,9 +370,10 @@ func (node *HealingBucketLeafNode) GetChild(_ string) (MetricNode, error) {
 
 // formatHealSummary returns a one-line summary of a HealingCounts.
 func formatHealSummary(c *madmin.HealingCounts) string {
-	s := fmt.Sprintf("%s started, %s ok, %s failed, %s",
+	s := fmt.Sprintf("%s started, %s ok, %s healed, %s failed, %s",
 		humanize.Comma(c.Started),
 		humanize.Comma(c.Completed),
+		humanize.Comma(c.Healed),
 		humanize.Comma(c.Failed),
 		humanize.Bytes(uint64(c.BytesCompleted)))
 	if c.Completed > 0 && c.AccTime > 0 {

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -167,6 +167,7 @@ func (node *RealtimeMetricsNode) GetChildren() []MetricChild {
 		{Name: "process", Description: "Process-level system metrics"},
 		{Name: "replication", Description: "Replication metrics"},
 		{Name: "scanner", Description: "Scanner-related metrics"},
+		{Name: "healing", Description: "Healing operation metrics"},
 		{Name: "batch_jobs", Description: "Batch job execution metrics"},
 		{Name: "site_resync", Description: "Site replication resync metrics"},
 		{Name: "by_host", Description: "Metrics broken down by individual host"},
@@ -220,6 +221,8 @@ func (node *RealtimeMetricsNode) GetChild(name string) (MetricNode, error) {
 	// Individual metric types - route directly from root
 	case "scanner":
 		return NewScannerMetricsNode(node.metrics.Aggregated.Scanner, node, "scanner"), nil
+	case "healing":
+		return NewHealingMetricsNode(node.metrics.Aggregated.Healing, node, "healing"), nil
 	case "drive":
 		return NewDiskMetricsNavigator(node.metrics.Aggregated.Disk, node, "drive", madmin.MetricsOptions{}), nil
 	case "os":
@@ -323,6 +326,7 @@ func (node *MetricsNode) GetChildren() []MetricChild {
 		{Name: "process", Description: "Process-level system metrics"},
 		{Name: "replication", Description: "Replication metrics"},
 		{Name: "scanner", Description: "Scanner-related metrics"},
+		{Name: "healing", Description: "Healing operation metrics"},
 		{Name: "batch_jobs", Description: "Batch job execution metrics"},
 		{Name: "site_resync", Description: "Site replication resync metrics"},
 	}
@@ -356,6 +360,8 @@ func (node *MetricsNode) GetChild(name string) (MetricNode, error) {
 	switch name {
 	case "scanner":
 		return NewScannerMetricsNode(node.metrics.Scanner, node, fmt.Sprintf("%s/scanner", node.path)), nil
+	case "healing":
+		return NewHealingMetricsNode(node.metrics.Healing, node, fmt.Sprintf("%s/healing", node.path)), nil
 	case "drive":
 		return NewDiskMetricsNavigator(node.metrics.Disk, node, fmt.Sprintf("%s/drive", node.path), madmin.MetricsOptions{}), nil
 	case "os":


### PR DESCRIPTION
Adds aggregated healing data and time segmented 24 healing information.

Last minute, Last Hour, Last Day (time segmented)

Allows tracking source of the healing operation, time taken, outcome, bytes, operations per bucket.