### PR TITLE
feat: Add power draw to realtime metrics

### DIFF
--- a/cpu_metrics_test.go
+++ b/cpu_metrics_test.go
@@ -523,6 +523,197 @@ func TestAddCPUsNil(t *testing.T) {
 	// Should not panic
 }
 
+func TestPowerSegmentAdd(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     PowerSegment
+		other    *PowerSegment
+		expected PowerSegment
+	}{
+		{
+			name:     "add nil",
+			base:     PowerSegment{SumWatts: 100, MinWatts: 90, MaxWatts: 110, N: 1},
+			other:    nil,
+			expected: PowerSegment{SumWatts: 100, MinWatts: 90, MaxWatts: 110, N: 1},
+		},
+		{
+			name:     "add zero N",
+			base:     PowerSegment{SumWatts: 100, MinWatts: 90, MaxWatts: 110, N: 1},
+			other:    &PowerSegment{SumWatts: 50, N: 0},
+			expected: PowerSegment{SumWatts: 100, MinWatts: 90, MaxWatts: 110, N: 1},
+		},
+		{
+			name:     "add into empty",
+			base:     PowerSegment{},
+			other:    &PowerSegment{SumWatts: 500, MinWatts: 480, MaxWatts: 520, N: 1},
+			expected: PowerSegment{SumWatts: 500, MinWatts: 480, MaxWatts: 520, N: 1},
+		},
+		{
+			name:     "merge two nodes",
+			base:     PowerSegment{SumWatts: 500, MinWatts: 480, MaxWatts: 520, N: 1},
+			other:    &PowerSegment{SumWatts: 300, MinWatts: 290, MaxWatts: 310, N: 1},
+			expected: PowerSegment{SumWatts: 800, MinWatts: 290, MaxWatts: 520, N: 2},
+		},
+		{
+			name:     "min takes lower",
+			base:     PowerSegment{SumWatts: 100, MinWatts: 50, MaxWatts: 200, N: 2},
+			other:    &PowerSegment{SumWatts: 80, MinWatts: 70, MaxWatts: 90, N: 1},
+			expected: PowerSegment{SumWatts: 180, MinWatts: 50, MaxWatts: 200, N: 3},
+		},
+		{
+			name:     "max takes higher",
+			base:     PowerSegment{SumWatts: 100, MinWatts: 50, MaxWatts: 200, N: 2},
+			other:    &PowerSegment{SumWatts: 80, MinWatts: 60, MaxWatts: 300, N: 1},
+			expected: PowerSegment{SumWatts: 180, MinWatts: 50, MaxWatts: 300, N: 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := tt.base
+			p.Add(tt.other)
+			if p != tt.expected {
+				t.Errorf("got %+v, want %+v", p, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCPUMetricsMergePower(t *testing.T) {
+	tests := []struct {
+		name     string
+		m        CPUMetrics
+		other    CPUMetrics
+		expected CPUMetrics
+	}{
+		{
+			name: "merge into empty",
+			m:    CPUMetrics{},
+			other: CPUMetrics{
+				PowerNodes:        1,
+				TotalWatts:        500,
+				MinNodeWatts:      500,
+				MaxNodeWatts:      500,
+				PowerSourceCounts: map[string]int{"dcmi": 1},
+			},
+			expected: CPUMetrics{
+				PowerNodes:        1,
+				TotalWatts:        500,
+				MinNodeWatts:      500,
+				MaxNodeWatts:      500,
+				PowerSourceCounts: map[string]int{"dcmi": 1},
+			},
+		},
+		{
+			name: "merge two nodes",
+			m: CPUMetrics{
+				PowerNodes:        1,
+				TotalWatts:        500,
+				MinNodeWatts:      500,
+				MaxNodeWatts:      500,
+				PowerSourceCounts: map[string]int{"dcmi": 1},
+			},
+			other: CPUMetrics{
+				PowerNodes:        1,
+				TotalWatts:        300,
+				MinNodeWatts:      300,
+				MaxNodeWatts:      300,
+				PowerSourceCounts: map[string]int{"sdr": 1},
+			},
+			expected: CPUMetrics{
+				PowerNodes:        2,
+				TotalWatts:        800,
+				MinNodeWatts:      300,
+				MaxNodeWatts:      500,
+				PowerSourceCounts: map[string]int{"dcmi": 1, "sdr": 1},
+			},
+		},
+		{
+			name: "other has no power",
+			m: CPUMetrics{
+				PowerNodes:   1,
+				TotalWatts:   500,
+				MinNodeWatts: 500,
+				MaxNodeWatts: 500,
+			},
+			other: CPUMetrics{},
+			expected: CPUMetrics{
+				PowerNodes:   1,
+				TotalWatts:   500,
+				MinNodeWatts: 500,
+				MaxNodeWatts: 500,
+			},
+		},
+		{
+			name: "min/max across three nodes",
+			m: CPUMetrics{
+				PowerNodes:   2,
+				TotalWatts:   900,
+				MinNodeWatts: 400,
+				MaxNodeWatts: 500,
+			},
+			other: CPUMetrics{
+				PowerNodes:   1,
+				TotalWatts:   350,
+				MinNodeWatts: 350,
+				MaxNodeWatts: 350,
+			},
+			expected: CPUMetrics{
+				PowerNodes:   3,
+				TotalWatts:   1250,
+				MinNodeWatts: 350,
+				MaxNodeWatts: 500,
+			},
+		},
+		{
+			name: "min stays when other is higher",
+			m: CPUMetrics{
+				PowerNodes:   1,
+				TotalWatts:   200,
+				MinNodeWatts: 200,
+				MaxNodeWatts: 200,
+			},
+			other: CPUMetrics{
+				PowerNodes:   1,
+				TotalWatts:   600,
+				MinNodeWatts: 600,
+				MaxNodeWatts: 600,
+			},
+			expected: CPUMetrics{
+				PowerNodes:   2,
+				TotalWatts:   800,
+				MinNodeWatts: 200,
+				MaxNodeWatts: 600,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.m
+			m.Merge(&tt.other)
+			if m.PowerNodes != tt.expected.PowerNodes {
+				t.Errorf("PowerNodes: got %d, want %d", m.PowerNodes, tt.expected.PowerNodes)
+			}
+			if m.TotalWatts != tt.expected.TotalWatts {
+				t.Errorf("TotalWatts: got %f, want %f", m.TotalWatts, tt.expected.TotalWatts)
+			}
+			if m.MinNodeWatts != tt.expected.MinNodeWatts {
+				t.Errorf("MinNodeWatts: got %f, want %f", m.MinNodeWatts, tt.expected.MinNodeWatts)
+			}
+			if m.MaxNodeWatts != tt.expected.MaxNodeWatts {
+				t.Errorf("MaxNodeWatts: got %f, want %f", m.MaxNodeWatts, tt.expected.MaxNodeWatts)
+			}
+			for src, count := range tt.expected.PowerSourceCounts {
+				if m.PowerSourceCounts[src] != count {
+					t.Errorf("PowerSourceCounts[%s]: got %d, want %d", src, m.PowerSourceCounts[src], count)
+				}
+			}
+			if len(m.PowerSourceCounts) != len(tt.expected.PowerSourceCounts) {
+				t.Errorf("PowerSourceCounts length: got %d, want %d", len(m.PowerSourceCounts), len(tt.expected.PowerSourceCounts))
+			}
+		})
+	}
+}
+
 // Helper function to create a pointer to uint64
 func uint64Ptr(v uint64) *uint64 {
 	return &v

--- a/metrics.go
+++ b/metrics.go
@@ -147,6 +147,8 @@ func (m MetricFlags) String() string {
 	addIf(m.Contains(MetricsByDisk), "ByDisk")
 	addIf(m.Contains(MetricsLegacyDiskIO), "LegacyIO")
 	addIf(m.Contains(MetricsByDiskSet), "ByDiskSet")
+	addIf(m.Contains(MetricsSMART), "SMART")
+	addIf(m.Contains(MetricsHourStats), "HourStats")
 	return b.String()
 }
 
@@ -1445,6 +1447,32 @@ func (c *CPUSegment) Add(other *CPUSegment) {
 // SegmentedCPUMetrics are time-segmented CPU metrics.
 type SegmentedCPUMetrics = Segmented[CPUSegment, *CPUSegment]
 
+// PowerSegment stores power draw for a single time segment.
+// Each node normalizes to a single sample (N=1) before reporting,
+// so N equals the number of contributing nodes after merge.
+type PowerSegment struct {
+	SumWatts float64 `json:"sumWatts,omitempty"`
+	MinWatts float64 `json:"minWatts,omitempty"`
+	MaxWatts float64 `json:"maxWatts,omitempty"`
+	N        int     `json:"n"`
+}
+
+// Add other to p for Segmenter interface.
+func (p *PowerSegment) Add(other *PowerSegment) {
+	if other == nil || other.N == 0 {
+		return
+	}
+	p.SumWatts += other.SumWatts
+	if p.N == 0 || other.MinWatts < p.MinWatts {
+		p.MinWatts = other.MinWatts
+	}
+	p.MaxWatts = max(p.MaxWatts, other.MaxWatts)
+	p.N += other.N
+}
+
+// SegmentedPowerMetrics are time-segmented power draw metrics.
+type SegmentedPowerMetrics = Segmented[PowerSegment, *PowerSegment]
+
 //msgp:replace cpu.TimesStat with:cpuTimesStat
 //msgp:replace load.AvgStat with:loadAvgStat
 
@@ -1480,6 +1508,15 @@ type CPUMetrics struct {
 	MaxCPUInfoFreq          uint64         `json:"max_freq,omitempty"`                   // Maximum of CpuinfoMaximumFrequency
 	MinScalingFreq          uint64         `json:"min_scaling_freq,omitempty"`           // Minimum of ScalingMinimumFrequency
 	MaxScalingFreq          uint64         `json:"max_scaling_freq,omitempty"`           // Maximum of ScalingMaximumFrequency
+
+	// Power draw metrics (from IPMI/BMC, omitted when unavailable)
+	PowerNodes        int                    `json:"power_nodes,omitempty"`
+	TotalWatts        float64                `json:"total_watts,omitempty"`
+	MinNodeWatts      float64                `json:"min_node_watts,omitempty"`
+	MaxNodeWatts      float64                `json:"max_node_watts,omitempty"`
+	PowerSourceCounts map[string]int         `json:"power_source_counts,omitempty"`
+	PowerLastDay      *SegmentedPowerMetrics `json:"powerLastDay,omitempty"`
+	PowerLastHour     *SegmentedPowerMetrics `json:"powerLastHour,omitempty"`
 }
 
 // Merge other into 'm'.
@@ -1565,6 +1602,36 @@ func (m *CPUMetrics) Merge(other *CPUMetrics) {
 			m.LastHour = new(SegmentedCPUMetrics)
 		}
 		m.LastHour.Add(other.LastHour)
+	}
+
+	// Merge power draw metrics
+	if other.PowerNodes > 0 {
+		if m.PowerNodes == 0 || other.MinNodeWatts < m.MinNodeWatts {
+			m.MinNodeWatts = other.MinNodeWatts
+		}
+		m.MaxNodeWatts = max(m.MaxNodeWatts, other.MaxNodeWatts)
+		m.TotalWatts += other.TotalWatts
+		m.PowerNodes += other.PowerNodes
+		if len(other.PowerSourceCounts) > 0 {
+			if m.PowerSourceCounts == nil {
+				m.PowerSourceCounts = make(map[string]int)
+			}
+			for src, count := range other.PowerSourceCounts {
+				m.PowerSourceCounts[src] += count
+			}
+		}
+	}
+	if other.PowerLastDay != nil {
+		if m.PowerLastDay == nil {
+			m.PowerLastDay = new(SegmentedPowerMetrics)
+		}
+		m.PowerLastDay.Add(other.PowerLastDay)
+	}
+	if other.PowerLastHour != nil {
+		if m.PowerLastHour == nil {
+			m.PowerLastHour = new(SegmentedPowerMetrics)
+		}
+		m.PowerLastHour.Add(other.PowerLastHour)
 	}
 }
 

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -3112,7 +3112,7 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint32 /* 17 bits */
+	var zb0001Mask uint32 /* 24 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -3333,6 +3333,101 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x10000
+		case "power_nodes":
+			z.PowerNodes, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "PowerNodes")
+				return
+			}
+			zb0001Mask |= 0x20000
+		case "total_watts":
+			z.TotalWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "TotalWatts")
+				return
+			}
+			zb0001Mask |= 0x40000
+		case "min_node_watts":
+			z.MinNodeWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "MinNodeWatts")
+				return
+			}
+			zb0001Mask |= 0x80000
+		case "max_node_watts":
+			z.MaxNodeWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNodeWatts")
+				return
+			}
+			zb0001Mask |= 0x100000
+		case "power_source_counts":
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "PowerSourceCounts")
+				return
+			}
+			if z.PowerSourceCounts == nil {
+				z.PowerSourceCounts = make(map[string]int, zb0004)
+			} else if len(z.PowerSourceCounts) > 0 {
+				clear(z.PowerSourceCounts)
+			}
+			for zb0004 > 0 {
+				zb0004--
+				var za0005 string
+				za0005, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts")
+					return
+				}
+				var za0006 int
+				za0006, err = dc.ReadInt()
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts", za0005)
+					return
+				}
+				z.PowerSourceCounts[za0005] = za0006
+			}
+			zb0001Mask |= 0x200000
+		case "powerLastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastDay")
+					return
+				}
+				z.PowerLastDay = nil
+			} else {
+				if z.PowerLastDay == nil {
+					z.PowerLastDay = new(SegmentedPowerMetrics)
+				}
+				err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastDay).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x400000
+		case "powerLastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastHour")
+					return
+				}
+				z.PowerLastHour = nil
+			} else {
+				if z.PowerLastHour == nil {
+					z.PowerLastHour = new(SegmentedPowerMetrics)
+				}
+				err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastHour).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x800000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -3342,7 +3437,7 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ffff {
+	if zb0001Mask != 0xffffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.TimesCount = 0
 		}
@@ -3394,6 +3489,27 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x10000) == 0 {
 			z.MaxScalingFreq = 0
 		}
+		if (zb0001Mask & 0x20000) == 0 {
+			z.PowerNodes = 0
+		}
+		if (zb0001Mask & 0x40000) == 0 {
+			z.TotalWatts = 0
+		}
+		if (zb0001Mask & 0x80000) == 0 {
+			z.MinNodeWatts = 0
+		}
+		if (zb0001Mask & 0x100000) == 0 {
+			z.MaxNodeWatts = 0
+		}
+		if (zb0001Mask & 0x200000) == 0 {
+			z.PowerSourceCounts = nil
+		}
+		if (zb0001Mask & 0x400000) == 0 {
+			z.PowerLastDay = nil
+		}
+		if (zb0001Mask & 0x800000) == 0 {
+			z.PowerLastHour = nil
+		}
 	}
 	return
 }
@@ -3401,8 +3517,8 @@ func (z *CPUMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *CPUMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(21)
-	var zb0001Mask uint32 /* 21 bits */
+	zb0001Len := uint32(28)
+	var zb0001Mask uint32 /* 28 bits */
 	_ = zb0001Mask
 	if z.TimesCount == 0 {
 		zb0001Len--
@@ -3471,6 +3587,34 @@ func (z *CPUMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.MaxScalingFreq == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100000
+	}
+	if z.PowerNodes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200000
+	}
+	if z.TotalWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400000
+	}
+	if z.MinNodeWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x800000
+	}
+	if z.MaxNodeWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1000000
+	}
+	if z.PowerSourceCounts == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000000
+	}
+	if z.PowerLastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4000000
+	}
+	if z.PowerLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8000000
 	}
 	// variable map header, size zb0001Len
 	err = en.WriteMapHeader(zb0001Len)
