### PR TITLE
feat(scanner): add ExcessiveVersionObjects to ScannerMetrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -38,7 +38,6 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/load"
 	"github.com/tinylib/msgp/msgp"
-	"github.com/tinylib/msgp/msgp/setof"
 )
 
 //go:generate msgp -unexported -d clearomitted -d "tag json" -d "timezone utc" -d "maps binkeys" -file $GOFILE
@@ -471,13 +470,12 @@ type ScannerMetrics struct {
 
 	// ExcessivePrefixes lists prefixes marked as having excessive sub-entries
 	// within the last 24 hours.
-	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
-	ExcessivePrefixes setof.String `json:"excessive,omitempty"`
+	ExcessivePrefixes []string `json:"excessive,omitempty"`
 
 	// ExcessiveVersionObjects lists objects that have exceeded the version
 	// count or cumulative size threshold within the last 24 hours.
 	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
-	ExcessiveVersionObjects setof.String `json:"excessive_versions,omitempty"`
+	ExcessiveVersionObjects []string `json:"excessive_versions,omitempty"`
 
 	// DiscardedExcessEntries counts entries dropped beyond the 100-entry cap
 	// during cross-node merge. This counter is not deduplicated.
@@ -594,40 +592,42 @@ func (s *ScannerMetrics) Merge(other *ScannerMetrics) {
 	s.ActivePaths = append(s.ActivePaths, other.ActivePaths...)
 	sort.Strings(s.ActivePaths)
 
-	// mergeExcessSet unions two setof.String sets and caps the result at
-	// maxExcessEntries. Sorting and truncation are only performed when the
-	// combined size exceeds the cap, keeping the common path allocation-free.
-	const maxExcessEntries = 100
-	mergeExcessSet := func(dst, src setof.String) (setof.String, uint64) {
-		if len(src) == 0 {
-			return dst, 0
+	if len(other.ExcessivePrefixes) > 0 {
+		merged := make(map[string]struct{}, len(s.ExcessivePrefixes)+len(other.ExcessivePrefixes))
+		for _, prefix := range s.ExcessivePrefixes {
+			merged[prefix] = struct{}{}
 		}
-		if dst == nil {
-			dst = make(setof.String, len(src))
+		for _, prefix := range other.ExcessivePrefixes {
+			merged[prefix] = struct{}{}
 		}
-		for k := range src {
-			dst[k] = struct{}{}
+		s.ExcessivePrefixes = make([]string, 0, len(merged))
+		for prefix := range merged {
+			s.ExcessivePrefixes = append(s.ExcessivePrefixes, prefix)
 		}
-		if len(dst) <= maxExcessEntries {
-			return dst, 0
+		sort.Strings(s.ExcessivePrefixes)
+	}
+
+	if len(other.ExcessiveVersionObjects) > 0 {
+		const maxExcessEntries = 100
+		seen := make(map[string]struct{}, len(s.ExcessiveVersionObjects)+len(other.ExcessiveVersionObjects))
+		for _, v := range s.ExcessiveVersionObjects {
+			seen[v] = struct{}{}
 		}
-		keys := make([]string, 0, len(dst))
-		for k := range dst {
+		for _, v := range other.ExcessiveVersionObjects {
+			seen[v] = struct{}{}
+		}
+		keys := make([]string, 0, len(seen))
+		for k := range seen {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		result := make(setof.String, maxExcessEntries)
-		for _, k := range keys[:maxExcessEntries] {
-			result[k] = struct{}{}
+		if len(keys) > maxExcessEntries {
+			s.DiscardedExcessEntries += uint64(len(keys) - maxExcessEntries)
+			keys = keys[:maxExcessEntries]
 		}
-		return result, uint64(len(keys) - maxExcessEntries)
+		s.ExcessiveVersionObjects = keys
 	}
-
-	var disc uint64
-	s.ExcessivePrefixes, disc = mergeExcessSet(s.ExcessivePrefixes, other.ExcessivePrefixes)
-	s.DiscardedExcessEntries += disc
-	s.ExcessiveVersionObjects, disc = mergeExcessSet(s.ExcessiveVersionObjects, other.ExcessiveVersionObjects)
-	s.DiscardedExcessEntries += disc + other.DiscardedExcessEntries
+	s.DiscardedExcessEntries += other.DiscardedExcessEntries
 
 	s.ILMExpiryPendingTasks += other.ILMExpiryPendingTasks
 	s.ILMExpiryTasksServiced.Merge(other.ILMExpiryTasksServiced)

--- a/metrics.go
+++ b/metrics.go
@@ -472,12 +472,12 @@ type ScannerMetrics struct {
 	// ExcessivePrefixes lists prefixes marked as having excessive sub-entries
 	// within the last 24 hours.
 	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
-	ExcessivePrefixes []string `json:"excessive,omitempty"`
+	ExcessivePrefixes setof.String `json:"excessive,omitempty"`
 
 	// ExcessiveVersionObjects lists objects that have exceeded the version
 	// count or cumulative size threshold within the last 24 hours.
 	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
-	ExcessiveVersionObjects []string `json:"excessive_versions,omitempty"`
+	ExcessiveVersionObjects setof.String `json:"excessive_versions,omitempty"`
 
 	// DiscardedExcessEntries counts entries dropped beyond the 100-entry cap
 	// during cross-node merge. This counter is not deduplicated.
@@ -594,38 +594,39 @@ func (s *ScannerMetrics) Merge(other *ScannerMetrics) {
 	s.ActivePaths = append(s.ActivePaths, other.ActivePaths...)
 	sort.Strings(s.ActivePaths)
 
-	// mergeExcessList deduplicates two excess-entry slices using setof.String
-	// and caps the merged result at maxExcessEntries. Returns the sorted
-	// merged slice and the count of unique entries dropped due to the cap.
+	// mergeExcessSet unions two setof.String sets and caps the result at
+	// maxExcessEntries. Sorting and truncation are only performed when the
+	// combined size exceeds the cap, keeping the common path allocation-free.
 	const maxExcessEntries = 100
-	mergeExcessList := func(dst, src []string) ([]string, uint64) {
-		if len(dst)+len(src) == 0 {
-			return nil, 0
+	mergeExcessSet := func(dst, src setof.String) (setof.String, uint64) {
+		if len(src) == 0 {
+			return dst, 0
 		}
-		seen := make(setof.String, len(dst)+len(src))
-		for _, s := range dst {
-			seen[s] = struct{}{}
+		if dst == nil {
+			dst = make(setof.String, len(src))
 		}
-		for _, s := range src {
-			seen[s] = struct{}{}
+		for k := range src {
+			dst[k] = struct{}{}
 		}
-		out := make([]string, 0, min(len(seen), maxExcessEntries))
-		var discarded uint64
-		for k := range seen {
-			if len(out) < maxExcessEntries {
-				out = append(out, k)
-			} else {
-				discarded++
-			}
+		if len(dst) <= maxExcessEntries {
+			return dst, 0
 		}
-		sort.Strings(out)
-		return out, discarded
+		keys := make([]string, 0, len(dst))
+		for k := range dst {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		result := make(setof.String, maxExcessEntries)
+		for _, k := range keys[:maxExcessEntries] {
+			result[k] = struct{}{}
+		}
+		return result, uint64(len(keys) - maxExcessEntries)
 	}
 
 	var disc uint64
-	s.ExcessivePrefixes, disc = mergeExcessList(s.ExcessivePrefixes, other.ExcessivePrefixes)
+	s.ExcessivePrefixes, disc = mergeExcessSet(s.ExcessivePrefixes, other.ExcessivePrefixes)
 	s.DiscardedExcessEntries += disc
-	s.ExcessiveVersionObjects, disc = mergeExcessList(s.ExcessiveVersionObjects, other.ExcessiveVersionObjects)
+	s.ExcessiveVersionObjects, disc = mergeExcessSet(s.ExcessiveVersionObjects, other.ExcessiveVersionObjects)
 	s.DiscardedExcessEntries += disc + other.DiscardedExcessEntries
 
 	s.ILMExpiryPendingTasks += other.ILMExpiryPendingTasks

--- a/metrics.go
+++ b/metrics.go
@@ -38,6 +38,7 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/load"
 	"github.com/tinylib/msgp/msgp"
+	"github.com/tinylib/msgp/msgp/setof"
 )
 
 //go:generate msgp -unexported -d clearomitted -d "tag json" -d "timezone utc" -d "maps binkeys" -file $GOFILE
@@ -468,9 +469,19 @@ type ScannerMetrics struct {
 	// Currently active path(s) being scanned.
 	ActivePaths []string `json:"active,omitempty"`
 
-	// Excessive prefixes.
-	// Paths that have been marked as having excessive number of entries within the last 24 hours.
+	// ExcessivePrefixes lists prefixes marked as having excessive sub-entries
+	// within the last 24 hours.
+	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
 	ExcessivePrefixes []string `json:"excessive,omitempty"`
+
+	// ExcessiveVersionObjects lists objects that have exceeded the version
+	// count or cumulative size threshold within the last 24 hours.
+	// Capped at 100 entries per cross-node merge; see DiscardedExcessEntries.
+	ExcessiveVersionObjects []string `json:"excessive_versions,omitempty"`
+
+	// DiscardedExcessEntries counts entries dropped beyond the 100-entry cap
+	// during cross-node merge. This counter is not deduplicated.
+	DiscardedExcessEntries uint64 `json:"discarded_excess_entries,omitempty"`
 
 	// Number of queued ILM expiry tasks.
 	ILMExpiryPendingTasks int `json:"ilm_expiry_pending_tasks,omitempty"`
@@ -583,22 +594,39 @@ func (s *ScannerMetrics) Merge(other *ScannerMetrics) {
 	s.ActivePaths = append(s.ActivePaths, other.ActivePaths...)
 	sort.Strings(s.ActivePaths)
 
-	if len(other.ExcessivePrefixes) > 0 {
-		// Merge and remove duplicates
-		merged := make(map[string]struct{}, len(s.ExcessivePrefixes)+len(other.ExcessivePrefixes))
-		for _, prefix := range s.ExcessivePrefixes {
-			merged[prefix] = struct{}{}
+	// mergeExcessList deduplicates two excess-entry slices using setof.String
+	// and caps the merged result at maxExcessEntries. Returns the sorted
+	// merged slice and the count of unique entries dropped due to the cap.
+	const maxExcessEntries = 100
+	mergeExcessList := func(dst, src []string) ([]string, uint64) {
+		if len(dst)+len(src) == 0 {
+			return nil, 0
 		}
-		// Add other excessive prefixes
-		for _, prefix := range other.ExcessivePrefixes {
-			merged[prefix] = struct{}{}
+		seen := make(setof.String, len(dst)+len(src))
+		for _, s := range dst {
+			seen[s] = struct{}{}
 		}
-		s.ExcessivePrefixes = make([]string, 0, len(merged))
-		for prefix := range merged {
-			s.ExcessivePrefixes = append(s.ExcessivePrefixes, prefix)
+		for _, s := range src {
+			seen[s] = struct{}{}
 		}
-		sort.Strings(s.ExcessivePrefixes)
+		out := make([]string, 0, min(len(seen), maxExcessEntries))
+		var discarded uint64
+		for k := range seen {
+			if len(out) < maxExcessEntries {
+				out = append(out, k)
+			} else {
+				discarded++
+			}
+		}
+		sort.Strings(out)
+		return out, discarded
 	}
+
+	var disc uint64
+	s.ExcessivePrefixes, disc = mergeExcessList(s.ExcessivePrefixes, other.ExcessivePrefixes)
+	s.DiscardedExcessEntries += disc
+	s.ExcessiveVersionObjects, disc = mergeExcessList(s.ExcessiveVersionObjects, other.ExcessiveVersionObjects)
+	s.DiscardedExcessEntries += disc + other.DiscardedExcessEntries
 
 	s.ILMExpiryPendingTasks += other.ILMExpiryPendingTasks
 	s.ILMExpiryTasksServiced.Merge(other.ILMExpiryTasksServiced)

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/tinylib/msgp/msgp"
+	"github.com/tinylib/msgp/msgp/setof"
 )
 
 // DecodeMsg implements msgp.Decodable
@@ -30877,43 +30878,17 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x10
 		case "excessive":
-			var zb0011 uint32
-			zb0011, err = dc.ReadArrayHeader()
+			err = z.ExcessivePrefixes.DecodeMsg(dc)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessivePrefixes")
 				return
 			}
-			if cap(z.ExcessivePrefixes) >= int(zb0011) {
-				z.ExcessivePrefixes = (z.ExcessivePrefixes)[:zb0011]
-			} else {
-				z.ExcessivePrefixes = make([]string, zb0011)
-			}
-			for za0015 := range z.ExcessivePrefixes {
-				z.ExcessivePrefixes[za0015], err = dc.ReadString()
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
-					return
-				}
-			}
 			zb0001Mask |= 0x20
 		case "excessive_versions":
-			var zb0012 uint32
-			zb0012, err = dc.ReadArrayHeader()
+			err = z.ExcessiveVersionObjects.DecodeMsg(dc)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessiveVersionObjects")
 				return
-			}
-			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
-				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
-			} else {
-				z.ExcessiveVersionObjects = make([]string, zb0012)
-			}
-			for za0016 := range z.ExcessiveVersionObjects {
-				z.ExcessiveVersionObjects[za0016], err = dc.ReadString()
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
-					return
-				}
 			}
 			zb0001Mask |= 0x40
 		case "discarded_excess_entries":
@@ -30937,21 +30912,21 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0013 uint32
-			zb0013, err = dc.ReadArrayHeader()
+			var zb0011 uint32
+			zb0011, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0013) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
+			if cap(z.QueuedForExpiry) >= int(zb0011) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0011]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0011)
 			}
-			for za0017 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0017].DecodeMsg(dc)
+			for za0015 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0015].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
 					return
 				}
 			}
@@ -30982,10 +30957,10 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.ActivePaths = nil
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.ExcessivePrefixes = nil
+			z.ExcessivePrefixes = setof.String{}
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ExcessiveVersionObjects = nil
+			z.ExcessiveVersionObjects = setof.String{}
 		}
 		if (zb0001Mask & 0x80) == 0 {
 			z.DiscardedExcessEntries = 0
@@ -31025,14 +31000,6 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.ActivePaths == nil {
 		zb0001Len--
 		zb0001Mask |= 0x80
-	}
-	if z.ExcessivePrefixes == nil {
-		zb0001Len--
-		zb0001Mask |= 0x100
-	}
-	if z.ExcessiveVersionObjects == nil {
-		zb0001Len--
-		zb0001Mask |= 0x200
 	}
 	if z.DiscardedExcessEntries == 0 {
 		zb0001Len--
@@ -31270,43 +31237,25 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
-			// write "excessive"
-			err = en.Append(0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
-			if err != nil {
-				return
-			}
-			err = en.WriteArrayHeader(uint32(len(z.ExcessivePrefixes)))
-			if err != nil {
-				err = msgp.WrapError(err, "ExcessivePrefixes")
-				return
-			}
-			for za0015 := range z.ExcessivePrefixes {
-				err = en.WriteString(z.ExcessivePrefixes[za0015])
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
-					return
-				}
-			}
+		// write "excessive"
+		err = en.Append(0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
+		if err != nil {
+			return
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
-			// write "excessive_versions"
-			err = en.Append(0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteArrayHeader(uint32(len(z.ExcessiveVersionObjects)))
-			if err != nil {
-				err = msgp.WrapError(err, "ExcessiveVersionObjects")
-				return
-			}
-			for za0016 := range z.ExcessiveVersionObjects {
-				err = en.WriteString(z.ExcessiveVersionObjects[za0016])
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
-					return
-				}
-			}
+		err = z.ExcessivePrefixes.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "ExcessivePrefixes")
+			return
+		}
+		// write "excessive_versions"
+		err = en.Append(0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+		if err != nil {
+			return
+		}
+		err = z.ExcessiveVersionObjects.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "ExcessiveVersionObjects")
+			return
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// write "discarded_excess_entries"
@@ -31353,10 +31302,10 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			for za0017 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0017].EncodeMsg(en)
+			for za0015 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0015].EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
 					return
 				}
 			}
@@ -31391,14 +31340,6 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.ActivePaths == nil {
 		zb0001Len--
 		zb0001Mask |= 0x80
-	}
-	if z.ExcessivePrefixes == nil {
-		zb0001Len--
-		zb0001Mask |= 0x100
-	}
-	if z.ExcessiveVersionObjects == nil {
-		zb0001Len--
-		zb0001Mask |= 0x200
 	}
 	if z.DiscardedExcessEntries == 0 {
 		zb0001Len--
@@ -31524,21 +31465,19 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendString(o, z.ActivePaths[za0014])
 			}
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
-			// string "excessive"
-			o = append(o, 0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
-			o = msgp.AppendArrayHeader(o, uint32(len(z.ExcessivePrefixes)))
-			for za0015 := range z.ExcessivePrefixes {
-				o = msgp.AppendString(o, z.ExcessivePrefixes[za0015])
-			}
+		// string "excessive"
+		o = append(o, 0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
+		o, err = z.ExcessivePrefixes.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "ExcessivePrefixes")
+			return
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
-			// string "excessive_versions"
-			o = append(o, 0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
-			o = msgp.AppendArrayHeader(o, uint32(len(z.ExcessiveVersionObjects)))
-			for za0016 := range z.ExcessiveVersionObjects {
-				o = msgp.AppendString(o, z.ExcessiveVersionObjects[za0016])
-			}
+		// string "excessive_versions"
+		o = append(o, 0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+		o, err = z.ExcessiveVersionObjects.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "ExcessiveVersionObjects")
+			return
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// string "discarded_excess_entries"
@@ -31561,10 +31500,10 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			// string "queued_for_expiry"
 			o = append(o, 0xb1, 0x71, 0x75, 0x65, 0x75, 0x65, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.QueuedForExpiry)))
-			for za0017 := range z.QueuedForExpiry {
-				o, err = z.QueuedForExpiry[za0017].MarshalMsg(o)
+			for za0015 := range z.QueuedForExpiry {
+				o, err = z.QueuedForExpiry[za0015].MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
 					return
 				}
 			}
@@ -31847,43 +31786,17 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x10
 		case "excessive":
-			var zb0011 uint32
-			zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			bts, err = z.ExcessivePrefixes.UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessivePrefixes")
 				return
 			}
-			if cap(z.ExcessivePrefixes) >= int(zb0011) {
-				z.ExcessivePrefixes = (z.ExcessivePrefixes)[:zb0011]
-			} else {
-				z.ExcessivePrefixes = make([]string, zb0011)
-			}
-			for za0015 := range z.ExcessivePrefixes {
-				z.ExcessivePrefixes[za0015], bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
-					return
-				}
-			}
 			zb0001Mask |= 0x20
 		case "excessive_versions":
-			var zb0012 uint32
-			zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			bts, err = z.ExcessiveVersionObjects.UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessiveVersionObjects")
 				return
-			}
-			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
-				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
-			} else {
-				z.ExcessiveVersionObjects = make([]string, zb0012)
-			}
-			for za0016 := range z.ExcessiveVersionObjects {
-				z.ExcessiveVersionObjects[za0016], bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
-					return
-				}
 			}
 			zb0001Mask |= 0x40
 		case "discarded_excess_entries":
@@ -31907,21 +31820,21 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0013 uint32
-			zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0011 uint32
+			zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0013) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
+			if cap(z.QueuedForExpiry) >= int(zb0011) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0011]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0011)
 			}
