### PR TITLE
feat(health): add HealthDataTypeSysProductInfo

### DIFF
--- a/health.go
+++ b/health.go
@@ -1481,36 +1481,38 @@ type HealthDataType string
 
 // HealthDataTypes
 const (
-	HealthDataTypeMinioInfo    HealthDataType = "minioinfo"
-	HealthDataTypeMinioConfig  HealthDataType = "minioconfig"
-	HealthDataTypeSysCPU       HealthDataType = "syscpu"
-	HealthDataTypeSysDriveHw   HealthDataType = "sysdrivehw"
-	HealthDataTypeSysOsInfo    HealthDataType = "sysosinfo"
-	HealthDataTypeSysMem       HealthDataType = "sysmem"
-	HealthDataTypeSysNet       HealthDataType = "sysnet"
-	HealthDataTypeSysProcess   HealthDataType = "sysprocess"
-	HealthDataTypeSysErrors    HealthDataType = "syserrors"
-	HealthDataTypeSysServices  HealthDataType = "sysservices"
-	HealthDataTypeSysConfig    HealthDataType = "sysconfig"
-	HealthDataTypeReplication  HealthDataType = "replication"
-	HealthDataTypeShardsHealth HealthDataType = "shardshealth"
+	HealthDataTypeMinioInfo      HealthDataType = "minioinfo"
+	HealthDataTypeMinioConfig    HealthDataType = "minioconfig"
+	HealthDataTypeSysCPU         HealthDataType = "syscpu"
+	HealthDataTypeSysDriveHw     HealthDataType = "sysdrivehw"
+	HealthDataTypeSysOsInfo      HealthDataType = "sysosinfo"
+	HealthDataTypeSysMem         HealthDataType = "sysmem"
+	HealthDataTypeSysNet         HealthDataType = "sysnet"
+	HealthDataTypeSysProcess     HealthDataType = "sysprocess"
+	HealthDataTypeSysErrors      HealthDataType = "syserrors"
+	HealthDataTypeSysServices    HealthDataType = "sysservices"
+	HealthDataTypeSysConfig      HealthDataType = "sysconfig"
+	HealthDataTypeSysProductInfo HealthDataType = "sysproductinfo"
+	HealthDataTypeReplication    HealthDataType = "replication"
+	HealthDataTypeShardsHealth   HealthDataType = "shardshealth"
 )
 
 // HealthDataTypesMap - Map of Health datatypes
 var HealthDataTypesMap = map[string]HealthDataType{
-	"minioinfo":    HealthDataTypeMinioInfo,
-	"minioconfig":  HealthDataTypeMinioConfig,
-	"syscpu":       HealthDataTypeSysCPU,
-	"sysdrivehw":   HealthDataTypeSysDriveHw,
-	"sysosinfo":    HealthDataTypeSysOsInfo,
-	"sysmem":       HealthDataTypeSysMem,
-	"sysnet":       HealthDataTypeSysNet,
-	"sysprocess":   HealthDataTypeSysProcess,
-	"syserrors":    HealthDataTypeSysErrors,
-	"sysservices":  HealthDataTypeSysServices,
-	"sysconfig":    HealthDataTypeSysConfig,
-	"replication":  HealthDataTypeReplication,
-	"shardshealth": HealthDataTypeShardsHealth,
+	"minioinfo":      HealthDataTypeMinioInfo,
+	"minioconfig":    HealthDataTypeMinioConfig,
+	"syscpu":         HealthDataTypeSysCPU,
+	"sysdrivehw":     HealthDataTypeSysDriveHw,
+	"sysosinfo":      HealthDataTypeSysOsInfo,
+	"sysmem":         HealthDataTypeSysMem,
+	"sysnet":         HealthDataTypeSysNet,
+	"sysprocess":     HealthDataTypeSysProcess,
+	"syserrors":      HealthDataTypeSysErrors,
+	"sysservices":    HealthDataTypeSysServices,
+	"sysconfig":      HealthDataTypeSysConfig,
+	"sysproductinfo": HealthDataTypeSysProductInfo,
+	"replication":    HealthDataTypeReplication,
+	"shardshealth":   HealthDataTypeShardsHealth,
 }
 
 // HealthDataTypesList - List of health datatypes
@@ -1526,6 +1528,7 @@ var HealthDataTypesList = []HealthDataType{
 	HealthDataTypeSysErrors,
 	HealthDataTypeSysServices,
 	HealthDataTypeSysConfig,
+	HealthDataTypeSysProductInfo,
 	HealthDataTypeReplication,
 	HealthDataTypeShardsHealth,
 }


### PR DESCRIPTION
## Summary                                                                                                                                                 
                                                                                                                                                           
  Adds `HealthDataTypeSysProductInfo` (`"sysproductinfo"`) plus matching                                                                                     
  map/list entries. Purely additive — no struct or API changes.
                                                                                                                                                             
  ## Motivation                                                                                                                                            

  `SysInfo.ProductInfo`, `GetProductInfo`, and `getDMIInfo` already exist                                                                                    
  but had no `HealthDataType`, so the section was impossible to request
  via `ServerHealthInfo`. Server-side wiring lands in the matching                                                                                           
  eos PR.    
  Fixes: https://github.com/miniohq/subnet/issues/6318
  
 ## How to test?
  - Build minio from miniohq/eos#5047                                                                                                                      
  - Build mc from miniohq/ec#509
  - `mc support diag --airgap <alias>`
  - `gunzip -c diag-data-*.json.gz | jq -s 'last | .sys.productinfo'`
  - Expect one entry per node: real vendor/name/version on Linux with DMI, `"unknown"` fallback elsewhere                                                    
  - Re-run with `--anonymize strict`: `serial_number`/`uuid` blanked, others preserved  
  
  ## Expected Output(standard mode, on a Linux host with DMI)
                                                                                                                                                             
  ```json                                                                                                                                                  
  [
    {
      "addr": "node-1:9000",
      "family": "PowerEdge",                                                                                                                                 
      "name": "PowerEdge R750",
      "vendor": "Dell Inc.",                                                                                                                                 
      "serial_number": "5XYZ123",                                                                                                                          
      "uuid": "4c4c4544-0058-5910-8050-cac04f445232",                                                                                                        
      "sku": "SKU=PE-R750",                                                                                                                                  
      "version": "2.10.0"                                                                                                                                    
    }                                                                                                                                                        
  ]             