### PR TITLE
feat: add D-state threads diag for mc support diag

### DIFF
--- a/health-dstate-threads.go
+++ b/health-dstate-threads.go
@@ -50,17 +50,17 @@ type DStateThreadGroup struct {
 	Samples    []DStateThreadInfo `json:"samples,omitempty"`
 }
 
-// DStateThreadsDiag is the per-node snapshot of threads in
-// uninterruptible disk sleep, captured by `mc support diag`.
+// DStateThreadsDiag is the per-process snapshot of threads in
+// uninterruptible disk sleep, captured by `mc support diag`. Embedded
+// inside ProcInfo (the process owns its threads); per-node identity
+// comes from the parent ProcInfo's NodeCommon.
 //
-// StuckTotal is the alertable number (Total can be non-zero on a healthy
-// box doing I/O). TotalThreads gives saturation context for dense nodes.
-// WindowSeconds bounds DwellSeconds — a thread reporting
+// StuckTotal is the alertable number (Total can be non-zero on a
+// healthy box doing I/O). TotalThreads gives saturation context for
+// dense nodes. WindowSeconds bounds DwellSeconds — a thread reporting
 // DwellSeconds == WindowSeconds has been in D for at least the entire
 // ring window.
 type DStateThreadsDiag struct {
-	NodeCommon
-
 	Total                 int                 `json:"total"`
 	StuckTotal            int                 `json:"stuck_total,omitempty"`
 	TotalThreads          int                 `json:"total_threads,omitempty"`

--- a/health-dstate-threads.go
+++ b/health-dstate-threads.go
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+// DStateThreadInfo - identifies a single thread caught in uninterruptible
+// disk sleep ("D" state) along with the kernel symbol it was blocked on
+// (wchan) and its kernel stack at the moment of capture.
+type DStateThreadInfo struct {
+	TID   int    `json:"tid"`
+	Name  string `json:"name,omitempty"`
+	Wchan string `json:"wchan,omitempty"`
+	Stack string `json:"stack,omitempty"`
+}
+
+// DStateThreadGroup - groups D-state threads by their shared wchan, with a
+// representative sample of full stacks. Group sizes give an at-a-glance view
+// of where threads are stuck cluster-wide.
+type DStateThreadGroup struct {
+	Wchan   string             `json:"wchan"`
+	Count   int                `json:"count"`
+	Samples []DStateThreadInfo `json:"samples,omitempty"`
+}
+
+// DStateThreadsDiag - per-node snapshot of threads currently in
+// uninterruptible disk sleep, captured as part of `mc support diag`. Helps
+// engineers debugging a stuck cluster see where threads are blocked without
+// requiring SSH access.
+type DStateThreadsDiag struct {
+	NodeCommon
+
+	Total  int                 `json:"total"`
+	Groups []DStateThreadGroup `json:"groups,omitempty"`
+}

--- a/health-dstate-threads.go
+++ b/health-dstate-threads.go
@@ -42,9 +42,18 @@ type DStateThreadGroup struct {
 // uninterruptible disk sleep, captured as part of `mc support diag`. Helps
 // engineers debugging a stuck cluster see where threads are blocked without
 // requiring SSH access.
+//
+// Total is the number of threads in D state at sample time. TotalThreads is
+// the size of the per-thread enumeration the sample was drawn from (i.e. all
+// threads in the MinIO process, regardless of state). The ratio
+// Total/TotalThreads gives consumers a sense of how saturated the process
+// is — a handful of momentarily D-state threads on a dense node with
+// thousands of threads is qualitatively different from the same absolute
+// count on a small node.
 type DStateThreadsDiag struct {
 	NodeCommon
 
-	Total  int                 `json:"total"`
-	Groups []DStateThreadGroup `json:"groups,omitempty"`
+	Total        int                 `json:"total"`
+	TotalThreads int                 `json:"total_threads,omitempty"`
+	Groups       []DStateThreadGroup `json:"groups,omitempty"`
 }

--- a/health-dstate-threads.go
+++ b/health-dstate-threads.go
@@ -22,20 +22,42 @@ package madmin
 // DStateThreadInfo - identifies a single thread caught in uninterruptible
 // disk sleep ("D" state) along with the kernel symbol it was blocked on
 // (wchan) and its kernel stack at the moment of capture.
+//
+// Starttime is the kernel-reported thread start time in clock ticks since
+// boot (field 22 of /proc/<tid>/stat); together with TID it forms a stable
+// identity that survives PID/TID reuse over the dwell-history window.
+//
+// DwellSeconds is the minimum continuous time the thread has been in D state
+// on the same wchan, derived from consecutive ring-buffer samples on the
+// server. BlkIOSecondsInWindow is the cumulative block-I/O wait that
+// accumulated during that same window (delayacct_blkio_ticks delta), a
+// corroborating signal that the thread was actually waiting on I/O the
+// whole time rather than just unlucky-at-sample.
+//
+// Stuck is true when DwellSeconds >= the server-side threshold; it is the
+// single boolean consumers (health-analyzer, dashboards) should key off
+// of so the threshold definition lives in one place.
 type DStateThreadInfo struct {
-	TID   int    `json:"tid"`
-	Name  string `json:"name,omitempty"`
-	Wchan string `json:"wchan,omitempty"`
-	Stack string `json:"stack,omitempty"`
+	TID                  int     `json:"tid"`
+	Starttime            uint64  `json:"starttime,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	Wchan                string  `json:"wchan,omitempty"`
+	DwellSeconds         int     `json:"dwell_seconds,omitempty"`
+	BlkIOSecondsInWindow float64 `json:"blkio_seconds_in_window,omitempty"`
+	Stuck                bool    `json:"stuck,omitempty"`
+	Stack                string  `json:"stack,omitempty"`
 }
 
 // DStateThreadGroup - groups D-state threads by their shared wchan, with a
-// representative sample of full stacks. Group sizes give an at-a-glance view
+// representative sample of full stacks. Count is the total threads currently
+// in this wchan bucket; StuckCount is the subset of those whose DwellSeconds
+// crossed the server's stuck threshold. Group sizes give an at-a-glance view
 // of where threads are stuck cluster-wide.
 type DStateThreadGroup struct {
-	Wchan   string             `json:"wchan"`
-	Count   int                `json:"count"`
-	Samples []DStateThreadInfo `json:"samples,omitempty"`
+	Wchan      string             `json:"wchan"`
+	Count      int                `json:"count"`
+	StuckCount int                `json:"stuck_count,omitempty"`
+	Samples    []DStateThreadInfo `json:"samples,omitempty"`
 }
 
 // DStateThreadsDiag - per-node snapshot of threads currently in
@@ -43,17 +65,24 @@ type DStateThreadGroup struct {
 // engineers debugging a stuck cluster see where threads are blocked without
 // requiring SSH access.
 //
-// Total is the number of threads in D state at sample time. TotalThreads is
-// the size of the per-thread enumeration the sample was drawn from (i.e. all
-// threads in the MinIO process, regardless of state). The ratio
-// Total/TotalThreads gives consumers a sense of how saturated the process
-// is — a handful of momentarily D-state threads on a dense node with
-// thousands of threads is qualitatively different from the same absolute
-// count on a small node.
+// Total is the number of threads in D state at sample time. StuckTotal is
+// the subset whose DwellSeconds has crossed StuckThresholdSeconds and is
+// the count to alert on. TotalThreads is the size of the per-thread
+// enumeration the sample was drawn from (i.e. all threads in the MinIO
+// process, regardless of state); Total/TotalThreads gives saturation
+// context for dense nodes.
+//
+// WindowSeconds reports how far back the server's dwell ring buffer
+// covered when this snapshot was built — DwellSeconds for any thread is
+// capped at this value, so a thread with DwellSeconds == WindowSeconds
+// has been in D for at least the entire ring window.
 type DStateThreadsDiag struct {
 	NodeCommon
 
-	Total        int                 `json:"total"`
-	TotalThreads int                 `json:"total_threads,omitempty"`
-	Groups       []DStateThreadGroup `json:"groups,omitempty"`
+	Total                 int                 `json:"total"`
+	StuckTotal            int                 `json:"stuck_total,omitempty"`
+	TotalThreads          int                 `json:"total_threads,omitempty"`
+	WindowSeconds         int                 `json:"window_seconds,omitempty"`
+	StuckThresholdSeconds int                 `json:"stuck_threshold_seconds,omitempty"`
+	Groups                []DStateThreadGroup `json:"groups,omitempty"`
 }

--- a/health-dstate-threads.go
+++ b/health-dstate-threads.go
@@ -19,24 +19,16 @@
 
 package madmin
 
-// DStateThreadInfo - identifies a single thread caught in uninterruptible
-// disk sleep ("D" state) along with the kernel symbol it was blocked on
-// (wchan) and its kernel stack at the moment of capture.
+// DStateThreadInfo - one thread caught in uninterruptible disk sleep.
 //
-// Starttime is the kernel-reported thread start time in clock ticks since
-// boot (field 22 of /proc/<tid>/stat); together with TID it forms a stable
-// identity that survives PID/TID reuse over the dwell-history window.
+// Starttime is the kernel-reported start time in clock ticks (proc stat
+// field 22); pairing it with TID gives a stable identity even when TIDs
+// are reused over the server's dwell-history window.
 //
-// DwellSeconds is the minimum continuous time the thread has been in D state
-// on the same wchan, derived from consecutive ring-buffer samples on the
-// server. BlkIOSecondsInWindow is the cumulative block-I/O wait that
-// accumulated during that same window (delayacct_blkio_ticks delta), a
-// corroborating signal that the thread was actually waiting on I/O the
-// whole time rather than just unlucky-at-sample.
-//
-// Stuck is true when DwellSeconds >= the server-side threshold; it is the
-// single boolean consumers (health-analyzer, dashboards) should key off
-// of so the threshold definition lives in one place.
+// DwellSeconds is the minimum continuous time the thread has been in D
+// on the same wchan. BlkIOSecondsInWindow is the corroborating
+// delayacct_blkio_ticks delta. Stuck is the server-thresholded boolean
+// so consumers don't redefine "stuck" locally.
 type DStateThreadInfo struct {
 	TID                  int     `json:"tid"`
 	Starttime            uint64  `json:"starttime,omitempty"`
@@ -48,11 +40,9 @@ type DStateThreadInfo struct {
 	Stack                string  `json:"stack,omitempty"`
 }
 
-// DStateThreadGroup - groups D-state threads by their shared wchan, with a
-// representative sample of full stacks. Count is the total threads currently
-// in this wchan bucket; StuckCount is the subset of those whose DwellSeconds
-// crossed the server's stuck threshold. Group sizes give an at-a-glance view
-// of where threads are stuck cluster-wide.
+// DStateThreadGroup groups D-state threads sharing a wchan. Count is all
+// threads currently in this bucket; StuckCount is the subset past the
+// server's dwell threshold.
 type DStateThreadGroup struct {
 	Wchan      string             `json:"wchan"`
 	Count      int                `json:"count"`
@@ -60,22 +50,14 @@ type DStateThreadGroup struct {
 	Samples    []DStateThreadInfo `json:"samples,omitempty"`
 }
 
-// DStateThreadsDiag - per-node snapshot of threads currently in
-// uninterruptible disk sleep, captured as part of `mc support diag`. Helps
-// engineers debugging a stuck cluster see where threads are blocked without
-// requiring SSH access.
+// DStateThreadsDiag is the per-node snapshot of threads in
+// uninterruptible disk sleep, captured by `mc support diag`.
 //
-// Total is the number of threads in D state at sample time. StuckTotal is
-// the subset whose DwellSeconds has crossed StuckThresholdSeconds and is
-// the count to alert on. TotalThreads is the size of the per-thread
-// enumeration the sample was drawn from (i.e. all threads in the MinIO
-// process, regardless of state); Total/TotalThreads gives saturation
-// context for dense nodes.
-//
-// WindowSeconds reports how far back the server's dwell ring buffer
-// covered when this snapshot was built — DwellSeconds for any thread is
-// capped at this value, so a thread with DwellSeconds == WindowSeconds
-// has been in D for at least the entire ring window.
+// StuckTotal is the alertable number (Total can be non-zero on a healthy
+// box doing I/O). TotalThreads gives saturation context for dense nodes.
+// WindowSeconds bounds DwellSeconds — a thread reporting
+// DwellSeconds == WindowSeconds has been in D for at least the entire
+// ring window.
 type DStateThreadsDiag struct {
 	NodeCommon
 

--- a/health.go
+++ b/health.go
@@ -1276,17 +1276,18 @@ func (p *ProcInfo) AddProcInfo(metrics *ProcessMetrics) {
 
 // SysInfo - Includes hardware and system information of the MinIO cluster
 type SysInfo struct {
-	CPUInfo        []CPUs         `json:"cpus,omitempty"`
-	Partitions     []Partitions   `json:"partitions,omitempty"`
-	OSInfo         []OSInfo       `json:"osinfo,omitempty"`
-	MemInfo        []MemInfo      `json:"meminfo,omitempty"`
-	ProcInfo       []ProcInfo     `json:"procinfo,omitempty"`
-	NetInfo        []NetInfo      `json:"netinfo,omitempty"`
-	SysErrs        []SysErrors    `json:"errors,omitempty"`
-	SysServices    []SysServices  `json:"services,omitempty"`
-	SysConfig      []SysConfig    `json:"config,omitempty"`
-	ProductInfo    []ProductInfo  `json:"productinfo,omitempty"`
-	KubernetesInfo KubernetesInfo `json:"kubernetes"`
+	CPUInfo        []CPUs              `json:"cpus,omitempty"`
+	Partitions     []Partitions        `json:"partitions,omitempty"`
+	OSInfo         []OSInfo            `json:"osinfo,omitempty"`
+	MemInfo        []MemInfo           `json:"meminfo,omitempty"`
+	ProcInfo       []ProcInfo          `json:"procinfo,omitempty"`
+	NetInfo        []NetInfo           `json:"netinfo,omitempty"`
+	SysErrs        []SysErrors         `json:"errors,omitempty"`
+	SysServices    []SysServices       `json:"services,omitempty"`
+	SysConfig      []SysConfig         `json:"config,omitempty"`
+	ProductInfo    []ProductInfo       `json:"productinfo,omitempty"`
+	DStateThreads  []DStateThreadsDiag `json:"dstate_threads,omitempty"`
+	KubernetesInfo KubernetesInfo      `json:"kubernetes"`
 }
 
 // DeploymentInfo contains diagnostic information about the AIStor deployment
@@ -1481,38 +1482,40 @@ type HealthDataType string
 
 // HealthDataTypes
 const (
-	HealthDataTypeMinioInfo      HealthDataType = "minioinfo"
-	HealthDataTypeMinioConfig    HealthDataType = "minioconfig"
-	HealthDataTypeSysCPU         HealthDataType = "syscpu"
-	HealthDataTypeSysDriveHw     HealthDataType = "sysdrivehw"
-	HealthDataTypeSysOsInfo      HealthDataType = "sysosinfo"
-	HealthDataTypeSysMem         HealthDataType = "sysmem"
-	HealthDataTypeSysNet         HealthDataType = "sysnet"
-	HealthDataTypeSysProcess     HealthDataType = "sysprocess"
-	HealthDataTypeSysErrors      HealthDataType = "syserrors"
-	HealthDataTypeSysServices    HealthDataType = "sysservices"
-	HealthDataTypeSysConfig      HealthDataType = "sysconfig"
-	HealthDataTypeSysProductInfo HealthDataType = "sysproductinfo"
-	HealthDataTypeReplication    HealthDataType = "replication"
-	HealthDataTypeShardsHealth   HealthDataType = "shardshealth"
+	HealthDataTypeMinioInfo        HealthDataType = "minioinfo"
+	HealthDataTypeMinioConfig      HealthDataType = "minioconfig"
+	HealthDataTypeSysCPU           HealthDataType = "syscpu"
+	HealthDataTypeSysDriveHw       HealthDataType = "sysdrivehw"
+	HealthDataTypeSysOsInfo        HealthDataType = "sysosinfo"
+	HealthDataTypeSysMem           HealthDataType = "sysmem"
+	HealthDataTypeSysNet           HealthDataType = "sysnet"
+	HealthDataTypeSysProcess       HealthDataType = "sysprocess"
+	HealthDataTypeSysErrors        HealthDataType = "syserrors"
+	HealthDataTypeSysServices      HealthDataType = "sysservices"
+	HealthDataTypeSysConfig        HealthDataType = "sysconfig"
+	HealthDataTypeSysProductInfo   HealthDataType = "sysproductinfo"
+	HealthDataTypeReplication      HealthDataType = "replication"
+	HealthDataTypeShardsHealth     HealthDataType = "shardshealth"
+	HealthDataTypeSysDStateThreads HealthDataType = "sysdstatethreads"
 )
 
 // HealthDataTypesMap - Map of Health datatypes
 var HealthDataTypesMap = map[string]HealthDataType{
-	"minioinfo":      HealthDataTypeMinioInfo,
-	"minioconfig":    HealthDataTypeMinioConfig,
-	"syscpu":         HealthDataTypeSysCPU,
-	"sysdrivehw":     HealthDataTypeSysDriveHw,
-	"sysosinfo":      HealthDataTypeSysOsInfo,
-	"sysmem":         HealthDataTypeSysMem,
-	"sysnet":         HealthDataTypeSysNet,
-	"sysprocess":     HealthDataTypeSysProcess,
-	"syserrors":      HealthDataTypeSysErrors,
-	"sysservices":    HealthDataTypeSysServices,
-	"sysconfig":      HealthDataTypeSysConfig,
-	"sysproductinfo": HealthDataTypeSysProductInfo,
-	"replication":    HealthDataTypeReplication,
-	"shardshealth":   HealthDataTypeShardsHealth,
+	"minioinfo":        HealthDataTypeMinioInfo,
+	"minioconfig":      HealthDataTypeMinioConfig,
+	"syscpu":           HealthDataTypeSysCPU,
+	"sysdrivehw":       HealthDataTypeSysDriveHw,
+	"sysosinfo":        HealthDataTypeSysOsInfo,
+	"sysmem":           HealthDataTypeSysMem,
+	"sysnet":           HealthDataTypeSysNet,
+	"sysprocess":       HealthDataTypeSysProcess,
+	"syserrors":        HealthDataTypeSysErrors,
+	"sysservices":      HealthDataTypeSysServices,
+	"sysconfig":        HealthDataTypeSysConfig,
+	"sysproductinfo":   HealthDataTypeSysProductInfo,
+	"replication":      HealthDataTypeReplication,
+	"shardshealth":     HealthDataTypeShardsHealth,
+	"sysdstatethreads": HealthDataTypeSysDStateThreads,
 }
 
 // HealthDataTypesList - List of health datatypes
@@ -1531,6 +1534,7 @@ var HealthDataTypesList = []HealthDataType{
 	HealthDataTypeSysProductInfo,
 	HealthDataTypeReplication,
 	HealthDataTypeShardsHealth,
+	HealthDataTypeSysDStateThreads,
 }
 
 // HealthInfoVersionStruct - struct for health info version

--- a/health.go
+++ b/health.go
@@ -1013,6 +1013,13 @@ type ProcInfo struct {
 	Times          cpu.TimesStat              `json:"times,omitempty"`
 	UIDs           []int32                    `json:"uids,omitempty"`
 	Username       string                     `json:"username,omitempty"`
+
+	// DStateThreads is the per-process snapshot of threads currently in
+	// uninterruptible disk sleep (D), captured for `mc support diag`.
+	// Populated only when the diag collector finds threads in D and the
+	// node has dwell history; nil otherwise (e.g. realtime ProcInfo
+	// callers that don't request thread diagnostics).
+	DStateThreads *DStateThreadsDiag `json:"dstate_threads,omitempty"`
 }
 
 func aTob[a, b any](aa []a, conv func(item a) b) []b {
@@ -1276,18 +1283,17 @@ func (p *ProcInfo) AddProcInfo(metrics *ProcessMetrics) {
 
 // SysInfo - Includes hardware and system information of the MinIO cluster
 type SysInfo struct {
-	CPUInfo        []CPUs              `json:"cpus,omitempty"`
-	Partitions     []Partitions        `json:"partitions,omitempty"`
-	OSInfo         []OSInfo            `json:"osinfo,omitempty"`
-	MemInfo        []MemInfo           `json:"meminfo,omitempty"`
-	ProcInfo       []ProcInfo          `json:"procinfo,omitempty"`
-	NetInfo        []NetInfo           `json:"netinfo,omitempty"`
-	SysErrs        []SysErrors         `json:"errors,omitempty"`
-	SysServices    []SysServices       `json:"services,omitempty"`
-	SysConfig      []SysConfig         `json:"config,omitempty"`
-	ProductInfo    []ProductInfo       `json:"productinfo,omitempty"`
-	DStateThreads  []DStateThreadsDiag `json:"dstate_threads,omitempty"`
-	KubernetesInfo KubernetesInfo      `json:"kubernetes"`
+	CPUInfo        []CPUs         `json:"cpus,omitempty"`
+	Partitions     []Partitions   `json:"partitions,omitempty"`
+	OSInfo         []OSInfo       `json:"osinfo,omitempty"`
+	MemInfo        []MemInfo      `json:"meminfo,omitempty"`
+	ProcInfo       []ProcInfo     `json:"procinfo,omitempty"`
+	NetInfo        []NetInfo      `json:"netinfo,omitempty"`
+	SysErrs        []SysErrors    `json:"errors,omitempty"`
+	SysServices    []SysServices  `json:"services,omitempty"`
+	SysConfig      []SysConfig    `json:"config,omitempty"`
+	ProductInfo    []ProductInfo  `json:"productinfo,omitempty"`
+	KubernetesInfo KubernetesInfo `json:"kubernetes"`
 }
 
 // DeploymentInfo contains diagnostic information about the AIStor deployment
@@ -1496,42 +1502,40 @@ type HealthDataType string
 
 // HealthDataTypes
 const (
-	HealthDataTypeMinioInfo        HealthDataType = "minioinfo"
-	HealthDataTypeMinioConfig      HealthDataType = "minioconfig"
-	HealthDataTypeSysCPU           HealthDataType = "syscpu"
-	HealthDataTypeSysDriveHw       HealthDataType = "sysdrivehw"
-	HealthDataTypeSysOsInfo        HealthDataType = "sysosinfo"
-	HealthDataTypeSysMem           HealthDataType = "sysmem"
-	HealthDataTypeSysNet           HealthDataType = "sysnet"
-	HealthDataTypeSysProcess       HealthDataType = "sysprocess"
-	HealthDataTypeSysErrors        HealthDataType = "syserrors"
-	HealthDataTypeSysServices      HealthDataType = "sysservices"
-	HealthDataTypeSysConfig        HealthDataType = "sysconfig"
-	HealthDataTypeSysProductInfo   HealthDataType = "sysproductinfo"
-	HealthDataTypeSysDStateThreads HealthDataType = "sysdstatethreads"
-	HealthDataTypeReplication      HealthDataType = "replication"
-	HealthDataTypeShardsHealth     HealthDataType = "shardshealth"
-	HealthDataTypeIAMInfo          HealthDataType = "iaminfo"
+	HealthDataTypeMinioInfo      HealthDataType = "minioinfo"
+	HealthDataTypeMinioConfig    HealthDataType = "minioconfig"
+	HealthDataTypeSysCPU         HealthDataType = "syscpu"
+	HealthDataTypeSysDriveHw     HealthDataType = "sysdrivehw"
+	HealthDataTypeSysOsInfo      HealthDataType = "sysosinfo"
+	HealthDataTypeSysMem         HealthDataType = "sysmem"
+	HealthDataTypeSysNet         HealthDataType = "sysnet"
+	HealthDataTypeSysProcess     HealthDataType = "sysprocess"
+	HealthDataTypeSysErrors      HealthDataType = "syserrors"
+	HealthDataTypeSysServices    HealthDataType = "sysservices"
+	HealthDataTypeSysConfig      HealthDataType = "sysconfig"
+	HealthDataTypeSysProductInfo HealthDataType = "sysproductinfo"
+	HealthDataTypeReplication    HealthDataType = "replication"
+	HealthDataTypeShardsHealth   HealthDataType = "shardshealth"
+	HealthDataTypeIAMInfo        HealthDataType = "iaminfo"
 )
 
 // HealthDataTypesMap - Map of Health datatypes
 var HealthDataTypesMap = map[string]HealthDataType{
-	"minioinfo":        HealthDataTypeMinioInfo,
-	"minioconfig":      HealthDataTypeMinioConfig,
-	"syscpu":           HealthDataTypeSysCPU,
-	"sysdrivehw":       HealthDataTypeSysDriveHw,
-	"sysosinfo":        HealthDataTypeSysOsInfo,
-	"sysmem":           HealthDataTypeSysMem,
-	"sysnet":           HealthDataTypeSysNet,
-	"sysprocess":       HealthDataTypeSysProcess,
-	"syserrors":        HealthDataTypeSysErrors,
-	"sysservices":      HealthDataTypeSysServices,
-	"sysconfig":        HealthDataTypeSysConfig,
-	"sysproductinfo":   HealthDataTypeSysProductInfo,
-	"sysdstatethreads": HealthDataTypeSysDStateThreads,
-	"replication":      HealthDataTypeReplication,
-	"shardshealth":     HealthDataTypeShardsHealth,
-	"iaminfo":          HealthDataTypeIAMInfo,
+	"minioinfo":      HealthDataTypeMinioInfo,
+	"minioconfig":    HealthDataTypeMinioConfig,
+	"syscpu":         HealthDataTypeSysCPU,
+	"sysdrivehw":     HealthDataTypeSysDriveHw,
+	"sysosinfo":      HealthDataTypeSysOsInfo,
+	"sysmem":         HealthDataTypeSysMem,
+	"sysnet":         HealthDataTypeSysNet,
+	"sysprocess":     HealthDataTypeSysProcess,
+	"syserrors":      HealthDataTypeSysErrors,
+	"sysservices":    HealthDataTypeSysServices,
+	"sysconfig":      HealthDataTypeSysConfig,
+	"sysproductinfo": HealthDataTypeSysProductInfo,
+	"replication":    HealthDataTypeReplication,
+	"shardshealth":   HealthDataTypeShardsHealth,
+	"iaminfo":        HealthDataTypeIAMInfo,
 }
 
 // HealthDataTypesList - List of health datatypes
@@ -1548,7 +1552,6 @@ var HealthDataTypesList = []HealthDataType{
 	HealthDataTypeSysServices,
 	HealthDataTypeSysConfig,
 	HealthDataTypeSysProductInfo,
-	HealthDataTypeSysDStateThreads,
 	HealthDataTypeReplication,
 	HealthDataTypeShardsHealth,
 	HealthDataTypeIAMInfo,

--- a/health.go
+++ b/health.go
@@ -1494,9 +1494,9 @@ const (
 	HealthDataTypeSysServices      HealthDataType = "sysservices"
 	HealthDataTypeSysConfig        HealthDataType = "sysconfig"
 	HealthDataTypeSysProductInfo   HealthDataType = "sysproductinfo"
+	HealthDataTypeSysDStateThreads HealthDataType = "sysdstatethreads"
 	HealthDataTypeReplication      HealthDataType = "replication"
 	HealthDataTypeShardsHealth     HealthDataType = "shardshealth"
-	HealthDataTypeSysDStateThreads HealthDataType = "sysdstatethreads"
 )
 
 // HealthDataTypesMap - Map of Health datatypes
@@ -1513,9 +1513,9 @@ var HealthDataTypesMap = map[string]HealthDataType{
 	"sysservices":      HealthDataTypeSysServices,
 	"sysconfig":        HealthDataTypeSysConfig,
 	"sysproductinfo":   HealthDataTypeSysProductInfo,
+	"sysdstatethreads": HealthDataTypeSysDStateThreads,
 	"replication":      HealthDataTypeReplication,
 	"shardshealth":     HealthDataTypeShardsHealth,
-	"sysdstatethreads": HealthDataTypeSysDStateThreads,
 }
 
 // HealthDataTypesList - List of health datatypes
@@ -1532,9 +1532,9 @@ var HealthDataTypesList = []HealthDataType{
 	HealthDataTypeSysServices,
 	HealthDataTypeSysConfig,
 	HealthDataTypeSysProductInfo,
+	HealthDataTypeSysDStateThreads,
 	HealthDataTypeReplication,
 	HealthDataTypeShardsHealth,
-	HealthDataTypeSysDStateThreads,
 }
 
 // HealthInfoVersionStruct - struct for health info version


### PR DESCRIPTION
This PR is part of a 4-repo stack landing the D-state threads diag + the
companion thread / PSI Prometheus metrics. Land in this order so each
downstream PR resolves cleanly:

---


Adds a new diagnostic section that surfaces threads stuck in uninterruptible
disk sleep (D state) through `mc support diag`. Engineers debugging a stuck
cluster can see "1761 threads on iterate_dir" without SSH access.

Schema additions in `health.go` and a new `health-dstate-threads.go`:

- `DStateThreadsDiag`, `DStateThreadGroup`, `DStateThreadInfo` model a
  per-process snapshot grouped by kernel wchan with a small sample of
  stacks per bucket. Per-node identity is supplied by the parent
  `ProcInfo`'s `NodeCommon`.
- New field `ProcInfo.DStateThreads *DStateThreadsDiag`. The pointer
  shape lets servers that don't populate it leave it nil rather than
  emit an empty section.

No wire-format break: existing fields are untouched, only one new
optional JSON key (`dstate_threads`) is added on `ProcInfo`. Older
clients ignore it; newer servers leave it nil when not populated.
