### PR TITLE
feat: add multi-value filter fields to AuditLogOpts

### DIFF
--- a/api-logs.go
+++ b/api-logs.go
@@ -32,11 +32,21 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// APILogOpts represents the options for the APILogOpts
+// APILogOpts represents the options for fetching API logs.
+//
+// Wildcard syntax on Nodes / APIs / Buckets entries (case-insensitive):
+//
+//	"xyz"   → exact match
+//	"xyz*"  → prefix match
+//	"*xyz"  → suffix match
+//	"*xyz*" → contains match
+//	"*"     → matches anything
+//
+// Values within a single field OR-combine; across fields filters AND.
 type APILogOpts struct {
-	Nodes        []string      `json:"nodes,omitempty"`   // entries ending with "*" are prefix matches, otherwise exact match
-	APIs         []string      `json:"apis,omitempty"`    // entries ending with "*" are prefix matches, otherwise exact match
-	Buckets      []string      `json:"buckets,omitempty"` // entries ending with "*" are prefix matches, otherwise exact match
+	Nodes        []string      `json:"nodes,omitempty"`
+	APIs         []string      `json:"apis,omitempty"`
+	Buckets      []string      `json:"buckets,omitempty"`
 	Prefix       string        `json:"prefix,omitempty"`
 	StatusCodes  []int         `json:"statusCodes,omitempty"`
 	StatusRanges []string      `json:"statusRanges,omitempty"` // e.g. "2xx", "4xx", "5xx"

--- a/audit-logs.go
+++ b/audit-logs.go
@@ -34,12 +34,13 @@ import (
 
 // AuditLogOpts represents the options for the audit logs
 type AuditLogOpts struct {
-	Node       string            `json:"node,omitempty"`
-	API        string            `json:"api,omitempty"`
-	Bucket     string            `json:"bucket,omitempty"`
-	Interval   time.Duration     `json:"interval,omitempty"`
-	Category   log.AuditCategory `json:"category,omitempty"`
-	MaxPerNode int               `json:"maxPerNode,omitempty"`
+	Nodes      []string            `json:"nodes,omitempty"`   // entries ending with "*" are prefix matches, otherwise exact match
+	APIs       []string            `json:"apis,omitempty"`    // entries ending with "*" are prefix matches, otherwise exact match
+	Buckets    []string            `json:"buckets,omitempty"` // entries ending with "*" are prefix matches, otherwise exact match
+	Interval   time.Duration       `json:"interval,omitempty"`
+	Categories []log.AuditCategory `json:"categories,omitempty"`
+	MaxPerNode int                 `json:"maxPerNode,omitempty"` // Deprecated: use Limit
+	Limit      int                 `json:"limit,omitempty"`
 }
 
 // GetAuditLogs fetches the persisted audit logs from MinIO

--- a/audit-logs.go
+++ b/audit-logs.go
@@ -32,11 +32,21 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// AuditLogOpts represents the options for the audit logs
+// AuditLogOpts represents the options for the audit logs.
+//
+// Wildcard syntax on Nodes / APIs / Buckets entries (case-insensitive):
+//
+//	"xyz"   → exact match
+//	"xyz*"  → prefix match
+//	"*xyz"  → suffix match
+//	"*xyz*" → contains match
+//	"*"     → matches anything
+//
+// Values within a single field OR-combine; across fields filters AND.
 type AuditLogOpts struct {
-	Nodes      []string            `json:"nodes,omitempty"`   // entries ending with "*" are prefix matches, otherwise exact match
-	APIs       []string            `json:"apis,omitempty"`    // entries ending with "*" are prefix matches, otherwise exact match
-	Buckets    []string            `json:"buckets,omitempty"` // entries ending with "*" are prefix matches, otherwise exact match
+	Nodes      []string            `json:"nodes,omitempty"`
+	APIs       []string            `json:"apis,omitempty"`
+	Buckets    []string            `json:"buckets,omitempty"`
 	Interval   time.Duration       `json:"interval,omitempty"`
 	Categories []log.AuditCategory `json:"categories,omitempty"`
 	MaxPerNode int                 `json:"maxPerNode,omitempty"` // Deprecated: use Limit


### PR DESCRIPTION
Replace Node/API/Bucket/Category singletons on AuditLogOpts with
plural slice fields (Nodes/APIs/Buckets/Categories); within-field
OR, cross-field AND. MaxPerNode deprecated in favor of Limit.                                                                            
Mirrors the APILogOpts shape from #604.                                                                                                  
                                                                                                                                          
Wildcard syntax on Nodes/APIs/Buckets — for both AuditLogOpts                                                                            
and APILogOpts — now supports abc*, *abc, *abc*, and *  
(case-insensitive); bare values are exact matches.                                                                                                        
   
  Paired with [eos](https://github.com/miniohq/eos/pull/5254) + [ec](https://github.com/miniohq/ec/pull/523) PRs that consume the new shape.  
  
  Ref: https://github.com/miniohq/eos/issues/4967