-			for za0017 := range z.QueuedForExpiry {
-				bts, err = z.QueuedForExpiry[za0017].UnmarshalMsg(bts)
+			for za0015 := range z.QueuedForExpiry {
+				bts, err = z.QueuedForExpiry[za0015].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
 					return
 				}
 			}
@@ -31952,10 +31865,10 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.ActivePaths = nil
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.ExcessivePrefixes = nil
+			z.ExcessivePrefixes = setof.String{}
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ExcessiveVersionObjects = nil
+			z.ExcessiveVersionObjects = setof.String{}
 		}
 		if (zb0001Mask & 0x80) == 0 {
 			z.DiscardedExcessEntries = 0
@@ -32022,17 +31935,9 @@ func (z *ScannerMetrics) Msgsize() (s int) {
 	for za0014 := range z.ActivePaths {
 		s += msgp.StringPrefixSize + len(z.ActivePaths[za0014])
 	}
-	s += 10 + msgp.ArrayHeaderSize
-	for za0015 := range z.ExcessivePrefixes {
-		s += msgp.StringPrefixSize + len(z.ExcessivePrefixes[za0015])
-	}
-	s += 19 + msgp.ArrayHeaderSize
-	for za0016 := range z.ExcessiveVersionObjects {
-		s += msgp.StringPrefixSize + len(z.ExcessiveVersionObjects[za0016])
-	}
-	s += 25 + msgp.Uint64Size + 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
-	for za0017 := range z.QueuedForExpiry {
-		s += z.QueuedForExpiry[za0017].Msgsize()
+	s += 10 + z.ExcessivePrefixes.Msgsize() + 19 + z.ExcessiveVersionObjects.Msgsize() + 25 + msgp.Uint64Size + 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
+	for za0015 := range z.QueuedForExpiry {
+		s += z.QueuedForExpiry[za0015].Msgsize()
 	}
 	return
 }

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -30613,7 +30613,7 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 8 bits */
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -30896,13 +30896,40 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x20
+		case "excessive_versions":
+			var zb0012 uint32
+			zb0012, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ExcessiveVersionObjects")
+				return
+			}
+			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
+				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
+			} else {
+				z.ExcessiveVersionObjects = make([]string, zb0012)
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				z.ExcessiveVersionObjects[za0016], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
+			}
+			zb0001Mask |= 0x40
+		case "discarded_excess_entries":
+			z.DiscardedExcessEntries, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DiscardedExcessEntries")
+				return
+			}
+			zb0001Mask |= 0x80
 		case "ilm_expiry_pending_tasks":
 			z.ILMExpiryPendingTasks, err = dc.ReadInt()
 			if err != nil {
 				err = msgp.WrapError(err, "ILMExpiryPendingTasks")
 				return
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x100
 		case "ilm_expiry_tasks_cleanup":
 			err = z.ILMExpiryTasksServiced.DecodeMsg(dc)
 			if err != nil {
@@ -30910,25 +30937,25 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0012 uint32
-			zb0012, err = dc.ReadArrayHeader()
+			var zb0013 uint32
+			zb0013, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0012) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0012]
+			if cap(z.QueuedForExpiry) >= int(zb0013) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0012)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
 			}
