### PR TITLE
feat(health): add IAMInfo health-data section

### DIFF
--- a/health.go
+++ b/health.go
@@ -1420,6 +1420,19 @@ type ShardsHealthInfo struct {
 	FailedWrites map[string]map[string][]uint64 `json:"failed_writes,omitempty"`
 }
 
+// IAMPolicyDiag holds per-policy diagnostic findings.
+type IAMPolicyDiag struct {
+	UnsafeConditionKeys []string `json:"unsafe_condition_keys,omitempty"`
+}
+
+// IAMInfo carries IAM diagnostics. TotalPolicies is the count of policies
+// inspected; FlaggedPolicies lists only those with at least one finding.
+type IAMInfo struct {
+	Error           string                   `json:"error,omitempty"`
+	TotalPolicies   int                      `json:"total_policies,omitempty"`
+	FlaggedPolicies map[string]IAMPolicyDiag `json:"flagged_policies,omitempty"`
+}
+
 // MinioHealthInfo - Includes MinIO confifuration information
 type MinioHealthInfo struct {
 	Error string `json:"error,omitempty"`
@@ -1429,6 +1442,7 @@ type MinioHealthInfo struct {
 	Replication     *ReplDiagInfo     `json:"replication,omitempty"` // Deprecated May 2025
 	ReplicationInfo *ReplDiagInfoV2   `json:"replication_info,omitempty"`
 	ShardsHealth    *ShardsHealthInfo `json:"shards_health,omitempty"`
+	IAMInfo         *IAMInfo          `json:"iam_info,omitempty"`
 }
 
 // HealthInfo - MinIO cluster's health Info
@@ -1495,6 +1509,7 @@ const (
 	HealthDataTypeSysProductInfo HealthDataType = "sysproductinfo"
 	HealthDataTypeReplication    HealthDataType = "replication"
 	HealthDataTypeShardsHealth   HealthDataType = "shardshealth"
+	HealthDataTypeIAMInfo        HealthDataType = "iaminfo"
 )
 
 // HealthDataTypesMap - Map of Health datatypes
@@ -1513,6 +1528,7 @@ var HealthDataTypesMap = map[string]HealthDataType{
 	"sysproductinfo": HealthDataTypeSysProductInfo,
 	"replication":    HealthDataTypeReplication,
 	"shardshealth":   HealthDataTypeShardsHealth,
+	"iaminfo":        HealthDataTypeIAMInfo,
 }
 
 // HealthDataTypesList - List of health datatypes
@@ -1531,6 +1547,7 @@ var HealthDataTypesList = []HealthDataType{
 	HealthDataTypeSysProductInfo,
 	HealthDataTypeReplication,
 	HealthDataTypeShardsHealth,
+	HealthDataTypeIAMInfo,
 }
 
 // HealthInfoVersionStruct - struct for health info version


### PR DESCRIPTION
## Summary                                                                                                                                 
  New `iaminfo` health data type carrying per-policy IAM findings, for                                                             
  analysis by health-analyzer (e.g. flagging policies that use unsafe condition                                                              
  keys like `aws:Referer` / `aws:SourceIp` / `aws:UserAgent`).                                                                               
                                                                                                                                             
  Shape mirrors `SRPolicyStatsSummary`: `map[name]IAMPolicyDiag` with one named                                                              
  field per finding, so future audits can be added without breaking the wire                                                                 
  format. Only flagged policies appear in the map; `TotalPolicies` carries the                                                               
  denominator.                                                                                                                               

 Ref: https://github.com/miniohq/health-analyzer/issues/350   

  ## How to test?                                                                                                                                                                                                                                           
                                                                                                                                             
  1. Build minio from [eos#5537](https://github.com/miniohq/eos/pull/5537) and mc from [ec#537](https://github.com/miniohq/ec/pull/537).
  2. Add a policy using an unsafe condition key:                                                                                             
     `mc admin policy create myminio unsafe ./unsafe.json`                                                                                     
  3. Capture a diag and inspect the new section:
     `mc support diag myminio --airgap`                                                                                                        
    ` jq '.minio.iam_info' diag-data-*.json`                                                                                                   
 
 Sample unsafe.json:
 ```json                                                                                                                                  
  {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Effect": "Allow",
        "Action": "s3:GetObject",                                                                                                            
        "Resource": "arn:aws:s3:::my-bucket/*",
        "Condition": {                                                                                                                       
          "StringLike": { "aws:Referer": "https://myapp.example.com/*" }                                                                   
        }                                                                                                                                    
      },
      {                                                                                                                                      
        "Effect": "Allow",                                                                                                                 
        "Action": "s3:PutObject",
        "Resource": "arn:aws:s3:::my-bucket/*",
        "Condition": {                                                                                                                       
          "StringEquals": { "aws:UserAgent": "MyTrustedApp/1.0" }
        }                                                                                                                                    
      },                                                                                                                                     
      {
        "Effect": "Allow",                                                                                                                   
        "Action": "s3:*",                                                                                                                  
        "Resource": "arn:aws:s3:::my-bucket/*",
        "Condition": {
          "IpAddress": { "aws:SourceIp": "0.0.0.0/0" }                                                                                       
        }
      },                                                                                                                                     
      {                                                                                                                                    
        "Effect": "Allow",
        "Action": "s3:GetObject",
        "Resource": "arn:aws:s3:::my-bucket/*",                                                                                              
        "Condition": {
          "Bool": { "aws:SecureTransport": "false" }                                                                                         
        }                                                                                                                                  
      }                                                                                                                                      
    ]
  }                                                                                                                                          
  ``` 
  
  Expected `iam_info.flagged_policies`:

  ```json
  "flagged_policies": {
    "unsafe": {
      "unsafe_condition_keys": ["aws:Referer", "aws:SourceIp", "aws:UserAgent"]
    }                                                                                                                                        
  }
  ```                                                                                                                                        
 
<img width="333" height="174" alt="image" src="https://github.com/user-attachments/assets/9524d523-7815-44d0-8ee6-1701ce89a611" />
                                                                                                                                          
  `aws:SecureTransport` is intentionally ignored — it's a defensive condition, not a risky one. 
  All clean → policies field omitted, just total_policies. Section absent when iaminfo not requested.
                                                                                                                                             
  Compatibility:                                                                                                                                                                                                                                                                  
  Purely additive: new constant, new optional struct, new pointer field on                                                                 
  MinioHealthInfo. Older consumers ignore unknown JSON keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cluster health reporting now includes IAM diagnostics support
  * Health checks can identify and report flagged IAM policies with potential security concerns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->