### PR TITLE
Add MetricsTables for Table IO stats

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -67,6 +67,7 @@ const (
 	MetricsHealing
 	MetricsBuckets
 	MetricsKMS
+	MetricsTables
 
 	// MetricsAll must be last.
 	// Enables all metrics.
@@ -105,6 +106,7 @@ func (m MetricType) String() string {
 	addIf(m.Contains(MetricsHealing), "Healing")
 	addIf(m.Contains(MetricsBuckets), "Buckets")
 	addIf(m.Contains(MetricsKMS), "KMS")
+	addIf(m.Contains(MetricsTables), "Tables")
 	return b.String()
 }
 
@@ -380,6 +382,7 @@ type Metrics struct {
 	Healing     *HealingMetrics     `json:"healing,omitempty"`
 	Buckets     *BucketAPIMetrics   `json:"buckets,omitempty"`
 	KMS         *KMSRtMetrics       `json:"kms,omitempty"`
+	Tables      *TableAPIMetrics    `json:"tables,omitempty"`
 }
 
 // Merge other into r.
@@ -456,6 +459,12 @@ func (r *Metrics) Merge(other *Metrics) {
 			r.KMS = &KMSRtMetrics{}
 		}
 		r.KMS.Merge(other.KMS)
+	}
+	if other.Tables != nil {
+		if r.Tables == nil {
+			r.Tables = &TableAPIMetrics{}
+		}
+		r.Tables.Merge(other.Tables)
 	}
 }
 
@@ -3331,6 +3340,98 @@ func (b *BucketAPIMetrics) Merge(other *BucketAPIMetrics) {
 		ab := b.Buckets[bucket]
 		ab.Merge(&ob)
 		b.Buckets[bucket] = ab
+	}
+}
+
+// TableIOStat holds read/write counts and byte totals for a
+// table over one time window.
+type TableIOStat struct {
+	Reads    int64 `json:"reads"    msg:"r"`
+	Writes   int64 `json:"writes"   msg:"w"`
+	BytesIn  int64 `json:"bytesIn"  msg:"bi"`
+	BytesOut int64 `json:"bytesOut" msg:"bo"`
+}
+
+// TableIOMetrics holds windowed traffic for a table across time windows.
+type TableIOMetrics struct {
+	// Warehouse is the warehouse this table belongs to.
+	Warehouse string `json:"warehouse,omitempty" msg:"wh,omitempty"`
+
+	// LastMinute is the aggregate over the last minute. Always present.
+	LastMinute *TableIOStat `json:"lastMinute,omitempty" msg:"m,omitempty"`
+
+	// LastHour is the aggregate over the last hour.
+	// Populated only when MetricsHourStats is requested.
+	LastHour *TableIOStat `json:"lastHour,omitempty" msg:"h,omitempty"`
+
+	// LastDay is the aggregate over the last 24 hours.
+	// Populated only when MetricsDayStats is requested.
+	LastDay *TableIOStat `json:"lastDay,omitempty" msg:"d,omitempty"`
+}
+
+// TableAPIMetrics holds traffic for all active tables aggregated across nodes.
+// Keyed by table UUID.
+type TableAPIMetrics struct {
+	// Tables maps table UUID to its consolidated windowed metrics.
+	Tables map[string]TableIOMetrics `json:"tables,omitempty" msg:"tables,omitempty"`
+}
+
+// Add sums other into t in place.
+func (t *TableIOStat) Add(other *TableIOStat) {
+	if other == nil {
+		return
+	}
+	t.Reads += other.Reads
+	t.Writes += other.Writes
+	t.BytesIn += other.BytesIn
+	t.BytesOut += other.BytesOut
+}
+
+// IsZero reports whether all counters are zero.
+func (t *TableIOStat) IsZero() bool {
+	return t.Reads == 0 && t.Writes == 0 && t.BytesIn == 0 && t.BytesOut == 0
+}
+
+// Merge sums other into m.
+func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
+	if other == nil {
+		return
+	}
+	if m.Warehouse == "" {
+		m.Warehouse = other.Warehouse
+	}
+	if other.LastMinute != nil {
+		if m.LastMinute == nil {
+			m.LastMinute = &TableIOStat{}
+		}
+		m.LastMinute.Add(other.LastMinute)
+	}
+	if other.LastHour != nil {
+		if m.LastHour == nil {
+			m.LastHour = &TableIOStat{}
+		}
+		m.LastHour.Add(other.LastHour)
+	}
+	if other.LastDay != nil {
+		if m.LastDay == nil {
+			m.LastDay = &TableIOStat{}
+		}
+		m.LastDay.Add(other.LastDay)
+	}
+}
+
+// Merge folds other into t by merging each per-table entry.
+func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
+	if other == nil {
+		return
+	}
+	for uuid, om := range other.Tables {
+		if t.Tables == nil {
+			t.Tables = make(map[string]TableIOMetrics, len(other.Tables))
+		}
+		am := t.Tables[uuid]
+		am.Merge(&om)
+		t.Tables[uuid] = am
 	}
 }
 

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -17945,7 +17945,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 16 bits */
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -18259,6 +18259,78 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
+		case "tables":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				z.Tables = nil
+			} else {
+				if z.Tables == nil {
+					z.Tables = new(TableAPIMetrics)
+				}
+				var zb0002 uint32
+				zb0002, err = dc.ReadMapHeader()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				for zb0002 > 0 {
+					zb0002--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						err = msgp.WrapError(err, "Tables")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "tables":
+						var zb0003 uint32
+						zb0003, err = dc.ReadMapHeader()
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						if z.Tables.Tables == nil {
+							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
+						} else if len(z.Tables.Tables) > 0 {
+							clear(z.Tables.Tables)
+						}
+						for zb0003 > 0 {
+							zb0003--
+							var za0001 string
+							za0001, err = dc.ReadString()
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables")
+								return
+							}
+							var za0002 TableIOMetrics
+							err = za0002.DecodeMsg(dc)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables", za0001)
+								return
+							}
+							z.Tables.Tables[za0001] = za0002
+						}
+						zb0002Mask |= 0x1
+					default:
+						err = dc.Skip()
+						if err != nil {
+							err = msgp.WrapError(err, "Tables")
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if (zb0002Mask & 0x1) == 0 {
+					z.Tables.Tables = nil
+				}
+
+			}
+			zb0001Mask |= 0x10000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -18268,7 +18340,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xffff {
+	if zb0001Mask != 0x1ffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -18317,6 +18389,9 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x8000) == 0 {
 			z.KMS = nil
 		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.Tables = nil
+		}
 	}
 	return
 }