-			for za0016 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0016].DecodeMsg(dc)
+			for za0017 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0017].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0016)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
-			zb0001Mask |= 0x80
+			zb0001Mask |= 0x200
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -30938,7 +30965,7 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xff {
+	if zb0001Mask != 0x3ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.PerBucketStats = nil
 		}
@@ -30958,9 +30985,15 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.ExcessivePrefixes = nil
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ILMExpiryPendingTasks = 0
+			z.ExcessiveVersionObjects = nil
 		}
 		if (zb0001Mask & 0x80) == 0 {
+			z.DiscardedExcessEntries = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.ILMExpiryPendingTasks = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
 			z.QueuedForExpiry = nil
 		}
 	}
@@ -30970,8 +31003,8 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(12)
-	var zb0001Mask uint16 /* 12 bits */
+	zb0001Len := uint32(14)
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	if z.PerBucketStats == nil {
 		zb0001Len--
@@ -30997,13 +31030,21 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.ILMExpiryPendingTasks == 0 {
+	if z.ExcessiveVersionObjects == nil {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.QueuedForExpiry == nil {
+	if z.DiscardedExcessEntries == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.ILMExpiryPendingTasks == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x800
+	}
+	if z.QueuedForExpiry == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -31249,6 +31290,37 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "excessive_versions"
+			err = en.Append(0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ExcessiveVersionObjects)))
+			if err != nil {
+				err = msgp.WrapError(err, "ExcessiveVersionObjects")
+				return
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				err = en.WriteString(z.ExcessiveVersionObjects[za0016])
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// write "discarded_excess_entries"
+			err = en.Append(0xb8, 0x64, 0x69, 0x73, 0x63, 0x61, 0x72, 0x64, 0x65, 0x64, 0x5f, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DiscardedExcessEntries)
+			if err != nil {
+				err = msgp.WrapError(err, "DiscardedExcessEntries")
+				return
+			}
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
 			// write "ilm_expiry_pending_tasks"
 			err = en.Append(0xb8, 0x69, 0x6c, 0x6d, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79, 0x5f, 0x70, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x73, 0x6b, 0x73)
 			if err != nil {
@@ -31270,7 +31342,7 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "ILMExpiryTasksServiced")
 			return
 		}
-		if (zb0001Mask & 0x800) == 0 { // if not omitted
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
 			// write "queued_for_expiry"
 			err = en.Append(0xb1, 0x71, 0x75, 0x65, 0x75, 0x65, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79)
 			if err != nil {
@@ -31281,10 +31353,10 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			for za0016 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0016].EncodeMsg(en)
+			for za0017 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0017].EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0016)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -31297,8 +31369,8 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(12)
-	var zb0001Mask uint16 /* 12 bits */
+	zb0001Len := uint32(14)
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	if z.PerBucketStats == nil {
 		zb0001Len--
@@ -31324,13 +31396,21 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.ILMExpiryPendingTasks == 0 {
+	if z.ExcessiveVersionObjects == nil {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.QueuedForExpiry == nil {
+	if z.DiscardedExcessEntries == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.ILMExpiryPendingTasks == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x800
+	}
+	if z.QueuedForExpiry == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -31453,6 +31533,19 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "excessive_versions"
+			o = append(o, 0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ExcessiveVersionObjects)))
+			for za0016 := range z.ExcessiveVersionObjects {
+				o = msgp.AppendString(o, z.ExcessiveVersionObjects[za0016])
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// string "discarded_excess_entries"
+			o = append(o, 0xb8, 0x64, 0x69, 0x73, 0x63, 0x61, 0x72, 0x64, 0x65, 0x64, 0x5f, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x5f, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.DiscardedExcessEntries)
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
 			// string "ilm_expiry_pending_tasks"
 			o = append(o, 0xb8, 0x69, 0x6c, 0x6d, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79, 0x5f, 0x70, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x61, 0x73, 0x6b, 0x73)
 			o = msgp.AppendInt(o, z.ILMExpiryPendingTasks)
@@ -31464,14 +31557,14 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			err = msgp.WrapError(err, "ILMExpiryTasksServiced")
 			return
 		}
-		if (zb0001Mask & 0x800) == 0 { // if not omitted
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
 			// string "queued_for_expiry"
 			o = append(o, 0xb1, 0x71, 0x75, 0x65, 0x75, 0x65, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.QueuedForExpiry)))
