### PR TITLE
feat: add multi-value filter fields to ErrorLogOpts

### DIFF
--- a/error-logs.go
+++ b/error-logs.go
@@ -50,6 +50,17 @@ type ErrorLogOpts struct {
 	Prefixes []string      `json:"prefixes,omitempty"`
 	Interval time.Duration `json:"interval,omitempty"`
 	Limit    int           `json:"limit,omitempty"`
+
+	// Deprecated: use Nodes.
+	Node string `json:"node,omitempty"`
+	// Deprecated: use APIs.
+	API string `json:"api,omitempty"`
+	// Deprecated: use Buckets.
+	Bucket string `json:"bucket,omitempty"`
+	// Deprecated: use Prefixes.
+	Prefix string `json:"prefix,omitempty"`
+	// Deprecated: use Limit.
+	MaxPerNode int `json:"maxPerNode,omitempty"`
 }
 
 // GetErrorLogs fetches the persisted error logs from MinIO

--- a/error-logs.go
+++ b/error-logs.go
@@ -32,14 +32,24 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// ErrorLogOpts represents the options for the ErrorLogs
+// ErrorLogOpts represents the options for the ErrorLogs.
+//
+// Wildcard syntax on Nodes / APIs / Buckets entries (case-insensitive):
+//
+//	"xyz"   → exact match
+//	"xyz*"  → prefix match
+//	"*xyz"  → suffix match
+//	"*xyz*" → contains match
+//	"*"     → matches anything
+//
+// Values within a single field OR-combine; across fields filters AND.
 type ErrorLogOpts struct {
-	Node       string        `json:"node,omitempty"`
-	API        string        `json:"api,omitempty"`
-	Bucket     string        `json:"bucket,omitempty"`
-	Prefix     string        `json:"prefix,omitempty"`
-	Interval   time.Duration `json:"interval,omitempty"`
-	MaxPerNode int           `json:"maxPerNode,omitempty"`
+	Nodes    []string      `json:"nodes,omitempty"`
+	APIs     []string      `json:"apis,omitempty"`
+	Buckets  []string      `json:"buckets,omitempty"`
+	Prefixes []string      `json:"prefixes,omitempty"`
+	Interval time.Duration `json:"interval,omitempty"`
+	Limit    int           `json:"limit,omitempty"`
 }
 
 // GetErrorLogs fetches the persisted error logs from MinIO


### PR DESCRIPTION
Replace singular node/api/bucket string fields with typed slices supporting wildcard syntax. Prefixes field added for object-key prefix filtering. Mirrors AuditLogOpts (PR #608).

Wildcard rules (case-insensitive within a field, OR-combined):
  "xyz"   → exact match
  "xyz*"  → prefix match
  "*xyz"  → suffix match
  "*xyz*" → contains match
  "*"     → matches anything

part of: https://github.com/miniohq/eos/issues/5312