@@ -18324,8 +18399,8 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(16)
-	var zb0001Mask uint16 /* 16 bits */
+	zb0001Len := uint32(17)
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -18390,6 +18465,10 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.KMS == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
+	}
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10000
 	}
 	// variable map header, size zb0001Len
 	err = en.WriteMapHeader(zb0001Len)
@@ -18703,6 +18782,57 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// write "tables"
+			err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			if z.Tables == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				// check for omitted fields
+				zb0002Len := uint32(1)
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				if z.Tables.Tables == nil {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				// variable map header, size zb0002Len
+				err = en.Append(0x80 | uint8(zb0002Len))
+				if err != nil {
+					return
+				}
+				if (zb0002Mask & 0x1) == 0 { // if not omitted
+					// write "tables"
+					err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+					if err != nil {
+						return
+					}
+					err = en.WriteMapHeader(uint32(len(z.Tables.Tables)))
+					if err != nil {
+						err = msgp.WrapError(err, "Tables", "Tables")
+						return
+					}
+					for za0001, za0002 := range z.Tables.Tables {
+						err = en.WriteString(za0001)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						err = za0002.EncodeMsg(en)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables", za0001)
+							return
+						}
+					}
+				}
+			}
+		}
 	}
 	return
 }
@@ -18711,8 +18841,8 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(16)
-	var zb0001Mask uint16 /* 16 bits */
+	zb0001Len := uint32(17)
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -18777,6 +18907,10 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.KMS == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
+	}
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10000
 	}
 	// variable map header, size zb0001Len
 	o = msgp.AppendMapHeader(o, zb0001Len)
@@ -18991,6 +19125,37 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// string "tables"
+			o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+			if z.Tables == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				// check for omitted fields
+				zb0002Len := uint32(1)
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				if z.Tables.Tables == nil {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				// variable map header, size zb0002Len
+				o = append(o, 0x80|uint8(zb0002Len))
+				if (zb0002Mask & 0x1) == 0 { // if not omitted
+					// string "tables"
+					o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+					o = msgp.AppendMapHeader(o, uint32(len(z.Tables.Tables)))
+					for za0001, za0002 := range z.Tables.Tables {
+						o = msgp.AppendString(o, za0001)
+						o, err = za0002.MarshalMsg(o)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables", za0001)
+							return
+						}
+					}
+				}
+			}
+		}
 	}
 	return
 }
