### PR TITLE
add QoSRules to BucketDetails

### DIFF
--- a/user-commands.go
+++ b/user-commands.go
@@ -57,6 +57,7 @@ type BucketDetails struct {
 	SSEType             string           `json:"sseType,omitempty"`
 	SSEKeyID            string           `json:"sseKeyID,omitempty"`
 	Retention           *BucketRetention `json:"retention,omitempty"`
+	QoSRules            int              `json:"qosRules,omitempty"`
 }
 
 // BucketAccessInfo represents bucket usage of a bucket, and its relevant


### PR DESCRIPTION
Required by https://github.com/miniohq/eos/pull/4388

  Add QoS rule count to BucketDetails for AccountInfo response.                                                                                                               
                                                                                                                                                                              
  This allows the console to display per-bucket QoS rule counts without                                                                                                       
  making separate API calls for each bucket.  