### PR TITLE
feat: add BucketRetentionConfig to BucketDetails

### DIFF
--- a/user-commands.go
+++ b/user-commands.go
@@ -38,8 +38,8 @@ type AccountAccess struct {
 	Write bool `json:"write"`
 }
 
-// BucketRetentionConfig holds the default object lock retention rule for a bucket.
-type BucketRetentionConfig struct {
+// BucketRetention holds the default object lock retention rule for a bucket.
+type BucketRetention struct {
 	Mode  string `json:"mode"`
 	Days  uint64 `json:"days,omitempty"`
 	Years uint64 `json:"years,omitempty"`
@@ -48,15 +48,15 @@ type BucketRetentionConfig struct {
 // BucketDetails provides information about features currently
 // turned-on per bucket.
 type BucketDetails struct {
-	Versioning          bool                   `json:"versioning"`
-	VersioningSuspended bool                   `json:"versioningSuspended"`
-	Locking             bool                   `json:"locking"`
-	Replication         bool                   `json:"replication"`
-	Tagging             *tags.Tags             `json:"tags"`
-	Quota               *BucketQuota           `json:"quota"`
-	SSEType             string                 `json:"sseType,omitempty"`
-	SSEKeyID            string                 `json:"sseKeyID,omitempty"`
-	RetentionConfig     *BucketRetentionConfig `json:"retentionConfig,omitempty"`
+	Versioning          bool             `json:"versioning"`
+	VersioningSuspended bool             `json:"versioningSuspended"`
+	Locking             bool             `json:"locking"`
+	Replication         bool             `json:"replication"`
+	Tagging             *tags.Tags       `json:"tags"`
+	Quota               *BucketQuota     `json:"quota"`
+	SSEType             string           `json:"sseType,omitempty"`
+	SSEKeyID            string           `json:"sseKeyID,omitempty"`
+	Retention           *BucketRetention `json:"retention,omitempty"`
 }
 
 // BucketAccessInfo represents bucket usage of a bucket, and its relevant

--- a/user-commands.go
+++ b/user-commands.go
@@ -38,17 +38,25 @@ type AccountAccess struct {
 	Write bool `json:"write"`
 }
 
+// BucketRetentionConfig holds the default object lock retention rule for a bucket.
+type BucketRetentionConfig struct {
+	Mode  string `json:"mode"`
+	Days  uint64 `json:"days,omitempty"`
+	Years uint64 `json:"years,omitempty"`
+}
+
 // BucketDetails provides information about features currently
 // turned-on per bucket.
 type BucketDetails struct {
-	Versioning          bool         `json:"versioning"`
-	VersioningSuspended bool         `json:"versioningSuspended"`
-	Locking             bool         `json:"locking"`
-	Replication         bool         `json:"replication"`
-	Tagging             *tags.Tags   `json:"tags"`
-	Quota               *BucketQuota `json:"quota"`
-	SSEType             string       `json:"sseType,omitempty"`  // "SSE-S3", "SSE-KMS", or ""
-	SSEKeyID            string       `json:"sseKeyID,omitempty"` // KMS key ID, only set for SSE-KMS
+	Versioning          bool                   `json:"versioning"`
+	VersioningSuspended bool                   `json:"versioningSuspended"`
+	Locking             bool                   `json:"locking"`
+	Replication         bool                   `json:"replication"`
+	Tagging             *tags.Tags             `json:"tags"`
+	Quota               *BucketQuota           `json:"quota"`
+	SSEType             string                 `json:"sseType,omitempty"`
+	SSEKeyID            string                 `json:"sseKeyID,omitempty"`
+	RetentionConfig     *BucketRetentionConfig `json:"retentionConfig,omitempty"`
 }
 
 // BucketAccessInfo represents bucket usage of a bucket, and its relevant


### PR DESCRIPTION
Add `BucketRetentionConfig` struct and a `RetentionConfig` field to
`BucketDetails` so that the default object lock retention rule (mode,
days, years) is included in the `AccountInfo` response.

Previously, only the boolean `Locking` flag was exposed. Callers that
need to display or act on retention configuration had to issue a
separate S3 `GetObjectLockConfiguration` request per bucket — O(N)
requests for a list of N locked buckets.

With this change, the retention config is returned in bulk alongside
the rest of the bucket details, reducing that to a single request.

`RetentionConfig` is nil when the bucket has no default retention rule
configured (locking enabled but no rule set).