@@ -19005,7 +19170,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 16 bits */
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -19303,6 +19468,77 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
+		case "tables":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Tables = nil
+			} else {
+				if z.Tables == nil {
+					z.Tables = new(TableAPIMetrics)
+				}
+				var zb0002 uint32
+				zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				for zb0002 > 0 {
+					zb0002--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Tables")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "tables":
+						var zb0003 uint32
+						zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						if z.Tables.Tables == nil {
+							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
+						} else if len(z.Tables.Tables) > 0 {
+							clear(z.Tables.Tables)
+						}
+						for zb0003 > 0 {
+							var za0002 TableIOMetrics
+							zb0003--
+							var za0001 string
+							za0001, bts, err = msgp.ReadStringBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables")
+								return
+							}
+							bts, err = za0002.UnmarshalMsg(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables", za0001)
+								return
+							}
+							z.Tables.Tables[za0001] = za0002
+						}
+						zb0002Mask |= 0x1
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables")
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if (zb0002Mask & 0x1) == 0 {
+					z.Tables.Tables = nil
+				}
+
+			}
+			zb0001Mask |= 0x10000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -19312,7 +19548,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xffff {
+	if zb0001Mask != 0x1ffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -19360,6 +19596,9 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if (zb0001Mask & 0x8000) == 0 {
 			z.KMS = nil
+		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.Tables = nil
 		}
 	}
 	o = bts
@@ -19463,6 +19702,18 @@ func (z *Metrics) Msgsize() (s int) {
 		s += msgp.NilSize
 	} else {
 		s += z.KMS.Msgsize()
+	}
+	s += 7
+	if z.Tables == nil {
+		s += msgp.NilSize
+	} else {
+		s += 1 + 7 + msgp.MapHeaderSize
+		if z.Tables.Tables != nil {
+			for za0001, za0002 := range z.Tables.Tables {
+				_ = za0002
+				s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
+			}
+		}
 	}
 	return
 }
