### PR TITLE
Rename inventory to "system inventory"

### DIFF
--- a/service-commands.go
+++ b/service-commands.go
@@ -172,7 +172,7 @@ type ServiceTraceOpts struct {
 	Formatting        bool
 	PurgeOnDelete     bool
 	TablesScan        bool
-	Inventory         bool
+	SystemInventory   bool
 
 	OnlyErrors    bool
 	Threshold     time.Duration
@@ -203,7 +203,7 @@ func (t ServiceTraceOpts) TraceTypes() TraceType {
 	tt.SetIf(t.Formatting, TraceFormatting)
 	tt.SetIf(t.PurgeOnDelete, TracePurgeOnDelete)
 	tt.SetIf(t.TablesScan, TraceTablesScan)
-	tt.SetIf(t.Inventory, TraceInventory)
+	tt.SetIf(t.SystemInventory, TraceSystemInventory)
 
 	return tt
 }
@@ -234,7 +234,7 @@ func (t ServiceTraceOpts) AddParams(u url.Values) {
 	u.Set("kms", strconv.FormatBool(t.KMS))
 	u.Set("formatting", strconv.FormatBool(t.Formatting))
 	u.Set("purgeondelete", strconv.FormatBool(t.PurgeOnDelete))
-	u.Set("inventory", strconv.FormatBool(t.Inventory))
+	u.Set("systeminventory", strconv.FormatBool(t.SystemInventory))
 }
 
 // ParseParams will parse parameters and set them to t.
@@ -260,7 +260,7 @@ func (t *ServiceTraceOpts) ParseParams(r *http.Request) (err error) {
 	t.KMS = r.Form.Get("kms") == "true"
 	t.Formatting = r.Form.Get("formatting") == "true"
 	t.PurgeOnDelete = r.Form.Get("purgeondelete") == "true"
-	t.Inventory = r.Form.Get("inventory") == "true"
+	t.SystemInventory = r.Form.Get("systeminventory") == "true"
 
 	if th := r.Form.Get("threshold"); th != "" {
 		d, err := time.ParseDuration(th)

--- a/service-commands_test.go
+++ b/service-commands_test.go
@@ -45,19 +45,19 @@ func TestServiceTraceOptsTables(t *testing.T) {
 	}
 }
 
-func TestServiceTraceOptsInventory(t *testing.T) {
-	opts := ServiceTraceOpts{Inventory: true}
-	if got := opts.TraceTypes(); !got.Contains(TraceInventory) {
-		t.Fatalf("TraceTypes() missing TraceInventory: got %v", got)
+func TestServiceTraceOptsSystemInventory(t *testing.T) {
+	opts := ServiceTraceOpts{SystemInventory: true}
+	if got := opts.TraceTypes(); !got.Contains(TraceSystemInventory) {
+		t.Fatalf("TraceTypes() missing TraceSystemInventory: got %v", got)
 	}
 
 	vals := make(url.Values)
 	opts.AddParams(vals)
-	if got := vals.Get("inventory"); got != "true" {
-		t.Fatalf("AddParams() inventory flag = %q, want true", got)
+	if got := vals.Get("systeminventory"); got != "true" {
+		t.Fatalf("AddParams() systeminventory flag = %q, want true", got)
 	}
 
-	req := httptest.NewRequest("GET", "/minio/admin/v3/trace?inventory=true", nil)
+	req := httptest.NewRequest("GET", "/minio/admin/v3/trace?systeminventory=true", nil)
 	if err := req.ParseForm(); err != nil {
 		t.Fatalf("ParseForm() returned error = %v", err)
 	}
@@ -67,7 +67,7 @@ func TestServiceTraceOptsInventory(t *testing.T) {
 		t.Fatalf("ParseParams() returned error = %v", err)
 	}
 
-	if !parsed.Inventory {
-		t.Fatalf("ParseParams() did not set Inventory flag")
+	if !parsed.SystemInventory {
+		t.Fatalf("ParseParams() did not set SystemInventory flag")
 	}
 }

--- a/trace.go
+++ b/trace.go
@@ -80,8 +80,8 @@ const (
 	TracePurgeOnDelete
 	// TraceTablesScan will trace catalog scanner operations which are for replica catalog rebuilding.
 	TraceTablesScan
-	// TraceInventory will trace per-bucket system inventory operations.
-	TraceInventory
+	// TraceSystemInventory will trace per-bucket system inventory operations.
+	TraceSystemInventory
 	// Add more here...
 
 	// TraceAll contains all valid trace modes.

--- a/tracetype_string.go
+++ b/tracetype_string.go
@@ -32,11 +32,11 @@ func _() {
 	_ = x[TraceTables-2097152]
 	_ = x[TracePurgeOnDelete-4194304]
 	_ = x[TraceTablesScan-8388608]
-	_ = x[TraceInventory-16777216]
+	_ = x[TraceSystemInventory-16777216]
 	_ = x[TraceAll-33554431]
 }
 
-const _TraceType_name = "OSStorageS3InternalScannerDecommissionHealingBatchReplicationBatchKeyRotationBatchExpireRebalanceReplicationResyncBootstrapFTPILMKMSFormattingAdminObjectReplicationIAMTablesPurgeOnDeleteTablesScanInventoryAll"
+const _TraceType_name = "OSStorageS3InternalScannerDecommissionHealingBatchReplicationBatchKeyRotationBatchExpireRebalanceReplicationResyncBootstrapFTPILMKMSFormattingAdminObjectReplicationIAMTablesPurgeOnDeleteTablesScanSystemInventoryAll"
 
 var _TraceType_map = map[TraceType]string{
 	1:        _TraceType_name[0:2],
@@ -63,8 +63,8 @@ var _TraceType_map = map[TraceType]string{
 	2097152:  _TraceType_name[167:173],
 	4194304:  _TraceType_name[173:186],
 	8388608:  _TraceType_name[186:196],
-	16777216: _TraceType_name[196:205],
-	33554431: _TraceType_name[205:208],
+	16777216: _TraceType_name[196:211],
+	33554431: _TraceType_name[211:214],
 }
 
 func (i TraceType) String() string {


### PR DESCRIPTION
Rename `inventory` to `system inventory` in order to make the difference clear.