@@ -3762,6 +3906,116 @@ func (z *CPUMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
+		if (zb0001Mask & 0x200000) == 0 { // if not omitted
+			// write "power_nodes"
+			err = en.Append(0xab, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt(z.PowerNodes)
+			if err != nil {
+				err = msgp.WrapError(err, "PowerNodes")
+				return
+			}
+		}
+		if (zb0001Mask & 0x400000) == 0 { // if not omitted
+			// write "total_watts"
+			err = en.Append(0xab, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.TotalWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "TotalWatts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x800000) == 0 { // if not omitted
+			// write "min_node_watts"
+			err = en.Append(0xae, 0x6d, 0x69, 0x6e, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.MinNodeWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "MinNodeWatts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x1000000) == 0 { // if not omitted
+			// write "max_node_watts"
+			err = en.Append(0xae, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.MaxNodeWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNodeWatts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2000000) == 0 { // if not omitted
+			// write "power_source_counts"
+			err = en.Append(0xb3, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.PowerSourceCounts)))
+			if err != nil {
+				err = msgp.WrapError(err, "PowerSourceCounts")
+				return
+			}
+			for za0005, za0006 := range z.PowerSourceCounts {
+				err = en.WriteString(za0005)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts")
+					return
+				}
+				err = en.WriteInt(za0006)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts", za0005)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4000000) == 0 { // if not omitted
+			// write "powerLastDay"
+			err = en.Append(0xac, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x4c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.PowerLastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastDay).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8000000) == 0 { // if not omitted
+			// write "powerLastHour"
+			err = en.Append(0xad, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x4c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.PowerLastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastHour).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastHour")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -3770,8 +4024,8 @@ func (z *CPUMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *CPUMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(21)
-	var zb0001Mask uint32 /* 21 bits */
+	zb0001Len := uint32(28)
+	var zb0001Mask uint32 /* 28 bits */
 	_ = zb0001Mask
 	if z.TimesCount == 0 {
 		zb0001Len--
@@ -3840,6 +4094,34 @@ func (z *CPUMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.MaxScalingFreq == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100000
+	}
+	if z.PowerNodes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200000
+	}
+	if z.TotalWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400000
+	}
+	if z.MinNodeWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x800000
+	}
+	if z.MaxNodeWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1000000
+	}
+	if z.PowerSourceCounts == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000000
+	}
+	if z.PowerLastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4000000
+	}
+	if z.PowerLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8000000
 	}
 	// variable map header, size zb0001Len
 	o = msgp.AppendMapHeader(o, zb0001Len)