-			for za0016 := range z.QueuedForExpiry {
-				o, err = z.QueuedForExpiry[za0016].MarshalMsg(o)
+			for za0017 := range z.QueuedForExpiry {
+				o, err = z.QueuedForExpiry[za0017].MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0016)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -31490,7 +31583,7 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 8 bits */
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -31773,13 +31866,40 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x20
+		case "excessive_versions":
+			var zb0012 uint32
+			zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ExcessiveVersionObjects")
+				return
+			}
+			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
+				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
+			} else {
+				z.ExcessiveVersionObjects = make([]string, zb0012)
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				z.ExcessiveVersionObjects[za0016], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
+			}
+			zb0001Mask |= 0x40
+		case "discarded_excess_entries":
+			z.DiscardedExcessEntries, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DiscardedExcessEntries")
+				return
+			}
+			zb0001Mask |= 0x80
 		case "ilm_expiry_pending_tasks":
 			z.ILMExpiryPendingTasks, bts, err = msgp.ReadIntBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ILMExpiryPendingTasks")
 				return
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x100
 		case "ilm_expiry_tasks_cleanup":
 			bts, err = z.ILMExpiryTasksServiced.UnmarshalMsg(bts)
 			if err != nil {
@@ -31787,25 +31907,25 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0012 uint32
-			zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 uint32
+			zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0012) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0012]
+			if cap(z.QueuedForExpiry) >= int(zb0013) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0012)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
 			}
