### PR TITLE
Added multiple search support for api names and bucket names

### DIFF
--- a/api-logs.go
+++ b/api-logs.go
@@ -34,18 +34,14 @@ import (
 
 // APILogOpts represents the options for the APILogOpts
 type APILogOpts struct {
-	Node         string        `json:"node,omitempty"`
-	API          string        `json:"api,omitempty"`
-	Bucket       string        `json:"bucket,omitempty"`
-	BucketPrefix string        `json:"bucketPrefix,omitempty"`
+	Nodes        []string      `json:"nodes,omitempty"`   // entries ending with "*" are prefix matches, otherwise exact match
+	APIs         []string      `json:"apis,omitempty"`    // entries ending with "*" are prefix matches, otherwise exact match
+	Buckets      []string      `json:"buckets,omitempty"` // entries ending with "*" are prefix matches, otherwise exact match
 	Prefix       string        `json:"prefix,omitempty"`
-	StatusCode   int           `json:"statusCode,omitempty"` // Deprecated: use StatusCodes/StatusRanges
 	StatusCodes  []int         `json:"statusCodes,omitempty"`
 	StatusRanges []string      `json:"statusRanges,omitempty"` // e.g. "2xx", "4xx", "5xx"
 	Interval     time.Duration `json:"interval,omitempty"`
-	Origin       log.Origin    `json:"origin,omitempty"` // Deprecated: use Origins
 	Origins      []log.Origin  `json:"origins,omitempty"`
-	Type         log.APIType   `json:"type,omitempty"` // Deprecated: use Types
 	Types        []log.APIType `json:"types,omitempty"`
 	MaxPerNode   int           `json:"maxPerNode,omitempty"` // Deprecated
 	Limit        int           `json:"limit,omitempty"`


### PR DESCRIPTION
Add APIs []string and Buckets []string to APILogOpts for multi-value  filtering. Both support case-insensitive matching: entries ending with "*" are prefix matches, otherwise substring match.    