### PR TITLE
tables: add replication resync sdk functions

### DIFF
--- a/tables-replication.go
+++ b/tables-replication.go
@@ -135,3 +135,43 @@ func (adm *AdminClient) TablesReplicationResetCatalog(ctx context.Context) error
 
 	return nil
 }
+
+// TablesReplicationResyncCatalogOpen enters the post-failover resyncing
+// window (phase 1 of post-failover) on this site.
+func (adm *AdminClient) TablesReplicationResyncCatalogOpen(ctx context.Context) error {
+	reqData := requestData{
+		relPath: adminAPIPrefix + "/tables/resync-catalog/open",
+	}
+
+	resp, err := adm.executeMethod(ctx, http.MethodPost, reqData)
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+
+	return nil
+}
+
+// TablesReplicationResyncCatalogRebuild signals the catalog scanner to run a
+// post-failover rebuild cycle. This is the second and final phase of post-failover.
+func (adm *AdminClient) TablesReplicationResyncCatalogRebuild(ctx context.Context) error {
+	reqData := requestData{
+		relPath: adminAPIPrefix + "/tables/resync-catalog/rebuild",
+	}
+
+	resp, err := adm.executeMethod(ctx, http.MethodPost, reqData)
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+
+	return nil
+}

--- a/tables-replication.go
+++ b/tables-replication.go
@@ -149,7 +149,7 @@ func (adm *AdminClient) TablesReplicationResyncCatalogOpen(ctx context.Context) 
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		return httpRespToErrorResponse(resp)
 	}
 
@@ -169,7 +169,7 @@ func (adm *AdminClient) TablesReplicationResyncCatalogRebuild(ctx context.Contex
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		return httpRespToErrorResponse(resp)
 	}
 


### PR DESCRIPTION
Adds SDK methods to invoke functionality in AIStor Tables, specifically resync the catalog after a failover event in a DR situation.