@@ -36893,6 +37144,818 @@ func (z *SiteResyncMetrics) Msgsize() (s int) {
 		s += msgp.StringPrefixSize + len(z.FailedBuckets[za0001])
 	}
 	s += 7 + msgp.StringPrefixSize + len(z.Bucket) + 7 + msgp.StringPrefixSize + len(z.Object)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableAPIMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "tables":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			if z.Tables == nil {
+				z.Tables = make(map[string]TableIOMetrics, zb0002)
+			} else if len(z.Tables) > 0 {
+				clear(z.Tables)
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var za0002 TableIOMetrics
+				err = za0002.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables", za0001)
+					return
+				}
+				z.Tables[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if (zb0001Mask & 0x1) == 0 {
+		z.Tables = nil
+	}
+
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(1)
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+	if (zb0001Mask & 0x1) == 0 { // if not omitted
+		// write "tables"
+		err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteMapHeader(uint32(len(z.Tables)))
+		if err != nil {
+			err = msgp.WrapError(err, "Tables")
+			return
+		}
+		for za0001, za0002 := range z.Tables {
+			err = en.WriteString(za0001)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			err = za0002.EncodeMsg(en)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(1)
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+	if (zb0001Mask & 0x1) == 0 { // if not omitted
+		// string "tables"
+		o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+		o = msgp.AppendMapHeader(o, uint32(len(z.Tables)))
+		for za0001, za0002 := range z.Tables {
+			o = msgp.AppendString(o, za0001)
+			o, err = za0002.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableAPIMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "tables":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			if z.Tables == nil {
+				z.Tables = make(map[string]TableIOMetrics, zb0002)
+			} else if len(z.Tables) > 0 {
+				clear(z.Tables)
+			}
+			for zb0002 > 0 {
+				var za0002 TableIOMetrics
+				zb0002--
+				var za0001 string
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				bts, err = za0002.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables", za0001)
+					return
+				}
+				z.Tables[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if (zb0001Mask & 0x1) == 0 {
+		z.Tables = nil
+	}
+
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableAPIMetrics) Msgsize() (s int) {
+	s = 1 + 7 + msgp.MapHeaderSize
+	if z.Tables != nil {
+		for za0001, za0002 := range z.Tables {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "warehouse":
+			z.Warehouse, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "lastMinute":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableIOStat)
+				}
+				err = z.LastMinute.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(TableIOStat)
+				}
+				err = z.LastHour.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(TableIOStat)
+				}
+				err = z.LastDay.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Warehouse = ""
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastDay = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.Warehouse == "" {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "warehouse"
+			err = en.Append(0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(z.Warehouse)
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "lastMinute"
+			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if err != nil {
+				return
+			}
+			if z.LastMinute == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastMinute.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastHour.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastDay.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.Warehouse == "" {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "warehouse"
+			o = append(o, 0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+			o = msgp.AppendString(o, z.Warehouse)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "lastMinute"
+			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if z.LastMinute == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastMinute.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastHour.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastDay.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "warehouse":
+			z.Warehouse, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "lastMinute":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableIOStat)
+				}
+				bts, err = z.LastMinute.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(TableIOStat)
+				}
+				bts, err = z.LastHour.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(TableIOStat)
+				}
+				bts, err = z.LastDay.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Warehouse = ""
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastDay = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableIOMetrics) Msgsize() (s int) {
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.Warehouse) + 11
+	if z.LastMinute == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastMinute.Msgsize()
+	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastHour.Msgsize()
+	}
+	s += 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastDay.Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableIOStat) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+		case "writes":
+			z.Writes, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+		case "bytesIn":
+			z.BytesIn, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		case "bytesOut":
+			z.BytesOut, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableIOStat) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "reads"
+	err = en.Append(0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Reads)
+	if err != nil {
+		err = msgp.WrapError(err, "Reads")
+		return
+	}
+	// write "writes"
+	err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Writes)
+	if err != nil {
+		err = msgp.WrapError(err, "Writes")
+		return
+	}
+	// write "bytesIn"
+	err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.BytesIn)
+	if err != nil {
+		err = msgp.WrapError(err, "BytesIn")
+		return
+	}
+	// write "bytesOut"
+	err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.BytesOut)
+	if err != nil {
+		err = msgp.WrapError(err, "BytesOut")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableIOStat) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "reads"
+	o = append(o, 0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+	o = msgp.AppendInt64(o, z.Reads)
+	// string "writes"
+	o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+	o = msgp.AppendInt64(o, z.Writes)
+	// string "bytesIn"
+	o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+	o = msgp.AppendInt64(o, z.BytesIn)
+	// string "bytesOut"
+	o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+	o = msgp.AppendInt64(o, z.BytesOut)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableIOStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+		case "writes":
+			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+		case "bytesIn":
+			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		case "bytesOut":
+			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableIOStat) Msgsize() (s int) {
+	s = 1 + 6 + msgp.Int64Size + 7 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Int64Size
 	return
 }
 

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -6563,6 +6563,345 @@ func BenchmarkDecodeSiteResyncMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalTableAPIMetrics(t *testing.T) {
+	v := TableAPIMetrics{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableAPIMetrics(t *testing.T) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableAPIMetrics Msgsize() is inaccurate")
+	}
+
+	vn := TableAPIMetrics{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTableIOMetrics(t *testing.T) {
+	v := TableIOMetrics{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableIOMetrics(t *testing.T) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableIOMetrics Msgsize() is inaccurate")
+	}
+
+	vn := TableIOMetrics{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTableIOStat(t *testing.T) {
+	v := TableIOStat{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableIOStat(t *testing.T) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableIOStat Msgsize() is inaccurate")
+	}
+
+	vn := TableIOStat{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTotalMinMaxUint64(t *testing.T) {
 	v := TotalMinMaxUint64{}
 	bts, err := v.MarshalMsg(nil)


### PR DESCRIPTION
 This PR adds support for tracking which Iceberg tables are getting the most traffic across the cluster — reads, writes, and bytes transferred over three time windows: last minute, last hour, and last 24 hours.

  A new metric flag (MetricsTableWindowed) so a node requesting metrics from its peers can ask specifically for table traffic data

```
  TableIOStat      — raw read/write/byte counters for one time window
  TableIOMetrics   — one table's traffic: warehouse + LastMinute/LastHour/LastDay
  TableAPIMetrics  — all active tables keyed by UUID; 
```