### PR TITLE
feat: add multi-value filter fields to APILogOpts

### DIFF
--- a/api-logs.go
+++ b/api-logs.go
@@ -39,12 +39,12 @@ type APILogOpts struct {
 	Bucket       string        `json:"bucket,omitempty"`
 	BucketPrefix string        `json:"bucketPrefix,omitempty"`
 	Prefix       string        `json:"prefix,omitempty"`
-	StatusCode   int           `json:"statusCode,omitempty"`  // Deprecated: use StatusCodes
+	StatusCode   int           `json:"statusCode,omitempty"` // Deprecated: use StatusCodes
 	StatusCodes  []string      `json:"statusCodes,omitempty"`
 	Interval     time.Duration `json:"interval,omitempty"`
-	Origin       log.Origin    `json:"origin,omitempty"`  // Deprecated: use Origins
+	Origin       log.Origin    `json:"origin,omitempty"` // Deprecated: use Origins
 	Origins      []string      `json:"origins,omitempty"`
-	Type         log.APIType   `json:"type,omitempty"`  // Deprecated: use Types
+	Type         log.APIType   `json:"type,omitempty"` // Deprecated: use Types
 	Types        []string      `json:"types,omitempty"`
 	MaxPerNode   int           `json:"maxPerNode,omitempty"` // Deprecated
 	Limit        int           `json:"limit,omitempty"`

--- a/api-logs.go
+++ b/api-logs.go
@@ -39,13 +39,14 @@ type APILogOpts struct {
 	Bucket       string        `json:"bucket,omitempty"`
 	BucketPrefix string        `json:"bucketPrefix,omitempty"`
 	Prefix       string        `json:"prefix,omitempty"`
-	StatusCode   int           `json:"statusCode,omitempty"` // Deprecated: use StatusCodes
-	StatusCodes  []string      `json:"statusCodes,omitempty"`
+	StatusCode   int           `json:"statusCode,omitempty"` // Deprecated: use StatusCodes/StatusRanges
+	StatusCodes  []int         `json:"statusCodes,omitempty"`
+	StatusRanges []string      `json:"statusRanges,omitempty"` // e.g. "2xx", "4xx", "5xx"
 	Interval     time.Duration `json:"interval,omitempty"`
 	Origin       log.Origin    `json:"origin,omitempty"` // Deprecated: use Origins
-	Origins      []string      `json:"origins,omitempty"`
+	Origins      []log.Origin  `json:"origins,omitempty"`
 	Type         log.APIType   `json:"type,omitempty"` // Deprecated: use Types
-	Types        []string      `json:"types,omitempty"`
+	Types        []log.APIType `json:"types,omitempty"`
 	MaxPerNode   int           `json:"maxPerNode,omitempty"` // Deprecated
 	Limit        int           `json:"limit,omitempty"`
 }

--- a/api-logs.go
+++ b/api-logs.go
@@ -34,16 +34,20 @@ import (
 
 // APILogOpts represents the options for the APILogOpts
 type APILogOpts struct {
-	Node       string        `json:"node,omitempty"`
-	API        string        `json:"api,omitempty"`
-	Bucket     string        `json:"bucket,omitempty"`
-	Prefix     string        `json:"prefix,omitempty"`
-	StatusCode int           `json:"statusCode,omitempty"`
-	Interval   time.Duration `json:"interval,omitempty"`
-	Origin     log.Origin    `json:"origin,omitempty"`
-	Type       log.APIType   `json:"type,omitempty"`
-	MaxPerNode int           `json:"maxPerNode,omitempty"` // Deprecated
-	Limit      int           `json:"limit,omitempty"`
+	Node         string        `json:"node,omitempty"`
+	API          string        `json:"api,omitempty"`
+	Bucket       string        `json:"bucket,omitempty"`
+	BucketPrefix string        `json:"bucketPrefix,omitempty"`
+	Prefix       string        `json:"prefix,omitempty"`
+	StatusCode   int           `json:"statusCode,omitempty"`  // Deprecated: use StatusCodes
+	StatusCodes  []string      `json:"statusCodes,omitempty"`
+	Interval     time.Duration `json:"interval,omitempty"`
+	Origin       log.Origin    `json:"origin,omitempty"`  // Deprecated: use Origins
+	Origins      []string      `json:"origins,omitempty"`
+	Type         log.APIType   `json:"type,omitempty"`  // Deprecated: use Types
+	Types        []string      `json:"types,omitempty"`
+	MaxPerNode   int           `json:"maxPerNode,omitempty"` // Deprecated
+	Limit        int           `json:"limit,omitempty"`
 }
 
 // GetAPILogs fetches the persisted API logs from MinIO


### PR DESCRIPTION
Add StatusCodes, Origins, Types, and BucketPrefix to APILogOpts to support filtering API logs by multiple values and bucket name prefix.