-			for za0016 := range z.QueuedForExpiry {
-				bts, err = z.QueuedForExpiry[za0016].UnmarshalMsg(bts)
+			for za0017 := range z.QueuedForExpiry {
+				bts, err = z.QueuedForExpiry[za0017].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0016)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
-			zb0001Mask |= 0x80
+			zb0001Mask |= 0x200
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -31815,7 +31935,7 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xff {
+	if zb0001Mask != 0x3ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.PerBucketStats = nil
 		}
@@ -31835,9 +31955,15 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.ExcessivePrefixes = nil
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ILMExpiryPendingTasks = 0
+			z.ExcessiveVersionObjects = nil
 		}
 		if (zb0001Mask & 0x80) == 0 {
+			z.DiscardedExcessEntries = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.ILMExpiryPendingTasks = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
 			z.QueuedForExpiry = nil
 		}
 	}
@@ -31900,9 +32026,13 @@ func (z *ScannerMetrics) Msgsize() (s int) {
 	for za0015 := range z.ExcessivePrefixes {
 		s += msgp.StringPrefixSize + len(z.ExcessivePrefixes[za0015])
 	}
-	s += 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
-	for za0016 := range z.QueuedForExpiry {
-		s += z.QueuedForExpiry[za0016].Msgsize()
+	s += 19 + msgp.ArrayHeaderSize
+	for za0016 := range z.ExcessiveVersionObjects {
+		s += msgp.StringPrefixSize + len(z.ExcessiveVersionObjects[za0016])
+	}
+	s += 25 + msgp.Uint64Size + 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
+	for za0017 := range z.QueuedForExpiry {
+		s += z.QueuedForExpiry[za0017].Msgsize()
 	}
 	return
 }

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/tinylib/msgp/msgp"
-	"github.com/tinylib/msgp/msgp/setof"
 )
 
 // DecodeMsg implements msgp.Decodable
@@ -30878,17 +30877,43 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x10
 		case "excessive":
-			err = z.ExcessivePrefixes.DecodeMsg(dc)
+			var zb0011 uint32
+			zb0011, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessivePrefixes")
 				return
 			}
+			if cap(z.ExcessivePrefixes) >= int(zb0011) {
+				z.ExcessivePrefixes = (z.ExcessivePrefixes)[:zb0011]
+			} else {
+				z.ExcessivePrefixes = make([]string, zb0011)
+			}
+			for za0015 := range z.ExcessivePrefixes {
+				z.ExcessivePrefixes[za0015], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
+					return
+				}
+			}
 			zb0001Mask |= 0x20
 		case "excessive_versions":
-			err = z.ExcessiveVersionObjects.DecodeMsg(dc)
+			var zb0012 uint32
+			zb0012, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessiveVersionObjects")
 				return
+			}
+			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
+				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
+			} else {
+				z.ExcessiveVersionObjects = make([]string, zb0012)
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				z.ExcessiveVersionObjects[za0016], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
 			}
 			zb0001Mask |= 0x40
 		case "discarded_excess_entries":
@@ -30912,21 +30937,21 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0011 uint32
-			zb0011, err = dc.ReadArrayHeader()
+			var zb0013 uint32
+			zb0013, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0011) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0011]
+			if cap(z.QueuedForExpiry) >= int(zb0013) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0011)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
 			}
-			for za0015 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0015].DecodeMsg(dc)
+			for za0017 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0017].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -30957,10 +30982,10 @@ func (z *ScannerMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.ActivePaths = nil
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.ExcessivePrefixes = setof.String{}
+			z.ExcessivePrefixes = nil
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ExcessiveVersionObjects = setof.String{}
+			z.ExcessiveVersionObjects = nil
 		}
 		if (zb0001Mask & 0x80) == 0 {
 			z.DiscardedExcessEntries = 0
@@ -31000,6 +31025,14 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.ActivePaths == nil {
 		zb0001Len--
 		zb0001Mask |= 0x80
+	}
+	if z.ExcessivePrefixes == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.ExcessiveVersionObjects == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	if z.DiscardedExcessEntries == 0 {
 		zb0001Len--
@@ -31237,25 +31270,43 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		// write "excessive"
-		err = en.Append(0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
-		if err != nil {
-			return
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "excessive"
+			err = en.Append(0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ExcessivePrefixes)))
+			if err != nil {
+				err = msgp.WrapError(err, "ExcessivePrefixes")
+				return
+			}
+			for za0015 := range z.ExcessivePrefixes {
+				err = en.WriteString(z.ExcessivePrefixes[za0015])
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
+					return
+				}
+			}
 		}
-		err = z.ExcessivePrefixes.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "ExcessivePrefixes")
-			return
-		}
-		// write "excessive_versions"
-		err = en.Append(0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
-		if err != nil {
-			return
-		}
-		err = z.ExcessiveVersionObjects.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "ExcessiveVersionObjects")
-			return
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "excessive_versions"
+			err = en.Append(0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ExcessiveVersionObjects)))
+			if err != nil {
+				err = msgp.WrapError(err, "ExcessiveVersionObjects")
+				return
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				err = en.WriteString(z.ExcessiveVersionObjects[za0016])
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
+			}
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// write "discarded_excess_entries"
@@ -31302,10 +31353,10 @@ func (z *ScannerMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			for za0015 := range z.QueuedForExpiry {
-				err = z.QueuedForExpiry[za0015].EncodeMsg(en)
+			for za0017 := range z.QueuedForExpiry {
+				err = z.QueuedForExpiry[za0017].EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -31340,6 +31391,14 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.ActivePaths == nil {
 		zb0001Len--
 		zb0001Mask |= 0x80
+	}
+	if z.ExcessivePrefixes == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.ExcessiveVersionObjects == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	if z.DiscardedExcessEntries == 0 {
 		zb0001Len--
@@ -31465,19 +31524,21 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendString(o, z.ActivePaths[za0014])
 			}
 		}
-		// string "excessive"
-		o = append(o, 0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
-		o, err = z.ExcessivePrefixes.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "ExcessivePrefixes")
-			return
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "excessive"
+			o = append(o, 0xa9, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ExcessivePrefixes)))
+			for za0015 := range z.ExcessivePrefixes {
+				o = msgp.AppendString(o, z.ExcessivePrefixes[za0015])
+			}
 		}
