### PR TITLE
feat: add OverwriteName to ClusterRegistrationReq

### DIFF
--- a/register.go
+++ b/register.go
@@ -20,9 +20,12 @@
 package madmin
 
 // ClusterRegistrationReq - JSON payload of the subnet api for cluster registration
-// Contains a registration token created by base64 encoding  of the registration info
+// Contains a registration token created by base64 encoding  of the registration info.
+// Set OverwriteName when the caller is reacting to an explicit name change
+// (so SUBNET replaces the stored name).
 type ClusterRegistrationReq struct {
-	Token string `json:"token"`
+	Token         string `json:"token"`
+	OverwriteName bool   `json:"overwrite_name,omitempty"`
 }
 
 // ClusterRegistrationInfo - Information stored in the cluster registration token

--- a/register.go
+++ b/register.go
@@ -21,8 +21,8 @@ package madmin
 
 // ClusterRegistrationReq - JSON payload of the subnet api for cluster registration
 // Contains a registration token created by base64 encoding  of the registration info.
-// Set OverwriteName when the caller is reacting to an explicit name change
-// (so SUBNET replaces the stored name).
+// OverwriteName ensures that SUBNET updates the cluster name with the one
+// configured on the cluster.
 type ClusterRegistrationReq struct {
 	Token         string `json:"token"`
 	OverwriteName bool   `json:"overwrite_name,omitempty"`


### PR DESCRIPTION
  Add `OverwriteName bool` to `ClusterRegistrationReq`. When set, it signals to SUBNET's `/api/cluster/register` handler that the caller wants the stored cluster name replaced with the one carried in the registration token.                                                                                                             
   
  `mc` has been carrying this field in a local override of the struct (`mc/cmd/license-register.go`). Promoting it to the canonical type so `mc`, `minio` server, and any future SDK consumer share a single definition. 
  
  ref: https://github.com/miniohq/subnet/issues/6293