### PR TITLE
feat(replication): add BucketReplWindowedStats type alias

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -2466,6 +2466,12 @@ func (r *ReplicationReceivedStats) Empty() bool {
 	return r == nil || (r.LastMinute.Count == 0 && r.LastHour.Count == 0 && r.LastDay.Count == 0 && r.SinceStart.Count == 0)
 }
 
+// BucketReplWindowedStats holds per-ARN windowed event counts for a single
+// replication direction (failed, retried, or transferred). Bytes are
+// populated for transferred events only; failed/retry events record
+// Count only — Bytes will always be zero for those.
+type BucketReplWindowedStats = ReplicationReceivedStats
+
 // ProcessMetrics contains aggregated minio process metrics
 type ProcessMetrics struct {
 	CollectedAt time.Time `json:"collected_at,omitempty"`


### PR DESCRIPTION
## Description

Adds a `BucketReplWindowedStats` type alias for `ReplicationReceivedStats`
in `metrics.go`.

```go
// BucketReplWindowedStats holds per-ARN windowed event counts for a single
// replication direction (failed, retried, or transferred). Bytes are
// populated for transferred events only; failed/retry events record
// Count only — Bytes will always be zero for those.
type BucketReplWindowedStats = ReplicationReceivedStats
```

## Motivation and Context

The EOS console tracks per-ARN windowed stats for three distinct replication
directions: successful transfers (`tgtWindowedStats`), transient failures
(`tgtFailedWindowed`), and MRF retries (`tgtRetryStats`). All three share
the same sliding-window shape — a count + bytes pair per time bucket — which
`ReplicationReceivedStats` already provides.

Using a type alias (not a new type) means:
- Zero cost — identical wire format, identical `Add`/`Empty` methods
- No new msgp codegen required
- Call sites that track failure/retry events get a semantically accurate
  name instead of the misleading "Received" framing

## How to test this PR?

```go
import madmin "github.com/minio/madmin-go/v4"

var w madmin.BucketReplWindowedStats
_ = madmin.ReplicationReceivedStats(w) // compiles: alias, not new type
```

## Types of changes

- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My change requires a change to the documentation — no, type alias
  is self-documenting
- [x] I have added tests — n/a (type alias, no logic)