-		// string "excessive_versions"
-		o = append(o, 0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
-		o, err = z.ExcessiveVersionObjects.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "ExcessiveVersionObjects")
-			return
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "excessive_versions"
+			o = append(o, 0xb2, 0x65, 0x78, 0x63, 0x65, 0x73, 0x73, 0x69, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ExcessiveVersionObjects)))
+			for za0016 := range z.ExcessiveVersionObjects {
+				o = msgp.AppendString(o, z.ExcessiveVersionObjects[za0016])
+			}
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// string "discarded_excess_entries"
@@ -31500,10 +31561,10 @@ func (z *ScannerMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			// string "queued_for_expiry"
 			o = append(o, 0xb1, 0x71, 0x75, 0x65, 0x75, 0x65, 0x64, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x65, 0x78, 0x70, 0x69, 0x72, 0x79)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.QueuedForExpiry)))
-			for za0015 := range z.QueuedForExpiry {
-				o, err = z.QueuedForExpiry[za0015].MarshalMsg(o)
+			for za0017 := range z.QueuedForExpiry {
+				o, err = z.QueuedForExpiry[za0017].MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -31786,17 +31847,43 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x10
 		case "excessive":
-			bts, err = z.ExcessivePrefixes.UnmarshalMsg(bts)
+			var zb0011 uint32
+			zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessivePrefixes")
 				return
 			}
+			if cap(z.ExcessivePrefixes) >= int(zb0011) {
+				z.ExcessivePrefixes = (z.ExcessivePrefixes)[:zb0011]
+			} else {
+				z.ExcessivePrefixes = make([]string, zb0011)
+			}
+			for za0015 := range z.ExcessivePrefixes {
+				z.ExcessivePrefixes[za0015], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessivePrefixes", za0015)
+					return
+				}
+			}
 			zb0001Mask |= 0x20
 		case "excessive_versions":
-			bts, err = z.ExcessiveVersionObjects.UnmarshalMsg(bts)
+			var zb0012 uint32
+			zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ExcessiveVersionObjects")
 				return
+			}
+			if cap(z.ExcessiveVersionObjects) >= int(zb0012) {
+				z.ExcessiveVersionObjects = (z.ExcessiveVersionObjects)[:zb0012]
+			} else {
+				z.ExcessiveVersionObjects = make([]string, zb0012)
+			}
+			for za0016 := range z.ExcessiveVersionObjects {
+				z.ExcessiveVersionObjects[za0016], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ExcessiveVersionObjects", za0016)
+					return
+				}
 			}
 			zb0001Mask |= 0x40
 		case "discarded_excess_entries":
@@ -31820,21 +31907,21 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "queued_for_expiry":
-			var zb0011 uint32
-			zb0011, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0013 uint32
+			zb0013, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "QueuedForExpiry")
 				return
 			}
-			if cap(z.QueuedForExpiry) >= int(zb0011) {
-				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0011]
+			if cap(z.QueuedForExpiry) >= int(zb0013) {
+				z.QueuedForExpiry = (z.QueuedForExpiry)[:zb0013]
 			} else {
-				z.QueuedForExpiry = make([]ExpiryObject, zb0011)
+				z.QueuedForExpiry = make([]ExpiryObject, zb0013)
 			}
-			for za0015 := range z.QueuedForExpiry {
-				bts, err = z.QueuedForExpiry[za0015].UnmarshalMsg(bts)
+			for za0017 := range z.QueuedForExpiry {
+				bts, err = z.QueuedForExpiry[za0017].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "QueuedForExpiry", za0015)
+					err = msgp.WrapError(err, "QueuedForExpiry", za0017)
 					return
 				}
 			}