@@ -3975,6 +4257,61 @@ func (z *CPUMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			o = append(o, 0xb0, 0x6d, 0x61, 0x78, 0x5f, 0x73, 0x63, 0x61, 0x6c, 0x69, 0x6e, 0x67, 0x5f, 0x66, 0x72, 0x65, 0x71)
 			o = msgp.AppendUint64(o, z.MaxScalingFreq)
 		}
+		if (zb0001Mask & 0x200000) == 0 { // if not omitted
+			// string "power_nodes"
+			o = append(o, 0xab, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+			o = msgp.AppendInt(o, z.PowerNodes)
+		}
+		if (zb0001Mask & 0x400000) == 0 { // if not omitted
+			// string "total_watts"
+			o = append(o, 0xab, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.TotalWatts)
+		}
+		if (zb0001Mask & 0x800000) == 0 { // if not omitted
+			// string "min_node_watts"
+			o = append(o, 0xae, 0x6d, 0x69, 0x6e, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.MinNodeWatts)
+		}
+		if (zb0001Mask & 0x1000000) == 0 { // if not omitted
+			// string "max_node_watts"
+			o = append(o, 0xae, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x6f, 0x64, 0x65, 0x5f, 0x77, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.MaxNodeWatts)
+		}
+		if (zb0001Mask & 0x2000000) == 0 { // if not omitted
+			// string "power_source_counts"
+			o = append(o, 0xb3, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x5f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73)
+			o = msgp.AppendMapHeader(o, uint32(len(z.PowerSourceCounts)))
+			for za0005, za0006 := range z.PowerSourceCounts {
+				o = msgp.AppendString(o, za0005)
+				o = msgp.AppendInt(o, za0006)
+			}
+		}
+		if (zb0001Mask & 0x4000000) == 0 { // if not omitted
+			// string "powerLastDay"
+			o = append(o, 0xac, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x4c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.PowerLastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8000000) == 0 { // if not omitted
+			// string "powerLastHour"
+			o = append(o, 0xad, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x4c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.PowerLastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastHour).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastHour")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -3989,7 +4326,7 @@ func (z *CPUMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint32 /* 17 bits */
+	var zb0001Mask uint32 /* 24 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -4208,6 +4545,99 @@ func (z *CPUMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x10000
+		case "power_nodes":
+			z.PowerNodes, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PowerNodes")
+				return
+			}
+			zb0001Mask |= 0x20000
+		case "total_watts":
+			z.TotalWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TotalWatts")
+				return
+			}
+			zb0001Mask |= 0x40000
+		case "min_node_watts":
+			z.MinNodeWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MinNodeWatts")
+				return
+			}
+			zb0001Mask |= 0x80000
+		case "max_node_watts":
+			z.MaxNodeWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNodeWatts")
+				return
+			}
+			zb0001Mask |= 0x100000
+		case "power_source_counts":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PowerSourceCounts")
+				return
+			}
+			if z.PowerSourceCounts == nil {
+				z.PowerSourceCounts = make(map[string]int, zb0004)
+			} else if len(z.PowerSourceCounts) > 0 {
+				clear(z.PowerSourceCounts)
+			}
+			for zb0004 > 0 {
+				var za0006 int
+				zb0004--
+				var za0005 string
+				za0005, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts")
+					return
+				}
+				za0006, bts, err = msgp.ReadIntBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerSourceCounts", za0005)
+					return
+				}
+				z.PowerSourceCounts[za0005] = za0006
+			}
+			zb0001Mask |= 0x200000
+		case "powerLastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.PowerLastDay = nil
+			} else {
+				if z.PowerLastDay == nil {
+					z.PowerLastDay = new(SegmentedPowerMetrics)
+				}
+				bts, err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastDay).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x400000
+		case "powerLastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.PowerLastHour = nil
+			} else {
+				if z.PowerLastHour == nil {
+					z.PowerLastHour = new(SegmentedPowerMetrics)
+				}
+				bts, err = (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastHour).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PowerLastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x800000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -4217,7 +4647,7 @@ func (z *CPUMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ffff {
+	if zb0001Mask != 0xffffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.TimesCount = 0
 		}
@@ -4269,6 +4699,27 @@ func (z *CPUMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x10000) == 0 {
 			z.MaxScalingFreq = 0
 		}
+		if (zb0001Mask & 0x20000) == 0 {
+			z.PowerNodes = 0
+		}
+		if (zb0001Mask & 0x40000) == 0 {
+			z.TotalWatts = 0
+		}
+		if (zb0001Mask & 0x80000) == 0 {
+			z.MinNodeWatts = 0
+		}
+		if (zb0001Mask & 0x100000) == 0 {
+			z.MaxNodeWatts = 0
+		}
+		if (zb0001Mask & 0x200000) == 0 {
+			z.PowerSourceCounts = nil
+		}
+		if (zb0001Mask & 0x400000) == 0 {
+			z.PowerLastDay = nil
+		}
+		if (zb0001Mask & 0x800000) == 0 {
+			z.PowerLastHour = nil
+		}
 	}
 	o = bts
 	return
@@ -4302,7 +4753,25 @@ func (z *CPUMetrics) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0003) + msgp.IntSize
 		}
 	}
-	s += 19 + msgp.Uint64Size + 27 + msgp.Uint64Size + 9 + msgp.Uint64Size + 9 + msgp.Uint64Size + 17 + msgp.Uint64Size + 17 + msgp.Uint64Size
+	s += 19 + msgp.Uint64Size + 27 + msgp.Uint64Size + 9 + msgp.Uint64Size + 9 + msgp.Uint64Size + 17 + msgp.Uint64Size + 17 + msgp.Uint64Size + 12 + msgp.IntSize + 12 + msgp.Float64Size + 15 + msgp.Float64Size + 15 + msgp.Float64Size + 20 + msgp.MapHeaderSize
+	if z.PowerSourceCounts != nil {
+		for za0005, za0006 := range z.PowerSourceCounts {
+			_ = za0006
+			s += msgp.StringPrefixSize + len(za0005) + msgp.IntSize
+		}
+	}
+	s += 13
+	if z.PowerLastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastDay).Msgsize()
+	}
+	s += 14
+	if z.PowerLastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[PowerSegment, *PowerSegment])(z.PowerLastHour).Msgsize()
+	}
 	return
 }
 
@@ -19728,6 +20197,275 @@ func (z *OSMetrics) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0007) + za0008.Msgsize()
 		}
 	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *PowerSegment) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "sumWatts":
+			z.SumWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "SumWatts")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "minWatts":
+			z.MinWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "MinWatts")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "maxWatts":
+			z.MaxWatts, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "MaxWatts")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.SumWatts = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.MinWatts = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MaxWatts = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *PowerSegment) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.SumWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.MinWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MaxWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "sumWatts"
+			err = en.Append(0xa8, 0x73, 0x75, 0x6d, 0x57, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.SumWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "SumWatts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "minWatts"
+			err = en.Append(0xa8, 0x6d, 0x69, 0x6e, 0x57, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.MinWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "MinWatts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "maxWatts"
+			err = en.Append(0xa8, 0x6d, 0x61, 0x78, 0x57, 0x61, 0x74, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.MaxWatts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxWatts")
+				return
+			}
+		}
+		// write "n"
+		err = en.Append(0xa1, 0x6e)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.N)
+		if err != nil {
+			err = msgp.WrapError(err, "N")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *PowerSegment) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.SumWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.MinWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MaxWatts == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "sumWatts"
+			o = append(o, 0xa8, 0x73, 0x75, 0x6d, 0x57, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.SumWatts)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "minWatts"
+			o = append(o, 0xa8, 0x6d, 0x69, 0x6e, 0x57, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.MinWatts)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "maxWatts"
+			o = append(o, 0xa8, 0x6d, 0x61, 0x78, 0x57, 0x61, 0x74, 0x74, 0x73)
+			o = msgp.AppendFloat64(o, z.MaxWatts)
+		}
+		// string "n"
+		o = append(o, 0xa1, 0x6e)
+		o = msgp.AppendInt(o, z.N)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *PowerSegment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "sumWatts":
+			z.SumWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SumWatts")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "minWatts":
+			z.MinWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MinWatts")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "maxWatts":
+			z.MaxWatts, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxWatts")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.SumWatts = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.MinWatts = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MaxWatts = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *PowerSegment) Msgsize() (s int) {
+	s = 1 + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 2 + msgp.IntSize
 	return
 }
 

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -3512,6 +3512,119 @@ func BenchmarkDecodeOSMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalPowerSegment(t *testing.T) {
+	v := PowerSegment{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgPowerSegment(b *testing.B) {
+	v := PowerSegment{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgPowerSegment(b *testing.B) {
+	v := PowerSegment{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalPowerSegment(b *testing.B) {
+	v := PowerSegment{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodePowerSegment(t *testing.T) {
+	v := PowerSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodePowerSegment Msgsize() is inaccurate")
+	}
+
+	vn := PowerSegment{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodePowerSegment(b *testing.B) {
+	v := PowerSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodePowerSegment(b *testing.B) {
+	v := PowerSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalProcessCPUTimes(t *testing.T) {
 	v := ProcessCPUTimes{}
 	bts, err := v.MarshalMsg(nil)

--- a/mnav/cpu.go
+++ b/mnav/cpu.go
@@ -56,8 +56,8 @@ func (node *CPUMetricsNavigator) GetChildren() []MetricChild {
 		return nil
 	}
 	return []MetricChild{
-		{Name: "cpu_last_hour", Description: "Last hour CPU usage (1-min segments)"},
-		{Name: "cpu_last_day", Description: "Last 24h CPU usage (15-min segments)"},
+		{Name: "last_hour", Description: "Last hour CPU usage (1-min segments)"},
+		{Name: "last_day", Description: "Last 24h CPU usage (15-min segments)"},
 		{Name: "power_last_hour", Description: "Last hour power draw (1-min segments)"},
 		{Name: "power_last_day", Description: "Last 24h power draw (15-min segments)"},
 	}
@@ -330,8 +330,13 @@ func (node *CPUMetricsNavigator) GetLeafData() map[string]string {
 			avgWatts, node.cpu.MinNodeWatts, node.cpu.MaxNodeWatts))
 
 		if len(node.cpu.PowerSourceCounts) > 0 {
-			for src, count := range node.cpu.PowerSourceCounts {
-				addEntry(fmt.Sprintf("Source %s", src), fmt.Sprintf("%d nodes", count))
+			sources := make([]string, 0, len(node.cpu.PowerSourceCounts))
+			for src := range node.cpu.PowerSourceCounts {
+				sources = append(sources, src)
+			}
+			sort.Strings(sources)
+			for _, src := range sources {
+				addEntry(fmt.Sprintf("Source %s", src), fmt.Sprintf("%d nodes", node.cpu.PowerSourceCounts[src]))
 			}
 		}
 	}
@@ -464,18 +469,18 @@ func (node *CPUMetricsNavigator) GetChild(name string) (MetricNode, error) {
 		return nil, fmt.Errorf("no CPU data available")
 	}
 	switch name {
-	case "cpu_last_hour":
+	case "last_hour":
 		return &CPUSegmentedNode{
 			segmented: node.cpu.LastHour,
 			parent:    node,
-			path:      node.path + "/cpu_last_hour",
+			path:      node.path + "/last_hour",
 			flags:     madmin.MetricsHourStats,
 		}, nil
-	case "cpu_last_day":
+	case "last_day":
 		return &CPUSegmentedNode{
 			segmented: node.cpu.LastDay,
 			parent:    node,
-			path:      node.path + "/cpu_last_day",
+			path:      node.path + "/last_day",
 			flags:     madmin.MetricsDayStats,
 		}, nil
 	case "power_last_hour":

--- a/mnav/cpu.go
+++ b/mnav/cpu.go
@@ -20,6 +20,7 @@ package mnav
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v4"
@@ -51,7 +52,15 @@ func NewCPUMetricsNavigator(cpu *madmin.CPUMetrics, parent MetricNode, path stri
 }
 
 func (node *CPUMetricsNavigator) GetChildren() []MetricChild {
-	return []MetricChild{}
+	if node.cpu == nil {
+		return nil
+	}
+	return []MetricChild{
+		{Name: "cpu_last_hour", Description: "Last hour CPU usage (1-min segments)"},
+		{Name: "cpu_last_day", Description: "Last 24h CPU usage (15-min segments)"},
+		{Name: "power_last_hour", Description: "Last hour power draw (1-min segments)"},
+		{Name: "power_last_day", Description: "Last 24h power draw (15-min segments)"},
+	}
 }
 
 func (node *CPUMetricsNavigator) GetLeafData() map[string]string {
@@ -91,7 +100,7 @@ func (node *CPUMetricsNavigator) GetLeafData() map[string]string {
 			totalGhz))
 		if node.cpu.Nodes > 0 {
 			avgGhzPerNode := totalGhz / float64(node.cpu.Nodes)
-			addEntry("Power per Node", fmt.Sprintf("%.2f GHz average per node",
+			addEntry("CPU Speed", fmt.Sprintf("%.2f GHz average per node",
 				avgGhzPerNode))
 		}
 	}
@@ -311,6 +320,22 @@ func (node *CPUMetricsNavigator) GetLeafData() map[string]string {
 		}
 	}
 
+	// Power Draw
+	if node.cpu.PowerNodes > 0 {
+		avgWatts := node.cpu.TotalWatts / float64(node.cpu.PowerNodes)
+		addEntry("POWER DRAW", fmt.Sprintf("%d of %d nodes reporting",
+			node.cpu.PowerNodes, node.cpu.Nodes))
+		addEntry("Fleet Total", fmt.Sprintf("%.0f W", node.cpu.TotalWatts))
+		addEntry("Per Node", fmt.Sprintf("%.1f W avg, %.0f W min, %.0f W max",
+			avgWatts, node.cpu.MinNodeWatts, node.cpu.MaxNodeWatts))
+
+		if len(node.cpu.PowerSourceCounts) > 0 {
+			for src, count := range node.cpu.PowerSourceCounts {
+				addEntry(fmt.Sprintf("Source %s", src), fmt.Sprintf("%d nodes", count))
+			}
+		}
+	}
+
 	// Convert ordered entries to map with numbered prefixes to preserve order
 	data := make(map[string]string)
 	for i, entry := range entries {
@@ -336,6 +361,138 @@ func (node *CPUMetricsNavigator) GetPath() string {
 	return node.path
 }
 
-func (node *CPUMetricsNavigator) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("no children available - all CPU data shown in main display")
+// CPUSegmentedNode shows time-segmented CPU usage data.
+type CPUSegmentedNode struct {
+	segmented *madmin.SegmentedCPUMetrics
+	parent    MetricNode
+	path      string
+	flags     madmin.MetricFlags
+}
+
+func (node *CPUSegmentedNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *CPUSegmentedNode) GetPath() string                    { return node.path }
+func (node *CPUSegmentedNode) GetParent() MetricNode              { return node.parent }
+func (node *CPUSegmentedNode) GetMetricType() madmin.MetricType   { return madmin.MetricsCPU }
+func (node *CPUSegmentedNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *CPUSegmentedNode) ShouldPauseRefresh() bool           { return true }
+func (node *CPUSegmentedNode) GetChildren() []MetricChild         { return nil }
+
+func (node *CPUSegmentedNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *CPUSegmentedNode) GetLeafData() map[string]string {
+	if node.segmented == nil || len(node.segmented.Segments) == 0 {
+		return nil
+	}
+	data := make(map[string]string)
+	idx := 0
+	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
+		seg := node.segmented.Segments[i]
+		if seg.N == 0 {
+			continue
+		}
+		idx++
+		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
+		name := fmt.Sprintf("%02d: %s->%s", idx, startTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
+
+		n := float64(seg.N)
+		user := seg.User / n
+		system := seg.System / n
+		idle := seg.Idle / n
+		iowait := seg.Iowait / n
+		total := user + system + idle + seg.Nice/n + iowait +
+			seg.Irq/n + seg.Softirq/n + seg.Steal/n +
+			seg.Guest/n + seg.GuestNice/n
+		if total == 0 {
+			continue
+		}
+		data[name] = fmt.Sprintf("User: %.1f%%, Sys: %.1f%%, Idle: %.1f%%, IOWait: %.1f%% (%d nodes)",
+			user/total*100, system/total*100, idle/total*100, iowait/total*100, seg.N)
+	}
+	return data
+}
+
+// PowerSegmentedNode shows time-segmented power draw data.
+type PowerSegmentedNode struct {
+	segmented *madmin.SegmentedPowerMetrics
+	parent    MetricNode
+	path      string
+	flags     madmin.MetricFlags
+}
+
+func (node *PowerSegmentedNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *PowerSegmentedNode) GetPath() string                    { return node.path }
+func (node *PowerSegmentedNode) GetParent() MetricNode              { return node.parent }
+func (node *PowerSegmentedNode) GetMetricType() madmin.MetricType   { return madmin.MetricsCPU }
+func (node *PowerSegmentedNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *PowerSegmentedNode) ShouldPauseRefresh() bool           { return true }
+func (node *PowerSegmentedNode) GetChildren() []MetricChild         { return nil }
+
+func (node *PowerSegmentedNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *PowerSegmentedNode) GetLeafData() map[string]string {
+	if node.segmented == nil || len(node.segmented.Segments) == 0 {
+		return nil
+	}
+	data := make(map[string]string)
+	idx := 0
+	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
+		seg := node.segmented.Segments[i]
+		if seg.N == 0 {
+			continue
+		}
+		idx++
+		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
+		name := fmt.Sprintf("%02d: %s->%s", idx, startTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
+		avg := seg.SumWatts / float64(seg.N)
+		data[name] = fmt.Sprintf("Avg: %s, Min: %s, Max: %s (%s nodes)",
+			humanize.SI(avg, "W"),
+			humanize.SI(seg.MinWatts, "W"),
+			humanize.SI(seg.MaxWatts, "W"),
+			humanize.Comma(int64(seg.N)))
+	}
+	return data
+}
+
+func (node *CPUMetricsNavigator) GetChild(name string) (MetricNode, error) {
+	if node.cpu == nil {
+		return nil, fmt.Errorf("no CPU data available")
+	}
+	switch name {
+	case "cpu_last_hour":
+		return &CPUSegmentedNode{
+			segmented: node.cpu.LastHour,
+			parent:    node,
+			path:      node.path + "/cpu_last_hour",
+			flags:     madmin.MetricsHourStats,
+		}, nil
+	case "cpu_last_day":
+		return &CPUSegmentedNode{
+			segmented: node.cpu.LastDay,
+			parent:    node,
+			path:      node.path + "/cpu_last_day",
+			flags:     madmin.MetricsDayStats,
+		}, nil
+	case "power_last_hour":
+		return &PowerSegmentedNode{
+			segmented: node.cpu.PowerLastHour,
+			parent:    node,
+			path:      node.path + "/power_last_hour",
+			flags:     madmin.MetricsHourStats,
+		}, nil
+	case "power_last_day":
+		return &PowerSegmentedNode{
+			segmented: node.cpu.PowerLastDay,
+			parent:    node,
+			path:      node.path + "/power_last_day",
+			flags:     madmin.MetricsDayStats,
+		}, nil
+	default:
+		return nil, fmt.Errorf("child not found: %s", name)
+	}
 }


### PR DESCRIPTION
Adds current and historic power draw numbers to aggregated realtime metrics.

Adds mnav for them.

CPU was the closest match. Didn't want to add a new type just for this. It will most likely be used along CPU metrics anyway.