@@ -31865,10 +31952,10 @@ func (z *ScannerMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.ActivePaths = nil
 		}
 		if (zb0001Mask & 0x20) == 0 {
-			z.ExcessivePrefixes = setof.String{}
+			z.ExcessivePrefixes = nil
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.ExcessiveVersionObjects = setof.String{}
+			z.ExcessiveVersionObjects = nil
 		}
 		if (zb0001Mask & 0x80) == 0 {
 			z.DiscardedExcessEntries = 0
@@ -31935,9 +32022,17 @@ func (z *ScannerMetrics) Msgsize() (s int) {
 	for za0014 := range z.ActivePaths {
 		s += msgp.StringPrefixSize + len(z.ActivePaths[za0014])
 	}
-	s += 10 + z.ExcessivePrefixes.Msgsize() + 19 + z.ExcessiveVersionObjects.Msgsize() + 25 + msgp.Uint64Size + 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
-	for za0015 := range z.QueuedForExpiry {
-		s += z.QueuedForExpiry[za0015].Msgsize()
+	s += 10 + msgp.ArrayHeaderSize
+	for za0015 := range z.ExcessivePrefixes {
+		s += msgp.StringPrefixSize + len(z.ExcessivePrefixes[za0015])
+	}
+	s += 19 + msgp.ArrayHeaderSize
+	for za0016 := range z.ExcessiveVersionObjects {
+		s += msgp.StringPrefixSize + len(z.ExcessiveVersionObjects[za0016])
+	}
+	s += 25 + msgp.Uint64Size + 25 + msgp.IntSize + 25 + z.ILMExpiryTasksServiced.Msgsize() + 18 + msgp.ArrayHeaderSize
+	for za0017 := range z.QueuedForExpiry {
+		s += z.QueuedForExpiry[za0017].Msgsize()
 	}
 	return
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/load"
+	"github.com/tinylib/msgp/msgp/setof"
 )
 
 // TestScannerMetricsMerge tests ScannerMetrics.Merge functionality
@@ -94,18 +95,13 @@ func TestScannerMetricsMerge(t *testing.T) {
 		{
 			name: "merge excessive prefixes",
 			base: &ScannerMetrics{
-				ExcessivePrefixes: []string{"prefix1", "prefix2"},
+				ExcessivePrefixes: setof.String{"prefix1": {}, "prefix2": {}},
 			},
 			other: &ScannerMetrics{
-				ExcessivePrefixes: []string{"prefix2", "prefix3"},
+				ExcessivePrefixes: setof.String{"prefix2": {}, "prefix3": {}},
 			},
 			verify: func(t *testing.T, result *ScannerMetrics) {
-				// Should be deduplicated and sorted
-				if len(result.ExcessivePrefixes) != 3 {
-					t.Errorf("ExcessivePrefixes length = %d, want 3", len(result.ExcessivePrefixes))
-				}
-				// Check sorted order
-				expected := []string{"prefix1", "prefix2", "prefix3"}
+				expected := setof.String{"prefix1": {}, "prefix2": {}, "prefix3": {}}
 				if !reflect.DeepEqual(result.ExcessivePrefixes, expected) {
 					t.Errorf("ExcessivePrefixes = %v, want %v", result.ExcessivePrefixes, expected)
 				}
@@ -114,16 +110,13 @@ func TestScannerMetricsMerge(t *testing.T) {
 		{
 			name: "merge excessive version objects",
 			base: &ScannerMetrics{
-				ExcessiveVersionObjects: []string{"bucket1/obj1", "bucket1/obj2"},
+				ExcessiveVersionObjects: setof.String{"bucket1/obj1": {}, "bucket1/obj2": {}},
 			},
 			other: &ScannerMetrics{
-				ExcessiveVersionObjects: []string{"bucket1/obj2", "bucket2/obj1"},
+				ExcessiveVersionObjects: setof.String{"bucket1/obj2": {}, "bucket2/obj1": {}},
 			},
 			verify: func(t *testing.T, result *ScannerMetrics) {
-				expected := []string{"bucket1/obj1", "bucket1/obj2", "bucket2/obj1"}
-				if len(result.ExcessiveVersionObjects) != 3 {
-					t.Errorf("ExcessiveVersionObjects length = %d, want 3", len(result.ExcessiveVersionObjects))
-				}
+				expected := setof.String{"bucket1/obj1": {}, "bucket1/obj2": {}, "bucket2/obj1": {}}
 				if !reflect.DeepEqual(result.ExcessiveVersionObjects, expected) {
 					t.Errorf("ExcessiveVersionObjects = %v, want %v", result.ExcessiveVersionObjects, expected)
 				}
@@ -135,16 +128,16 @@ func TestScannerMetricsMerge(t *testing.T) {
 		{
 			name: "merge excess cap at 100 entries",
 			base: func() *ScannerMetrics {
-				paths := make([]string, 80)
-				for i := range paths {
-					paths[i] = fmt.Sprintf("prefix%03d", i)
+				paths := make(setof.String, 80)
+				for i := range 80 {
+					paths[fmt.Sprintf("prefix%03d", i)] = struct{}{}
 				}
 				return &ScannerMetrics{ExcessivePrefixes: paths}
 			}(),
 			other: func() *ScannerMetrics {
-				paths := make([]string, 60)
-				for i := range paths {
-					paths[i] = fmt.Sprintf("prefix%03d", i+50) // 50–109, overlap at 50–79
+				paths := make(setof.String, 60)
+				for i := range 60 {
+					paths[fmt.Sprintf("prefix%03d", i+50)] = struct{}{} // 50–109, overlap at 50–79
 				}
 				return &ScannerMetrics{ExcessivePrefixes: paths}
 			}(),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -20,6 +20,7 @@
 package madmin
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -107,6 +108,67 @@ func TestScannerMetricsMerge(t *testing.T) {
 				expected := []string{"prefix1", "prefix2", "prefix3"}
 				if !reflect.DeepEqual(result.ExcessivePrefixes, expected) {
 					t.Errorf("ExcessivePrefixes = %v, want %v", result.ExcessivePrefixes, expected)
+				}
+			},
+		},
+		{
+			name: "merge excessive version objects",
+			base: &ScannerMetrics{
+				ExcessiveVersionObjects: []string{"bucket1/obj1", "bucket1/obj2"},
+			},
+			other: &ScannerMetrics{
+				ExcessiveVersionObjects: []string{"bucket1/obj2", "bucket2/obj1"},
+			},
+			verify: func(t *testing.T, result *ScannerMetrics) {
+				expected := []string{"bucket1/obj1", "bucket1/obj2", "bucket2/obj1"}
+				if len(result.ExcessiveVersionObjects) != 3 {
+					t.Errorf("ExcessiveVersionObjects length = %d, want 3", len(result.ExcessiveVersionObjects))
+				}
+				if !reflect.DeepEqual(result.ExcessiveVersionObjects, expected) {
+					t.Errorf("ExcessiveVersionObjects = %v, want %v", result.ExcessiveVersionObjects, expected)
+				}
+				if result.DiscardedExcessEntries != 0 {
+					t.Errorf("DiscardedExcessEntries = %d, want 0", result.DiscardedExcessEntries)
+				}
+			},
+		},
+		{
+			name: "merge excess cap at 100 entries",
+			base: func() *ScannerMetrics {
+				paths := make([]string, 80)
+				for i := range paths {
+					paths[i] = fmt.Sprintf("prefix%03d", i)
+				}
+				return &ScannerMetrics{ExcessivePrefixes: paths}
+			}(),
+			other: func() *ScannerMetrics {
+				paths := make([]string, 60)
+				for i := range paths {
+					paths[i] = fmt.Sprintf("prefix%03d", i+50) // 50–109, overlap at 50–79
+				}
+				return &ScannerMetrics{ExcessivePrefixes: paths}
+			}(),
+			verify: func(t *testing.T, result *ScannerMetrics) {
+				// 0–109 unique = 110 total; cap is 100, so 10 discarded
+				if len(result.ExcessivePrefixes) != 100 {
+					t.Errorf("ExcessivePrefixes length = %d, want 100", len(result.ExcessivePrefixes))
+				}
+				if result.DiscardedExcessEntries != 10 {
+					t.Errorf("DiscardedExcessEntries = %d, want 10", result.DiscardedExcessEntries)
+				}
+			},
+		},
+		{
+			name: "discarded excess entries accumulate across merges",
+			base: &ScannerMetrics{
+				DiscardedExcessEntries: 5,
+			},
+			other: &ScannerMetrics{
+				DiscardedExcessEntries: 3,
+			},
+			verify: func(t *testing.T, result *ScannerMetrics) {
+				if result.DiscardedExcessEntries != 8 {
+					t.Errorf("DiscardedExcessEntries = %d, want 8", result.DiscardedExcessEntries)
 				}
 			},
 		},

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/load"
-	"github.com/tinylib/msgp/msgp/setof"
 )
 
 // TestScannerMetricsMerge tests ScannerMetrics.Merge functionality
@@ -95,13 +94,13 @@ func TestScannerMetricsMerge(t *testing.T) {
 		{
 			name: "merge excessive prefixes",
 			base: &ScannerMetrics{
-				ExcessivePrefixes: setof.String{"prefix1": {}, "prefix2": {}},
+				ExcessivePrefixes: []string{"prefix1", "prefix2"},
 			},
 			other: &ScannerMetrics{
-				ExcessivePrefixes: setof.String{"prefix2": {}, "prefix3": {}},
+				ExcessivePrefixes: []string{"prefix2", "prefix3"},
 			},
 			verify: func(t *testing.T, result *ScannerMetrics) {
-				expected := setof.String{"prefix1": {}, "prefix2": {}, "prefix3": {}}
+				expected := []string{"prefix1", "prefix2", "prefix3"}
 				if !reflect.DeepEqual(result.ExcessivePrefixes, expected) {
 					t.Errorf("ExcessivePrefixes = %v, want %v", result.ExcessivePrefixes, expected)
 				}
@@ -110,13 +109,13 @@ func TestScannerMetricsMerge(t *testing.T) {
 		{
 			name: "merge excessive version objects",
 			base: &ScannerMetrics{
-				ExcessiveVersionObjects: setof.String{"bucket1/obj1": {}, "bucket1/obj2": {}},
+				ExcessiveVersionObjects: []string{"bucket1/obj1", "bucket1/obj2"},
 			},
 			other: &ScannerMetrics{
-				ExcessiveVersionObjects: setof.String{"bucket1/obj2": {}, "bucket2/obj1": {}},
+				ExcessiveVersionObjects: []string{"bucket1/obj2", "bucket2/obj1"},
 			},
 			verify: func(t *testing.T, result *ScannerMetrics) {
-				expected := setof.String{"bucket1/obj1": {}, "bucket1/obj2": {}, "bucket2/obj1": {}}
+				expected := []string{"bucket1/obj1", "bucket1/obj2", "bucket2/obj1"}
 				if !reflect.DeepEqual(result.ExcessiveVersionObjects, expected) {
 					t.Errorf("ExcessiveVersionObjects = %v, want %v", result.ExcessiveVersionObjects, expected)
 				}
@@ -126,25 +125,25 @@ func TestScannerMetricsMerge(t *testing.T) {
 			},
 		},
 		{
-			name: "merge excess cap at 100 entries",
+			name: "merge excess version objects cap at 100 entries",
 			base: func() *ScannerMetrics {
-				paths := make(setof.String, 80)
+				paths := make([]string, 80)
 				for i := range 80 {
-					paths[fmt.Sprintf("prefix%03d", i)] = struct{}{}
+					paths[i] = fmt.Sprintf("prefix%03d", i)
 				}
-				return &ScannerMetrics{ExcessivePrefixes: paths}
+				return &ScannerMetrics{ExcessiveVersionObjects: paths}
 			}(),
 			other: func() *ScannerMetrics {
-				paths := make(setof.String, 60)
+				paths := make([]string, 60)
 				for i := range 60 {
-					paths[fmt.Sprintf("prefix%03d", i+50)] = struct{}{} // 50–109, overlap at 50–79
+					paths[i] = fmt.Sprintf("prefix%03d", i+50) // 50–109, overlap at 50–79
 				}
-				return &ScannerMetrics{ExcessivePrefixes: paths}
+				return &ScannerMetrics{ExcessiveVersionObjects: paths}
 			}(),
 			verify: func(t *testing.T, result *ScannerMetrics) {
 				// 0–109 unique = 110 total; cap is 100, so 10 discarded
-				if len(result.ExcessivePrefixes) != 100 {
-					t.Errorf("ExcessivePrefixes length = %d, want 100", len(result.ExcessivePrefixes))
+				if len(result.ExcessiveVersionObjects) != 100 {
+					t.Errorf("ExcessiveVersionObjects length = %d, want 100", len(result.ExcessiveVersionObjects))
 				}
 				if result.DiscardedExcessEntries != 10 {
 					t.Errorf("DiscardedExcessEntries = %d, want 10", result.DiscardedExcessEntries)

--- a/mnav/scanner.go
+++ b/mnav/scanner.go
@@ -19,8 +19,6 @@ package mnav
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -200,7 +198,7 @@ func (node *ScannerMetricsNode) GetChild(name string) (MetricNode, error) {
 	case "active_paths":
 		return NewScannerPathsNode(node.scanner.ActivePaths, "active", node, fmt.Sprintf("%s/active_paths", node.path)), nil
 	case "excessive_paths":
-		return NewScannerPathsNode(slices.Sorted(maps.Keys(node.scanner.ExcessivePrefixes)), "excessive", node, fmt.Sprintf("%s/excessive_paths", node.path)), nil
+		return NewScannerPathsNode(node.scanner.ExcessivePrefixes, "excessive", node, fmt.Sprintf("%s/excessive_paths", node.path)), nil
 	default:
 		return nil, fmt.Errorf("child not found: %s", name)
 	}

--- a/mnav/scanner.go
+++ b/mnav/scanner.go
@@ -19,6 +19,8 @@ package mnav
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -198,7 +200,7 @@ func (node *ScannerMetricsNode) GetChild(name string) (MetricNode, error) {
 	case "active_paths":
 		return NewScannerPathsNode(node.scanner.ActivePaths, "active", node, fmt.Sprintf("%s/active_paths", node.path)), nil
 	case "excessive_paths":
-		return NewScannerPathsNode(node.scanner.ExcessivePrefixes, "excessive", node, fmt.Sprintf("%s/excessive_paths", node.path)), nil
+		return NewScannerPathsNode(slices.Sorted(maps.Keys(node.scanner.ExcessivePrefixes)), "excessive", node, fmt.Sprintf("%s/excessive_paths", node.path)), nil
 	default:
 		return nil, fmt.Errorf("child not found: %s", name)
 	}


### PR DESCRIPTION
## Description

`ScannerMetrics` already exposes `ExcessivePrefixes` (folders with too
many sub-entries) via the realtime metrics API, which collects per-node
reports and merges them cluster-wide. This PR does the same for the
version-excess side: add `ExcessiveVersionObjects []string` so objects
exceeding the version count or cumulative size threshold are visible in
`mc admin top scanner` and Prometheus scrapes across all nodes.

A `DiscardedExcessEntries uint64` counter tracks entries dropped when
the merged list is capped at 100 entries, letting operators know the
list is incomplete without polluting the payload.

## Changes

- **`ScannerMetrics`**: two new fields
  - `ExcessiveVersionObjects []string` (`json:"excessive_versions"`)
  - `DiscardedExcessEntries uint64` (`json:"discarded_excess_entries"`)
- **`ScannerMetrics.Merge()`**: replaces the unbounded
  `ExcessivePrefixes` dedup map with a `setof.String`-based helper
  that caps both excess slices at 100 entries and accumulates
  `DiscardedExcessEntries`
- **`metrics_gen.go`**: regenerated

## Testing

New test cases in `TestScannerMetricsMerge`:
- `ExcessiveVersionObjects` dedup and sort
- 100-entry cap with correct `DiscardedExcessEntries` count (110
  unique → 100 kept, 10 discarded)
- Accumulated `DiscardedExcessEntries` across successive merges