### PR TITLE
Proposal for table api stats in metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -3366,19 +3366,62 @@ type TableAPIMetrics struct {
 	LastDay *SegmentedTableIO `json:"lastDay,omitempty"`
 
 	// TopWarehouses contains the top 25 warehouses by request count if MetricsTopWarehouses is set.
-	TopWarehouses []TableIOMetrics `json:"topW,omitempty"`
+	TopWarehouses *TopTableIO `json:"topW,omitempty"`
 
 	// TopNamespaces contains the top 25 namespaces by request count if MetricsTopNamespaces is set.
-	TopNamespaces []TableIOMetrics `json:"topN,omitempty"`
+	TopNamespaces *TopTableIO `json:"topN,omitempty"`
 
 	// TopTables contains the top 25 tables by request count if MetricsTopTables is set.
-	TopTables []TableIOMetrics `json:"topT,omitempty"`
+	TopTables *TopTableIO `json:"topT,omitempty"`
+}
+
+// TopTableIO provides sorted IO numbers for tables.
+type TopTableIO struct {
+	// Minute stats always provided.
+	ByRequestsMin   []TableIOMetrics `json:"reqMin,omitempty"`
+	ByThroughputMin []TableIOMetrics `json:"thrMin,omitempty"`
+
+	// Hour is provided if MetricsHourStats is set.
+	ByRequestsHour   []TableIOMetrics `json:"reqHour,omitempty"`
+	ByThroughputHour []TableIOMetrics `json:"thrHour,omitempty"`
+
+	// Day is provided if MetricsDayStats is set.
+	ByRequestsDay   []TableIOMetrics `json:"reqDay,omitempty"`
+	ByThroughputDay []TableIOMetrics `json:"thrDay,omitempty"`
+}
+
+// Merge folds other into t. Entries with matching key are summed; the result
+// for each ranked list is sorted by its native ranking (requests or throughput).
+func (t *TopTableIO) Merge(other *TopTableIO, key func(*TableIOMetrics) string) {
+	if other == nil {
+		return
+	}
+	t.ByRequestsMin = mergeTopList(t.ByRequestsMin, other.ByRequestsMin, key, cmpByRequests)
+	t.ByThroughputMin = mergeTopList(t.ByThroughputMin, other.ByThroughputMin, key, cmpByThroughput)
+	t.ByRequestsHour = mergeTopList(t.ByRequestsHour, other.ByRequestsHour, key, cmpByRequests)
+	t.ByThroughputHour = mergeTopList(t.ByThroughputHour, other.ByThroughputHour, key, cmpByThroughput)
+	t.ByRequestsDay = mergeTopList(t.ByRequestsDay, other.ByRequestsDay, key, cmpByRequests)
+	t.ByThroughputDay = mergeTopList(t.ByThroughputDay, other.ByThroughputDay, key, cmpByThroughput)
+}
+
+// TopN re-ranks each contained list and trims to n entries. No-op if t is nil
+// or n <= 0.
+func (t *TopTableIO) TopN(n int) {
+	if t == nil || n <= 0 {
+		return
+	}
+	t.ByRequestsMin = sortTrimTopList(t.ByRequestsMin, n, cmpByRequests)
+	t.ByThroughputMin = sortTrimTopList(t.ByThroughputMin, n, cmpByThroughput)
+	t.ByRequestsHour = sortTrimTopList(t.ByRequestsHour, n, cmpByRequests)
+	t.ByThroughputHour = sortTrimTopList(t.ByThroughputHour, n, cmpByThroughput)
+	t.ByRequestsDay = sortTrimTopList(t.ByRequestsDay, n, cmpByRequests)
+	t.ByThroughputDay = sortTrimTopList(t.ByThroughputDay, n, cmpByThroughput)
 }
 
 // Merge folds other into t. CollectedAt takes the later timestamp;
 // Nodes is summed; LastMinute is added; LastHour and LastDay are
-// merged segment-wise; Top* lists are merged by identity and trimmed
-// back to tableTopTrimTarget once any list grows past tableTopTrimThreshold.
+// merged segment-wise; Top* groups are merged per-ranking and trimmed
+// back to tableTopTrimTarget once any ranked list grows past tableTopTrimThreshold.
 func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
 	if other == nil {
 		return
@@ -3405,20 +3448,32 @@ func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
 		}
 		t.LastDay.Merge(other.LastDay)
 	}
-	t.TopWarehouses = mergeTopTableList(t.TopWarehouses, other.TopWarehouses, (*TableIOMetrics).KeyWarehouse)
-	t.TopNamespaces = mergeTopTableList(t.TopNamespaces, other.TopNamespaces, (*TableIOMetrics).KeyNamespace)
-	t.TopTables = mergeTopTableList(t.TopTables, other.TopTables, (*TableIOMetrics).KeyTable)
+	t.TopWarehouses = mergeTopGroup(t.TopWarehouses, other.TopWarehouses, (*TableIOMetrics).KeyWarehouse)
+	t.TopNamespaces = mergeTopGroup(t.TopNamespaces, other.TopNamespaces, (*TableIOMetrics).KeyNamespace)
+	t.TopTables = mergeTopGroup(t.TopTables, other.TopTables, (*TableIOMetrics).KeyTable)
 }
 
-// TopN re-ranks every Top* list by LastMinute request count descending and
-// trims each to n entries. Pass n <= 0 to leave the lists unchanged.
+// TopN re-ranks every ranked list in each Top* group and trims to n entries.
+// Pass n <= 0 to leave the lists unchanged.
 func (t *TableAPIMetrics) TopN(n int) {
 	if n <= 0 {
 		return
 	}
-	t.TopWarehouses = sortTrimTopTables(t.TopWarehouses, n)
-	t.TopNamespaces = sortTrimTopTables(t.TopNamespaces, n)
-	t.TopTables = sortTrimTopTables(t.TopTables, n)
+	t.TopWarehouses.TopN(n)
+	t.TopNamespaces.TopN(n)
+	t.TopTables.TopN(n)
+}
+
+// mergeTopGroup folds src into dst, allocating dst if needed. Returns dst.
+func mergeTopGroup(dst, src *TopTableIO, key func(*TableIOMetrics) string) *TopTableIO {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		dst = &TopTableIO{}
+	}
+	dst.Merge(src, key)
+	return dst
 }
 
 // TableIOMetrics holds traffic for a table across time windows.
@@ -3432,30 +3487,17 @@ type TableIOMetrics struct {
 	// Warehouse will be populated if all data is from the same warehouse
 	Warehouse *string `json:"warehouse"`
 
-	// LastMinute is the aggregate over the last minute. Always present.
-	LastMinute *TableAPIStat `json:"lastMinute,omitempty"`
-
-	// LastHour is the aggregate over the last hour.
-	// Populated only when MetricsHourStats is requested.
-	LastHour *TableAPIStat `json:"lastHour,omitempty"`
-
-	// LastDay is the aggregate over the last 24 hours.
-	// Populated only when MetricsDayStats is requested.
-	LastDay *TableAPIStat `json:"lastDay,omitempty"`
+	TableAPIStat `msg:",flatten"`
 }
 
 // Merge sums other into m. Identity fields (Table/Namespace/Warehouse) are
 // copied verbatim on the first non-empty merge and collapsed to nil on
 // disagreement thereafter, preserving the "set iff single value" contract.
 func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
-	if other == nil {
+	if other == nil || other.IsZero() {
 		return
 	}
-	otherEmpty := other.LastMinute == nil && other.LastHour == nil && other.LastDay == nil
-	if otherEmpty {
-		return
-	}
-	if m.LastMinute == nil && m.LastHour == nil && m.LastDay == nil {
+	if m.IsZero() {
 		m.Table = other.Table
 		m.Namespace = other.Namespace
 		m.Warehouse = other.Warehouse
@@ -3464,24 +3506,7 @@ func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
 		m.Namespace = mergeIdentityField(m.Namespace, other.Namespace)
 		m.Warehouse = mergeIdentityField(m.Warehouse, other.Warehouse)
 	}
-	if other.LastMinute != nil {
-		if m.LastMinute == nil {
-			m.LastMinute = &TableAPIStat{}
-		}
-		m.LastMinute.Add(other.LastMinute)
-	}
-	if other.LastHour != nil {
-		if m.LastHour == nil {
-			m.LastHour = &TableAPIStat{}
-		}
-		m.LastHour.Add(other.LastHour)
-	}
-	if other.LastDay != nil {
-		if m.LastDay == nil {
-			m.LastDay = &TableAPIStat{}
-		}
-		m.LastDay.Add(other.LastDay)
-	}
+	m.Add(&other.TableAPIStat)
 }
 
 // mergeIdentityField returns a when both pointers reference the same value;
@@ -3583,13 +3608,13 @@ func (s *SegmentedTableIO) AsTableIOStat() []TableAPIStat {
 // table over one time window.
 // Read/Write is decided by the server based on API type.
 type TableAPIStat struct {
-	Reads           int64   `json:"reads,omitempty"`    // Requests classified as reads
-	Writes          int64   `json:"writes,omitempty"`   // Requests classified as writes
-	BytesIn         int64   `json:"bytesIn,omitempty"`  // Bytes in the Request body
-	BytesOut        int64   `json:"bytesOut,omitempty"` // Bytes in the Response body
-	NotOK           int64   `json:"notOK,omitempty"`    // Response >= status code 400
-	RequestTimeSecs float64 `json:"timeSecs,omitempty"` // Total request time
-	RespTTFBSecs    float64 `json:"ttfbSecs,omitempty"` // Total time spent on TTFB (req read -> response first byte) in seconds.
+	Reads           int64   `json:"r,omitempty"`     // Requests classified as reads
+	Writes          int64   `json:"w,omitempty"`     // Requests classified as writes
+	BytesIn         int64   `json:"in,omitempty"`    // Bytes in the Request body
+	BytesOut        int64   `json:"out,omitempty"`   // Bytes in the Response body
+	NotOK           int64   `json:"err,omitempty"`   // Response >= status code 400
+	RequestTimeSecs float64 `json:"rSecs,omitempty"` // Total request time in seconds
+	RespTTFBSecs    float64 `json:"ttfb,omitempty"`  // Total time spent on TTFB in seconds(req read -> response first byte) in seconds.
 }
 
 // Add sums other into t in place.
@@ -3621,37 +3646,22 @@ const (
 	tableTopTrimTarget    = 50
 )
 
-// tableScore returns the primary rank key for ordering Top* entries: total
-// request count over the last minute.
-func tableScore(m *TableIOMetrics) int64 {
-	if m == nil || m.LastMinute == nil {
-		return 0
-	}
-	return m.LastMinute.Reads + m.LastMinute.Writes
+// cmpByRequests orders TableIOMetrics descending by total request count
+// (Reads + Writes).
+func cmpByRequests(a, b *TableIOMetrics) int {
+	return cmp.Compare(b.Reads+b.Writes, a.Reads+a.Writes)
 }
 
-// tableBytes is the tiebreaker for entries with equal tableScore: total
-// last-minute bytes in both directions.
-func tableBytes(m *TableIOMetrics) int64 {
-	if m == nil || m.LastMinute == nil {
-		return 0
-	}
-	return m.LastMinute.BytesIn + m.LastMinute.BytesOut
+// cmpByThroughput orders TableIOMetrics descending by total bytes
+// (BytesIn + BytesOut).
+func cmpByThroughput(a, b *TableIOMetrics) int {
+	return cmp.Compare(b.BytesIn+b.BytesOut, a.BytesIn+a.BytesOut)
 }
 
-// tableRankCompare orders TableIOMetrics descending by tableScore, then by
-// tableBytes as a tiebreaker.
-func tableRankCompare(x, y *TableIOMetrics) int {
-	if c := cmp.Compare(tableScore(y), tableScore(x)); c != 0 {
-		return c
-	}
-	return cmp.Compare(tableBytes(y), tableBytes(x))
-}
-
-// mergeTopTableList unions src into dst, summing entries whose identity key
+// mergeTopList unions src into dst, summing entries whose identity key
 // matches and re-trimming back to tableTopTrimTarget once the combined slice
-// crosses tableTopTrimThreshold.
-func mergeTopTableList(dst, src []TableIOMetrics, key func(*TableIOMetrics) string) []TableIOMetrics {
+// crosses tableTopTrimThreshold. Sort order during trim is given by cmpFn.
+func mergeTopList(dst, src []TableIOMetrics, key func(*TableIOMetrics) string, cmpFn func(*TableIOMetrics, *TableIOMetrics) int) []TableIOMetrics {
 	if len(src) == 0 {
 		return dst
 	}
@@ -3674,19 +3684,19 @@ func mergeTopTableList(dst, src []TableIOMetrics, key func(*TableIOMetrics) stri
 		idx[k] = len(dst) - 1
 	}
 	if len(dst) > tableTopTrimThreshold {
-		dst = sortTrimTopTables(dst, tableTopTrimTarget)
+		dst = sortTrimTopList(dst, tableTopTrimTarget, cmpFn)
 	}
 	return dst
 }
 
-// sortTrimTopTables sorts a by tableRankCompare and trims to n entries.
+// sortTrimTopList sorts a by cmpFn and trims to n entries.
 // Returns a unchanged when n <= 0 or len(a) <= n.
-func sortTrimTopTables(a []TableIOMetrics, n int) []TableIOMetrics {
+func sortTrimTopList(a []TableIOMetrics, n int, cmpFn func(*TableIOMetrics, *TableIOMetrics) int) []TableIOMetrics {
 	if n <= 0 {
 		return a
 	}
 	slices.SortFunc(a, func(x, y TableIOMetrics) int {
-		return tableRankCompare(&x, &y)
+		return cmpFn(&x, &y)
 	})
 	if len(a) > n {
 		a = a[:n]

--- a/metrics.go
+++ b/metrics.go
@@ -67,7 +67,7 @@ const (
 	MetricsHealing
 	MetricsBuckets
 	MetricsKMS
-	MetricsTables
+	MetricsTablesAPI
 
 	// MetricsAll must be last.
 	// Enables all metrics.
@@ -106,7 +106,7 @@ func (m MetricType) String() string {
 	addIf(m.Contains(MetricsHealing), "Healing")
 	addIf(m.Contains(MetricsBuckets), "Buckets")
 	addIf(m.Contains(MetricsKMS), "KMS")
-	addIf(m.Contains(MetricsTables), "Tables")
+	addIf(m.Contains(MetricsTablesAPI), "Tables API")
 	return b.String()
 }
 
@@ -114,13 +114,16 @@ func (m MetricType) String() string {
 type MetricFlags uint64
 
 const (
-	MetricsDayStats     MetricFlags = 1 << (iota) // Include daily statistics (24h, 15-min segments)
-	MetricsByHost                                 // Aggregate metrics by host/node.
-	MetricsByDisk                                 // Aggregate metrics by disk.
-	MetricsLegacyDiskIO                           // Add legacy disk IO metrics.
-	MetricsByDiskSet                              // Aggregate metrics by disk pool+set index.
-	MetricsSMART                                  // Include S.M.A.R.T. disk health data.
-	MetricsHourStats                              // Include last-hour statistics (1h, 1-min segments)
+	MetricsDayStats      MetricFlags = 1 << (iota) // Include daily statistics (24h, 15-min segments)
+	MetricsByHost                                  // Aggregate metrics by host/node.
+	MetricsByDisk                                  // Aggregate metrics by disk.
+	MetricsLegacyDiskIO                            // Add legacy disk IO metrics.
+	MetricsByDiskSet                               // Aggregate metrics by disk pool+set index.
+	MetricsSMART                                   // Include S.M.A.R.T. disk health data.
+	MetricsHourStats                               // Include last-hour statistics (1h, 1-min segments)
+	MetricsTopWarehouses                           // Include top-25 metrics by warehouse
+	MetricsTopNamespaces                           // Include top-25 metrics by namespace
+	MetricsTopTables                               // Include top-25 tables
 )
 
 // Contains returns whether m contains all of x.
@@ -382,7 +385,7 @@ type Metrics struct {
 	Healing     *HealingMetrics     `json:"healing,omitempty"`
 	Buckets     *BucketAPIMetrics   `json:"buckets,omitempty"`
 	KMS         *KMSRtMetrics       `json:"kms,omitempty"`
-	Tables      *TableAPIMetrics    `json:"tables,omitempty"`
+	TablesAPI   *TableAPIMetrics    `json:"tables_api,omitempty"`
 }
 
 // Merge other into r.
@@ -460,11 +463,11 @@ func (r *Metrics) Merge(other *Metrics) {
 		}
 		r.KMS.Merge(other.KMS)
 	}
-	if other.Tables != nil {
-		if r.Tables == nil {
-			r.Tables = &TableAPIMetrics{}
+	if other.TablesAPI != nil {
+		if r.TablesAPI == nil {
+			r.TablesAPI = &TableAPIMetrics{}
 		}
-		r.Tables.Merge(other.Tables)
+		r.TablesAPI.Merge(other.TablesAPI)
 	}
 }
 
@@ -3254,15 +3257,15 @@ func (s *SegmentedBucketStats) Merge(other *SegmentedBucketStats) {
 	if s.FirstTime.IsZero() || (!other.FirstTime.IsZero() && other.FirstTime.Before(s.FirstTime)) {
 		s.FirstTime = other.FirstTime
 	}
-	s.Requests = addInt64Slices(s.Requests, other.Requests)
-	s.Gets = addInt64Slices(s.Gets, other.Gets)
-	s.Puts = addInt64Slices(s.Puts, other.Puts)
-	s.Lists = addInt64Slices(s.Lists, other.Lists)
-	s.Errors = addInt64Slices(s.Errors, other.Errors)
-	s.Errors4xx = addInt64Slices(s.Errors4xx, other.Errors4xx)
-	s.Errors5xx = addInt64Slices(s.Errors5xx, other.Errors5xx)
-	s.BytesIn = addInt64Slices(s.BytesIn, other.BytesIn)
-	s.BytesOut = addInt64Slices(s.BytesOut, other.BytesOut)
+	s.Requests = addSlices(s.Requests, other.Requests)
+	s.Gets = addSlices(s.Gets, other.Gets)
+	s.Puts = addSlices(s.Puts, other.Puts)
+	s.Lists = addSlices(s.Lists, other.Lists)
+	s.Errors = addSlices(s.Errors, other.Errors)
+	s.Errors4xx = addSlices(s.Errors4xx, other.Errors4xx)
+	s.Errors5xx = addSlices(s.Errors5xx, other.Errors5xx)
+	s.BytesIn = addSlices(s.BytesIn, other.BytesIn)
+	s.BytesOut = addSlices(s.BytesOut, other.BytesOut)
 }
 
 // BucketMetrics holds all data for one bucket across the available time
@@ -3343,41 +3346,257 @@ func (b *BucketAPIMetrics) Merge(other *BucketAPIMetrics) {
 	}
 }
 
-// TableIOStat holds read/write counts and byte totals for a
-// table over one time window.
-type TableIOStat struct {
-	Reads    int64 `json:"reads"    msg:"r"`
-	Writes   int64 `json:"writes"   msg:"w"`
-	BytesIn  int64 `json:"bytesIn"  msg:"bi"`
-	BytesOut int64 `json:"bytesOut" msg:"bo"`
-}
-
-// TableIOMetrics holds windowed traffic for a table across time windows.
-type TableIOMetrics struct {
-	// Warehouse is the warehouse this table belongs to.
-	Warehouse string `json:"warehouse,omitempty" msg:"wh,omitempty"`
-
-	// LastMinute is the aggregate over the last minute. Always present.
-	LastMinute *TableIOStat `json:"lastMinute,omitempty" msg:"m,omitempty"`
-
-	// LastHour is the aggregate over the last hour.
-	// Populated only when MetricsHourStats is requested.
-	LastHour *TableIOStat `json:"lastHour,omitempty" msg:"h,omitempty"`
-
-	// LastDay is the aggregate over the last 24 hours.
-	// Populated only when MetricsDayStats is requested.
-	LastDay *TableIOStat `json:"lastDay,omitempty" msg:"d,omitempty"`
-}
 
 // TableAPIMetrics holds traffic for all active tables aggregated across nodes.
 // Keyed by table UUID.
 type TableAPIMetrics struct {
-	// Tables maps table UUID to its consolidated windowed metrics.
-	Tables map[string]TableIOMetrics `json:"tables,omitempty" msg:"tables,omitempty"`
+	// Time these metrics were collected
+	CollectedAt time.Time `json:"collected"`
+
+	// Nodes responding with data
+	Nodes int `json:"nodes"`
+
+	// LastMinute is the aggregate over the last minute across all tables.
+	LastMinute *TableAPIStat `json:"lastMinute,omitempty"`
+
+	// LastHour is the aggregate over the last hour.
+	// Populated only when MetricsHourStats is requested.
+	LastHour *SegmentedTableIO `json:"lastHour,omitempty"`
+
+	// LastDay is the aggregate over the last 24 hours.
+	// Populated only when MetricsDayStats is requested.
+	LastDay *SegmentedTableIO `json:"lastDay,omitempty"`
+
+	// TopWarehouses contains the top 25 warehouses by request count if MetricsTopWarehouses is set.
+	TopWarehouses []TableIOMetrics `json:"topW,omitempty"`
+
+	// TopNamespaces contains the top 25 namespaces by request count if MetricsTopNamespaces is set.
+	TopNamespaces []TableIOMetrics `json:"topN,omitempty"`
+
+	// TopTables contains the top 25 tables by request count if MetricsTopTables is set.
+	TopTables []TableIOMetrics `json:"topT,omitempty"`
+}
+
+// Merge folds other into t. CollectedAt takes the later timestamp;
+// Nodes is summed; LastMinute is added; LastHour and LastDay are
+// merged segment-wise; Top* lists are merged by identity and trimmed
+// back to tableTopTrimTarget once any list grows past tableTopTrimThreshold.
+func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
+	if other == nil {
+		return
+	}
+	if other.CollectedAt.After(t.CollectedAt) {
+		t.CollectedAt = other.CollectedAt
+	}
+	t.Nodes += other.Nodes
+	if other.LastMinute != nil {
+		if t.LastMinute == nil {
+			t.LastMinute = &TableAPIStat{}
+		}
+		t.LastMinute.Add(other.LastMinute)
+	}
+	if other.LastHour != nil {
+		if t.LastHour == nil {
+			t.LastHour = &SegmentedTableIO{}
+		}
+		t.LastHour.Merge(other.LastHour)
+	}
+	if other.LastDay != nil {
+		if t.LastDay == nil {
+			t.LastDay = &SegmentedTableIO{}
+		}
+		t.LastDay.Merge(other.LastDay)
+	}
+	t.TopWarehouses = mergeTopTableList(t.TopWarehouses, other.TopWarehouses, (*TableIOMetrics).KeyWarehouse)
+	t.TopNamespaces = mergeTopTableList(t.TopNamespaces, other.TopNamespaces, (*TableIOMetrics).KeyNamespace)
+	t.TopTables = mergeTopTableList(t.TopTables, other.TopTables, (*TableIOMetrics).KeyTable)
+}
+
+// TopN re-ranks every Top* list by LastMinute request count descending and
+// trims each to n entries. Pass n <= 0 to leave the lists unchanged.
+func (t *TableAPIMetrics) TopN(n int) {
+	if n <= 0 {
+		return
+	}
+	t.TopWarehouses = sortTrimTopTables(t.TopWarehouses, n)
+	t.TopNamespaces = sortTrimTopTables(t.TopNamespaces, n)
+	t.TopTables = sortTrimTopTables(t.TopTables, n)
+}
+
+// TableIOMetrics holds traffic for a table across time windows.
+type TableIOMetrics struct {
+	// Table will be populated with table name if only one table.
+	Table *string `json:"table"`
+
+	// Namespace will be populated if all data is from the same namespace
+	Namespace *string `json:"namespace"`
+
+	// Warehouse will be populated if all data is from the same warehouse
+	Warehouse *string `json:"warehouse"`
+
+	// LastMinute is the aggregate over the last minute. Always present.
+	LastMinute *TableAPIStat `json:"lastMinute,omitempty"`
+
+	// LastHour is the aggregate over the last hour.
+	// Populated only when MetricsHourStats is requested.
+	LastHour *TableAPIStat `json:"lastHour,omitempty"`
+
+	// LastDay is the aggregate over the last 24 hours.
+	// Populated only when MetricsDayStats is requested.
+	LastDay *TableAPIStat `json:"lastDay,omitempty"`
+}
+
+
+// Merge sums other into m. Identity fields (Table/Namespace/Warehouse) are
+// copied verbatim on the first non-empty merge and collapsed to nil on
+// disagreement thereafter, preserving the "set iff single value" contract.
+func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
+	if other == nil {
+		return
+	}
+	otherEmpty := other.LastMinute == nil && other.LastHour == nil && other.LastDay == nil
+	if otherEmpty {
+		return
+	}
+	if m.LastMinute == nil && m.LastHour == nil && m.LastDay == nil {
+		m.Table = other.Table
+		m.Namespace = other.Namespace
+		m.Warehouse = other.Warehouse
+	} else {
+		m.Table = mergeIdentityField(m.Table, other.Table)
+		m.Namespace = mergeIdentityField(m.Namespace, other.Namespace)
+		m.Warehouse = mergeIdentityField(m.Warehouse, other.Warehouse)
+	}
+	if other.LastMinute != nil {
+		if m.LastMinute == nil {
+			m.LastMinute = &TableAPIStat{}
+		}
+		m.LastMinute.Add(other.LastMinute)
+	}
+	if other.LastHour != nil {
+		if m.LastHour == nil {
+			m.LastHour = &TableAPIStat{}
+		}
+		m.LastHour.Add(other.LastHour)
+	}
+	if other.LastDay != nil {
+		if m.LastDay == nil {
+			m.LastDay = &TableAPIStat{}
+		}
+		m.LastDay.Add(other.LastDay)
+	}
+}
+
+// mergeIdentityField returns a when both pointers reference the same value;
+// nil on any disagreement, including when either side is nil (a nil side
+// already represents "multiple values").
+func mergeIdentityField(a, b *string) *string {
+	if a == nil || b == nil {
+		return nil
+	}
+	if *a != *b {
+		return nil
+	}
+	return a
+}
+
+type SegmentedTableIO struct {
+	// IntervalSecs is the duration of each slot in seconds.
+	IntervalSecs int `json:"intervalSecs"`
+
+	// FirstTime is the timestamp of the oldest slot.
+	FirstTime time.Time `json:"firstTime"`
+
+	// Per-category counts; one slot per IntervalSecs.
+	Reads           []int64   `json:"reads,omitempty"`
+	Writes          []int64   `json:"writes,omitempty"`
+	BytesIn         []int64   `json:"bytesIn,omitempty"`
+	BytesOut        []int64   `json:"bytesOut,omitempty"`
+	NotOK           []int64   `json:"errors,omitempty"`
+	RequestTimeSecs []float32 `json:"timeSecs,omitempty"`
+	RespTTFBSecs    []float32 `json:"ttfbSecs,omitempty"`
+}
+
+// Merge folds other into s. Slots are right-aligned and summed so the most
+// recent slot always aligns; FirstTime extends to the earliest reported.
+func (s *SegmentedTableIO) Merge(other *SegmentedTableIO) {
+	if other == nil {
+		return
+	}
+	if s.IntervalSecs == 0 {
+		s.IntervalSecs = other.IntervalSecs
+	}
+	if s.FirstTime.IsZero() || (!other.FirstTime.IsZero() && other.FirstTime.Before(s.FirstTime)) {
+		s.FirstTime = other.FirstTime
+	}
+	s.Reads = addSlices(s.Reads, other.Reads)
+	s.Writes = addSlices(s.Writes, other.Writes)
+	s.BytesIn = addSlices(s.BytesIn, other.BytesIn)
+	s.BytesOut = addSlices(s.BytesOut, other.BytesOut)
+	s.NotOK = addSlices(s.NotOK, other.NotOK)
+	s.RequestTimeSecs = addSlices(s.RequestTimeSecs, other.RequestTimeSecs)
+	s.RespTTFBSecs = addSlices(s.RespTTFBSecs, other.RespTTFBSecs)
+}
+
+// AsTableIOStat returns one TableAPIStat per slot, right-aligned so the most
+// recent slot is at the last index. Per-category slices shorter than the
+// longest are aligned to the right (their oldest slots map to leading zeros).
+func (s *SegmentedTableIO) AsTableIOStat() []TableAPIStat {
+	if s == nil {
+		return nil
+	}
+	n := len(s.Reads)
+	for _, l := range []int{
+		len(s.Writes), len(s.BytesIn), len(s.BytesOut), len(s.NotOK),
+		len(s.RequestTimeSecs), len(s.RespTTFBSecs),
+	} {
+		if l > n {
+			n = l
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	res := make([]TableAPIStat, n)
+	for i, v := range s.Reads {
+		res[n-len(s.Reads)+i].Reads = v
+	}
+	for i, v := range s.Writes {
+		res[n-len(s.Writes)+i].Writes = v
+	}
+	for i, v := range s.BytesIn {
+		res[n-len(s.BytesIn)+i].BytesIn = v
+	}
+	for i, v := range s.BytesOut {
+		res[n-len(s.BytesOut)+i].BytesOut = v
+	}
+	for i, v := range s.NotOK {
+		res[n-len(s.NotOK)+i].NotOK = v
+	}
+	for i, v := range s.RequestTimeSecs {
+		res[n-len(s.RequestTimeSecs)+i].RequestTimeSecs = float64(v)
+	}
+	for i, v := range s.RespTTFBSecs {
+		res[n-len(s.RespTTFBSecs)+i].RespTTFBSecs = float64(v)
+	}
+	return res
+}
+
+// TableAPIStat holds read/write counts and byte totals for a
+// table over one time window.
+// Read/Write is decided by the server based on API type.
+type TableAPIStat struct {
+	Reads           int64   `json:"reads,omitempty"`    // Requests classified as reads
+	Writes          int64   `json:"writes,omitempty"`   // Requests classified as writes
+	BytesIn         int64   `json:"bytesIn,omitempty"`  // Bytes in the Request body
+	BytesOut        int64   `json:"bytesOut,omitempty"` // Bytes in the Response body
+	NotOK           int64   `json:"notOK,omitempty"`    // Response >= status code 400
+	RequestTimeSecs float64 `json:"timeSecs,omitempty"` // Total request time
+	RespTTFBSecs    float64 `json:"ttfbSecs,omitempty"` // Total time spent on TTFB (req read -> response first byte) in seconds.
 }
 
 // Add sums other into t in place.
-func (t *TableIOStat) Add(other *TableIOStat) {
+func (t *TableAPIStat) Add(other *TableAPIStat) {
 	if other == nil {
 		return
 	}
@@ -3385,65 +3604,149 @@ func (t *TableIOStat) Add(other *TableIOStat) {
 	t.Writes += other.Writes
 	t.BytesIn += other.BytesIn
 	t.BytesOut += other.BytesOut
+	t.RequestTimeSecs += other.RequestTimeSecs
+	t.RespTTFBSecs += other.RespTTFBSecs
+	t.NotOK += other.NotOK
 }
 
 // IsZero reports whether all counters are zero.
-func (t *TableIOStat) IsZero() bool {
-	return t.Reads == 0 && t.Writes == 0 && t.BytesIn == 0 && t.BytesOut == 0
+func (t *TableAPIStat) IsZero() bool {
+	return t == nil || t.Reads == 0 && t.Writes == 0
 }
 
-// Merge sums other into m.
-func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
-	if other == nil {
-		return
+// Top-list growth bounds for TableAPIMetrics. Merge accumulates entries
+// across sources; once any Top* slice exceeds tableTopTrimThreshold it is
+// re-ranked and clipped back to tableTopTrimTarget. The buffer between the
+// final top-25 surface and tableTopTrimTarget gives later merges room to
+// promote entries that would otherwise be dropped too early.
+const (
+	tableTopTrimThreshold = 100
+	tableTopTrimTarget    = 50
+)
+
+// tableScore returns the primary rank key for ordering Top* entries: total
+// request count over the last minute.
+func tableScore(m *TableIOMetrics) int64 {
+	if m == nil || m.LastMinute == nil {
+		return 0
 	}
-	if m.Warehouse == "" {
-		m.Warehouse = other.Warehouse
-	}
-	if other.LastMinute != nil {
-		if m.LastMinute == nil {
-			m.LastMinute = &TableIOStat{}
-		}
-		m.LastMinute.Add(other.LastMinute)
-	}
-	if other.LastHour != nil {
-		if m.LastHour == nil {
-			m.LastHour = &TableIOStat{}
-		}
-		m.LastHour.Add(other.LastHour)
-	}
-	if other.LastDay != nil {
-		if m.LastDay == nil {
-			m.LastDay = &TableIOStat{}
-		}
-		m.LastDay.Add(other.LastDay)
-	}
+	return m.LastMinute.Reads + m.LastMinute.Writes
 }
 
-// Merge folds other into t by merging each per-table entry.
-func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
-	if other == nil {
-		return
+// tableBytes is the tiebreaker for entries with equal tableScore: total
+// last-minute bytes in both directions.
+func tableBytes(m *TableIOMetrics) int64 {
+	if m == nil || m.LastMinute == nil {
+		return 0
 	}
-	for uuid, om := range other.Tables {
-		if t.Tables == nil {
-			t.Tables = make(map[string]TableIOMetrics, len(other.Tables))
-		}
-		am := t.Tables[uuid]
-		am.Merge(&om)
-		t.Tables[uuid] = am
-	}
+	return m.LastMinute.BytesIn + m.LastMinute.BytesOut
 }
 
-// addInt64Slices returns the element-wise sum of a and b, right-aligned so
+// tableRankCompare orders TableIOMetrics descending by tableScore, then by
+// tableBytes as a tiebreaker.
+func tableRankCompare(x, y *TableIOMetrics) int {
+	if c := cmp.Compare(tableScore(y), tableScore(x)); c != 0 {
+		return c
+	}
+	return cmp.Compare(tableBytes(y), tableBytes(x))
+}
+
+// mergeTopTableList unions src into dst, summing entries whose identity key
+// matches and re-trimming back to tableTopTrimTarget once the combined slice
+// crosses tableTopTrimThreshold.
+func mergeTopTableList(dst, src []TableIOMetrics, key func(*TableIOMetrics) string) []TableIOMetrics {
+	if len(src) == 0 {
+		return dst
+	}
+	if cap(dst) < len(dst)+len(src) {
+		grown := make([]TableIOMetrics, len(dst), len(dst)+len(src))
+		copy(grown, dst)
+		dst = grown
+	}
+	idx := make(map[string]int, len(dst)+len(src))
+	for i := range dst {
+		idx[key(&dst[i])] = i
+	}
+	for i := range src {
+		k := key(&src[i])
+		if pos, ok := idx[k]; ok {
+			dst[pos].Merge(&src[i])
+			continue
+		}
+		dst = append(dst, src[i])
+		idx[k] = len(dst) - 1
+	}
+	if len(dst) > tableTopTrimThreshold {
+		dst = sortTrimTopTables(dst, tableTopTrimTarget)
+	}
+	return dst
+}
+
+// sortTrimTopTables sorts a by tableRankCompare and trims to n entries.
+// Returns a unchanged when n <= 0 or len(a) <= n.
+func sortTrimTopTables(a []TableIOMetrics, n int) []TableIOMetrics {
+	if n <= 0 {
+		return a
+	}
+	slices.SortFunc(a, func(x, y TableIOMetrics) int {
+		return tableRankCompare(&x, &y)
+	})
+	if len(a) > n {
+		a = a[:n]
+	}
+	return a
+}
+
+// Identity keys for Top* slices. ASCII unit separator avoids accidental
+// collisions between user-provided names (which rarely if ever contain it).
+const tableKeySep = "\x1f"
+
+func ptrStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// KeyWarehouse returns the identity key used when merging warehouse-level
+// Top entries.
+func (m *TableIOMetrics) KeyWarehouse() string {
+	return ptrStr(m.Warehouse)
+}
+
+// KeyNamespace returns the identity key used when merging namespace-level
+// Top entries.
+func (m *TableIOMetrics) KeyNamespace() string {
+	return ptrStr(m.Warehouse) + tableKeySep + ptrStr(m.Namespace)
+}
+
+// KeyTable returns the identity key used when merging table-level Top
+// entries.
+func (m *TableIOMetrics) KeyTable() string {
+	return ptrStr(m.Warehouse) + tableKeySep + ptrStr(m.Namespace) + tableKeySep + ptrStr(m.Table)
+}
+
+type addable interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64
+}
+
+// addSlices returns the element-wise sum of a and b, right-aligned so
 // that slot index len-1 (most recent) always corresponds between both.
-// The longer slice is used as the base; if b is longer, a copy is made so
-// the caller's backing array is not mutated.
-func addInt64Slices(a, b []int64) []int64 {
+// The 'a' array is mutated, but the 'b' value is never mutated.
+func addSlices[A addable](a, b []A) []A {
 	if len(b) > len(a) {
-		tmp := make([]int64, len(b))
-		copy(tmp, b)
-		a, b = tmp, a
+		// Extend a and shift values while adding b.
+		diff := len(b) - len(a)
+		a = append(a, make([]A, diff)...)
+		for i := len(a) - 1; i >= diff; i-- {
+			a[i] = a[i-diff] + b[i]
+		}
+		for i := 0; i < diff; i++ {
+			a[i] = b[i]
+		}
+		return a
 	}
 	offset := len(a) - len(b)
 	for i, v := range b {

--- a/metrics.go
+++ b/metrics.go
@@ -67,6 +67,7 @@ const (
 	MetricsHealing
 	MetricsBuckets
 	MetricsKMS
+	MetricsTables
 
 	// MetricsAll must be last.
 	// Enables all metrics.
@@ -105,6 +106,7 @@ func (m MetricType) String() string {
 	addIf(m.Contains(MetricsHealing), "Healing")
 	addIf(m.Contains(MetricsBuckets), "Buckets")
 	addIf(m.Contains(MetricsKMS), "KMS")
+	addIf(m.Contains(MetricsTables), "Tables")
 	return b.String()
 }
 
@@ -380,6 +382,7 @@ type Metrics struct {
 	Healing     *HealingMetrics     `json:"healing,omitempty"`
 	Buckets     *BucketAPIMetrics   `json:"buckets,omitempty"`
 	KMS         *KMSRtMetrics       `json:"kms,omitempty"`
+	Tables      *TableAPIMetrics    `json:"tables,omitempty"`
 }
 
 // Merge other into r.
@@ -456,6 +459,12 @@ func (r *Metrics) Merge(other *Metrics) {
 			r.KMS = &KMSRtMetrics{}
 		}
 		r.KMS.Merge(other.KMS)
+	}
+	if other.Tables != nil {
+		if r.Tables == nil {
+			r.Tables = &TableAPIMetrics{}
+		}
+		r.Tables.Merge(other.Tables)
 	}
 }
 
@@ -3331,6 +3340,98 @@ func (b *BucketAPIMetrics) Merge(other *BucketAPIMetrics) {
 		ab := b.Buckets[bucket]
 		ab.Merge(&ob)
 		b.Buckets[bucket] = ab
+	}
+}
+
+// TableIOStat holds read/write counts and byte totals for a
+// table over one time window.
+type TableIOStat struct {
+	Reads    int64 `json:"reads"    msg:"r"`
+	Writes   int64 `json:"writes"   msg:"w"`
+	BytesIn  int64 `json:"bytesIn"  msg:"bi"`
+	BytesOut int64 `json:"bytesOut" msg:"bo"`
+}
+
+// TableIOMetrics holds windowed traffic for a table across time windows.
+type TableIOMetrics struct {
+	// Warehouse is the warehouse this table belongs to.
+	Warehouse string `json:"warehouse,omitempty" msg:"wh,omitempty"`
+
+	// LastMinute is the aggregate over the last minute. Always present.
+	LastMinute *TableIOStat `json:"lastMinute,omitempty" msg:"m,omitempty"`
+
+	// LastHour is the aggregate over the last hour.
+	// Populated only when MetricsHourStats is requested.
+	LastHour *TableIOStat `json:"lastHour,omitempty" msg:"h,omitempty"`
+
+	// LastDay is the aggregate over the last 24 hours.
+	// Populated only when MetricsDayStats is requested.
+	LastDay *TableIOStat `json:"lastDay,omitempty" msg:"d,omitempty"`
+}
+
+// TableAPIMetrics holds traffic for all active tables aggregated across nodes.
+// Keyed by table UUID.
+type TableAPIMetrics struct {
+	// Tables maps table UUID to its consolidated windowed metrics.
+	Tables map[string]TableIOMetrics `json:"tables,omitempty" msg:"tables,omitempty"`
+}
+
+// Add sums other into t in place.
+func (t *TableIOStat) Add(other *TableIOStat) {
+	if other == nil {
+		return
+	}
+	t.Reads += other.Reads
+	t.Writes += other.Writes
+	t.BytesIn += other.BytesIn
+	t.BytesOut += other.BytesOut
+}
+
+// IsZero reports whether all counters are zero.
+func (t *TableIOStat) IsZero() bool {
+	return t.Reads == 0 && t.Writes == 0 && t.BytesIn == 0 && t.BytesOut == 0
+}
+
+// Merge sums other into m.
+func (m *TableIOMetrics) Merge(other *TableIOMetrics) {
+	if other == nil {
+		return
+	}
+	if m.Warehouse == "" {
+		m.Warehouse = other.Warehouse
+	}
+	if other.LastMinute != nil {
+		if m.LastMinute == nil {
+			m.LastMinute = &TableIOStat{}
+		}
+		m.LastMinute.Add(other.LastMinute)
+	}
+	if other.LastHour != nil {
+		if m.LastHour == nil {
+			m.LastHour = &TableIOStat{}
+		}
+		m.LastHour.Add(other.LastHour)
+	}
+	if other.LastDay != nil {
+		if m.LastDay == nil {
+			m.LastDay = &TableIOStat{}
+		}
+		m.LastDay.Add(other.LastDay)
+	}
+}
+
+// Merge folds other into t by merging each per-table entry.
+func (t *TableAPIMetrics) Merge(other *TableAPIMetrics) {
+	if other == nil {
+		return
+	}
+	for uuid, om := range other.Tables {
+		if t.Tables == nil {
+			t.Tables = make(map[string]TableIOMetrics, len(other.Tables))
+		}
+		am := t.Tables[uuid]
+		am.Merge(&om)
+		t.Tables[uuid] = am
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -3346,9 +3346,7 @@ func (b *BucketAPIMetrics) Merge(other *BucketAPIMetrics) {
 	}
 }
 
-
 // TableAPIMetrics holds traffic for all active tables aggregated across nodes.
-// Keyed by table UUID.
 type TableAPIMetrics struct {
 	// Time these metrics were collected
 	CollectedAt time.Time `json:"collected"`
@@ -3446,7 +3444,6 @@ type TableIOMetrics struct {
 	LastDay *TableAPIStat `json:"lastDay,omitempty"`
 }
 
-
 // Merge sums other into m. Identity fields (Table/Namespace/Warehouse) are
 // copied verbatim on the first non-empty merge and collapsed to nil on
 // disagreement thereafter, preserving the "set iff single value" contract.
@@ -3512,7 +3509,7 @@ type SegmentedTableIO struct {
 	Writes          []int64   `json:"writes,omitempty"`
 	BytesIn         []int64   `json:"bytesIn,omitempty"`
 	BytesOut        []int64   `json:"bytesOut,omitempty"`
-	NotOK           []int64   `json:"errors,omitempty"`
+	NotOK           []int64   `json:"notOk,omitempty"`
 	RequestTimeSecs []float32 `json:"timeSecs,omitempty"`
 	RespTTFBSecs    []float32 `json:"ttfbSecs,omitempty"`
 }

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -17945,7 +17945,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 16 bits */
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -18259,6 +18259,78 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
+		case "tables":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				z.Tables = nil
+			} else {
+				if z.Tables == nil {
+					z.Tables = new(TableAPIMetrics)
+				}
+				var zb0002 uint32
+				zb0002, err = dc.ReadMapHeader()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				for zb0002 > 0 {
+					zb0002--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						err = msgp.WrapError(err, "Tables")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "tables":
+						var zb0003 uint32
+						zb0003, err = dc.ReadMapHeader()
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						if z.Tables.Tables == nil {
+							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
+						} else if len(z.Tables.Tables) > 0 {
+							clear(z.Tables.Tables)
+						}
+						for zb0003 > 0 {
+							zb0003--
+							var za0001 string
+							za0001, err = dc.ReadString()
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables")
+								return
+							}
+							var za0002 TableIOMetrics
+							err = za0002.DecodeMsg(dc)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables", za0001)
+								return
+							}
+							z.Tables.Tables[za0001] = za0002
+						}
+						zb0002Mask |= 0x1
+					default:
+						err = dc.Skip()
+						if err != nil {
+							err = msgp.WrapError(err, "Tables")
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if (zb0002Mask & 0x1) == 0 {
+					z.Tables.Tables = nil
+				}
+
+			}
+			zb0001Mask |= 0x10000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -18268,7 +18340,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xffff {
+	if zb0001Mask != 0x1ffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -18317,6 +18389,9 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x8000) == 0 {
 			z.KMS = nil
 		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.Tables = nil
+		}
 	}
 	return
 }
@@ -18324,8 +18399,8 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(16)
-	var zb0001Mask uint16 /* 16 bits */
+	zb0001Len := uint32(17)
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -18390,6 +18465,10 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.KMS == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
+	}
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10000
 	}
 	// variable map header, size zb0001Len
 	err = en.WriteMapHeader(zb0001Len)
@@ -18703,6 +18782,57 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// write "tables"
+			err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			if z.Tables == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				// check for omitted fields
+				zb0002Len := uint32(1)
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				if z.Tables.Tables == nil {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				// variable map header, size zb0002Len
+				err = en.Append(0x80 | uint8(zb0002Len))
+				if err != nil {
+					return
+				}
+				if (zb0002Mask & 0x1) == 0 { // if not omitted
+					// write "tables"
+					err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+					if err != nil {
+						return
+					}
+					err = en.WriteMapHeader(uint32(len(z.Tables.Tables)))
+					if err != nil {
+						err = msgp.WrapError(err, "Tables", "Tables")
+						return
+					}
+					for za0001, za0002 := range z.Tables.Tables {
+						err = en.WriteString(za0001)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						err = za0002.EncodeMsg(en)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables", za0001)
+							return
+						}
+					}
+				}
+			}
+		}
 	}
 	return
 }
@@ -18711,8 +18841,8 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(16)
-	var zb0001Mask uint16 /* 16 bits */
+	zb0001Len := uint32(17)
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	if z.Scanner == nil {
 		zb0001Len--
@@ -18777,6 +18907,10 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.KMS == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
+	}
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10000
 	}
 	// variable map header, size zb0001Len
 	o = msgp.AppendMapHeader(o, zb0001Len)
@@ -18991,6 +19125,37 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// string "tables"
+			o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+			if z.Tables == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				// check for omitted fields
+				zb0002Len := uint32(1)
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				if z.Tables.Tables == nil {
+					zb0002Len--
+					zb0002Mask |= 0x1
+				}
+				// variable map header, size zb0002Len
+				o = append(o, 0x80|uint8(zb0002Len))
+				if (zb0002Mask & 0x1) == 0 { // if not omitted
+					// string "tables"
+					o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+					o = msgp.AppendMapHeader(o, uint32(len(z.Tables.Tables)))
+					for za0001, za0002 := range z.Tables.Tables {
+						o = msgp.AppendString(o, za0001)
+						o, err = za0002.MarshalMsg(o)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables", za0001)
+							return
+						}
+					}
+				}
+			}
+		}
 	}
 	return
 }
@@ -19005,7 +19170,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 16 bits */
+	var zb0001Mask uint32 /* 17 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -19303,6 +19468,77 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
+		case "tables":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Tables = nil
+			} else {
+				if z.Tables == nil {
+					z.Tables = new(TableAPIMetrics)
+				}
+				var zb0002 uint32
+				zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var zb0002Mask uint8 /* 1 bits */
+				_ = zb0002Mask
+				for zb0002 > 0 {
+					zb0002--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Tables")
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "tables":
+						var zb0003 uint32
+						zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables", "Tables")
+							return
+						}
+						if z.Tables.Tables == nil {
+							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
+						} else if len(z.Tables.Tables) > 0 {
+							clear(z.Tables.Tables)
+						}
+						for zb0003 > 0 {
+							var za0002 TableIOMetrics
+							zb0003--
+							var za0001 string
+							za0001, bts, err = msgp.ReadStringBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables")
+								return
+							}
+							bts, err = za0002.UnmarshalMsg(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "Tables", "Tables", za0001)
+								return
+							}
+							z.Tables.Tables[za0001] = za0002
+						}
+						zb0002Mask |= 0x1
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Tables")
+							return
+						}
+					}
+				}
+				// Clear omitted fields.
+				if (zb0002Mask & 0x1) == 0 {
+					z.Tables.Tables = nil
+				}
+
+			}
+			zb0001Mask |= 0x10000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -19312,7 +19548,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xffff {
+	if zb0001Mask != 0x1ffff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Scanner = nil
 		}
@@ -19360,6 +19596,9 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if (zb0001Mask & 0x8000) == 0 {
 			z.KMS = nil
+		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.Tables = nil
 		}
 	}
 	o = bts
@@ -19463,6 +19702,18 @@ func (z *Metrics) Msgsize() (s int) {
 		s += msgp.NilSize
 	} else {
 		s += z.KMS.Msgsize()
+	}
+	s += 7
+	if z.Tables == nil {
+		s += msgp.NilSize
+	} else {
+		s += 1 + 7 + msgp.MapHeaderSize
+		if z.Tables.Tables != nil {
+			for za0001, za0002 := range z.Tables.Tables {
+				_ = za0002
+				s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
+			}
+		}
 	}
 	return
 }
@@ -36893,6 +37144,818 @@ func (z *SiteResyncMetrics) Msgsize() (s int) {
 		s += msgp.StringPrefixSize + len(z.FailedBuckets[za0001])
 	}
 	s += 7 + msgp.StringPrefixSize + len(z.Bucket) + 7 + msgp.StringPrefixSize + len(z.Object)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableAPIMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "tables":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			if z.Tables == nil {
+				z.Tables = make(map[string]TableIOMetrics, zb0002)
+			} else if len(z.Tables) > 0 {
+				clear(z.Tables)
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				var za0002 TableIOMetrics
+				err = za0002.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables", za0001)
+					return
+				}
+				z.Tables[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if (zb0001Mask & 0x1) == 0 {
+		z.Tables = nil
+	}
+
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(1)
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+	if (zb0001Mask & 0x1) == 0 { // if not omitted
+		// write "tables"
+		err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteMapHeader(uint32(len(z.Tables)))
+		if err != nil {
+			err = msgp.WrapError(err, "Tables")
+			return
+		}
+		for za0001, za0002 := range z.Tables {
+			err = en.WriteString(za0001)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			err = za0002.EncodeMsg(en)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(1)
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	if z.Tables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+	if (zb0001Mask & 0x1) == 0 { // if not omitted
+		// string "tables"
+		o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+		o = msgp.AppendMapHeader(o, uint32(len(z.Tables)))
+		for za0001, za0002 := range z.Tables {
+			o = msgp.AppendString(o, za0001)
+			o, err = za0002.MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableAPIMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 1 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "tables":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Tables")
+				return
+			}
+			if z.Tables == nil {
+				z.Tables = make(map[string]TableIOMetrics, zb0002)
+			} else if len(z.Tables) > 0 {
+				clear(z.Tables)
+			}
+			for zb0002 > 0 {
+				var za0002 TableIOMetrics
+				zb0002--
+				var za0001 string
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables")
+					return
+				}
+				bts, err = za0002.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Tables", za0001)
+					return
+				}
+				z.Tables[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if (zb0001Mask & 0x1) == 0 {
+		z.Tables = nil
+	}
+
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableAPIMetrics) Msgsize() (s int) {
+	s = 1 + 7 + msgp.MapHeaderSize
+	if z.Tables != nil {
+		for za0001, za0002 := range z.Tables {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "warehouse":
+			z.Warehouse, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "lastMinute":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableIOStat)
+				}
+				err = z.LastMinute.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(TableIOStat)
+				}
+				err = z.LastHour.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(TableIOStat)
+				}
+				err = z.LastDay.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Warehouse = ""
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastDay = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.Warehouse == "" {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "warehouse"
+			err = en.Append(0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(z.Warehouse)
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "lastMinute"
+			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if err != nil {
+				return
+			}
+			if z.LastMinute == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastMinute.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastHour.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastDay.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.Warehouse == "" {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "warehouse"
+			o = append(o, 0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+			o = msgp.AppendString(o, z.Warehouse)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "lastMinute"
+			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if z.LastMinute == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastMinute.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastHour.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastDay.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "warehouse":
+			z.Warehouse, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "lastMinute":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableIOStat)
+				}
+				bts, err = z.LastMinute.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(TableIOStat)
+				}
+				bts, err = z.LastHour.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(TableIOStat)
+				}
+				bts, err = z.LastDay.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Warehouse = ""
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastDay = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableIOMetrics) Msgsize() (s int) {
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.Warehouse) + 11
+	if z.LastMinute == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastMinute.Msgsize()
+	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastHour.Msgsize()
+	}
+	s += 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastDay.Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableIOStat) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+		case "writes":
+			z.Writes, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+		case "bytesIn":
+			z.BytesIn, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		case "bytesOut":
+			z.BytesOut, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableIOStat) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "reads"
+	err = en.Append(0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Reads)
+	if err != nil {
+		err = msgp.WrapError(err, "Reads")
+		return
+	}
+	// write "writes"
+	err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.Writes)
+	if err != nil {
+		err = msgp.WrapError(err, "Writes")
+		return
+	}
+	// write "bytesIn"
+	err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.BytesIn)
+	if err != nil {
+		err = msgp.WrapError(err, "BytesIn")
+		return
+	}
+	// write "bytesOut"
+	err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.BytesOut)
+	if err != nil {
+		err = msgp.WrapError(err, "BytesOut")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableIOStat) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "reads"
+	o = append(o, 0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+	o = msgp.AppendInt64(o, z.Reads)
+	// string "writes"
+	o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+	o = msgp.AppendInt64(o, z.Writes)
+	// string "bytesIn"
+	o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+	o = msgp.AppendInt64(o, z.BytesIn)
+	// string "bytesOut"
+	o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+	o = msgp.AppendInt64(o, z.BytesOut)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableIOStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+		case "writes":
+			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+		case "bytesIn":
+			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		case "bytesOut":
+			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableIOStat) Msgsize() (s int) {
+	s = 1 + 6 + msgp.Int64Size + 7 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Int64Size
 	return
 }
 

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -36286,7 +36286,7 @@ func (z *SegmentedTableIO) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x8
-		case "errors":
+		case "notOk":
 			var zb0006 uint32
 			zb0006, err = dc.ReadArrayHeader()
 			if err != nil {
@@ -36520,8 +36520,8 @@ func (z *SegmentedTableIO) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// write "errors"
-			err = en.Append(0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			// write "notOk"
+			err = en.Append(0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x6b)
 			if err != nil {
 				return
 			}
@@ -36659,8 +36659,8 @@ func (z *SegmentedTableIO) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// string "errors"
-			o = append(o, 0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			// string "notOk"
+			o = append(o, 0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x6b)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.NotOK)))
 			for za0005 := range z.NotOK {
 				o = msgp.AppendInt64(o, z.NotOK[za0005])
@@ -36798,7 +36798,7 @@ func (z *SegmentedTableIO) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x8
-		case "errors":
+		case "notOk":
 			var zb0006 uint32
 			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
@@ -36896,7 +36896,7 @@ func (z *SegmentedTableIO) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SegmentedTableIO) Msgsize() (s int) {
-	s = 1 + 13 + msgp.IntSize + 10 + msgp.TimeSize + 6 + msgp.ArrayHeaderSize + (len(z.Reads) * (msgp.Int64Size)) + 7 + msgp.ArrayHeaderSize + (len(z.Writes) * (msgp.Int64Size)) + 8 + msgp.ArrayHeaderSize + (len(z.BytesIn) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.BytesOut) * (msgp.Int64Size)) + 7 + msgp.ArrayHeaderSize + (len(z.NotOK) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RequestTimeSecs) * (msgp.Float32Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RespTTFBSecs) * (msgp.Float32Size))
+	s = 1 + 13 + msgp.IntSize + 10 + msgp.TimeSize + 6 + msgp.ArrayHeaderSize + (len(z.Reads) * (msgp.Int64Size)) + 7 + msgp.ArrayHeaderSize + (len(z.Writes) * (msgp.Int64Size)) + 8 + msgp.ArrayHeaderSize + (len(z.BytesIn) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.BytesOut) * (msgp.Int64Size)) + 6 + msgp.ArrayHeaderSize + (len(z.NotOK) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RequestTimeSecs) * (msgp.Float32Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RespTTFBSecs) * (msgp.Float32Size))
 	return
 }
 

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -37801,61 +37801,58 @@ func (z *TableAPIMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x4
 		case "topW":
-			var zb0002 uint32
-			zb0002, err = dc.ReadArrayHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "TopWarehouses")
-				return
-			}
-			if cap(z.TopWarehouses) >= int(zb0002) {
-				z.TopWarehouses = (z.TopWarehouses)[:zb0002]
-			} else {
-				z.TopWarehouses = make([]TableIOMetrics, zb0002)
-			}
-			for za0001 := range z.TopWarehouses {
-				err = z.TopWarehouses[za0001].DecodeMsg(dc)
+			if dc.IsNil() {
+				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					err = msgp.WrapError(err, "TopWarehouses")
+					return
+				}
+				z.TopWarehouses = nil
+			} else {
+				if z.TopWarehouses == nil {
+					z.TopWarehouses = new(TopTableIO)
+				}
+				err = z.TopWarehouses.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses")
 					return
 				}
 			}
 			zb0001Mask |= 0x8
 		case "topN":
-			var zb0003 uint32
-			zb0003, err = dc.ReadArrayHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "TopNamespaces")
-				return
-			}
-			if cap(z.TopNamespaces) >= int(zb0003) {
-				z.TopNamespaces = (z.TopNamespaces)[:zb0003]
-			} else {
-				z.TopNamespaces = make([]TableIOMetrics, zb0003)
-			}
-			for za0002 := range z.TopNamespaces {
-				err = z.TopNamespaces[za0002].DecodeMsg(dc)
+			if dc.IsNil() {
+				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					err = msgp.WrapError(err, "TopNamespaces")
+					return
+				}
+				z.TopNamespaces = nil
+			} else {
+				if z.TopNamespaces == nil {
+					z.TopNamespaces = new(TopTableIO)
+				}
+				err = z.TopNamespaces.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces")
 					return
 				}
 			}
 			zb0001Mask |= 0x10
 		case "topT":
-			var zb0004 uint32
-			zb0004, err = dc.ReadArrayHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "TopTables")
-				return
-			}
-			if cap(z.TopTables) >= int(zb0004) {
-				z.TopTables = (z.TopTables)[:zb0004]
-			} else {
-				z.TopTables = make([]TableIOMetrics, zb0004)
-			}
-			for za0003 := range z.TopTables {
-				err = z.TopTables[za0003].DecodeMsg(dc)
+			if dc.IsNil() {
+				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopTables", za0003)
+					err = msgp.WrapError(err, "TopTables")
+					return
+				}
+				z.TopTables = nil
+			} else {
+				if z.TopTables == nil {
+					z.TopTables = new(TopTableIO)
+				}
+				err = z.TopTables.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables")
 					return
 				}
 			}
@@ -38013,15 +38010,15 @@ func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			if err != nil {
 				return
 			}
-			err = en.WriteArrayHeader(uint32(len(z.TopWarehouses)))
-			if err != nil {
-				err = msgp.WrapError(err, "TopWarehouses")
-				return
-			}
-			for za0001 := range z.TopWarehouses {
-				err = z.TopWarehouses[za0001].EncodeMsg(en)
+			if z.TopWarehouses == nil {
+				err = en.WriteNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+			} else {
+				err = z.TopWarehouses.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses")
 					return
 				}
 			}
@@ -38032,15 +38029,15 @@ func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			if err != nil {
 				return
 			}
-			err = en.WriteArrayHeader(uint32(len(z.TopNamespaces)))
-			if err != nil {
-				err = msgp.WrapError(err, "TopNamespaces")
-				return
-			}
-			for za0002 := range z.TopNamespaces {
-				err = z.TopNamespaces[za0002].EncodeMsg(en)
+			if z.TopNamespaces == nil {
+				err = en.WriteNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+			} else {
+				err = z.TopNamespaces.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces")
 					return
 				}
 			}
@@ -38051,15 +38048,15 @@ func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			if err != nil {
 				return
 			}
-			err = en.WriteArrayHeader(uint32(len(z.TopTables)))
-			if err != nil {
-				err = msgp.WrapError(err, "TopTables")
-				return
-			}
-			for za0003 := range z.TopTables {
-				err = z.TopTables[za0003].EncodeMsg(en)
+			if z.TopTables == nil {
+				err = en.WriteNil()
 				if err != nil {
-					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+			} else {
+				err = z.TopTables.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables")
 					return
 				}
 			}
@@ -38152,11 +38149,12 @@ func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
 			// string "topW"
 			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x57)
-			o = msgp.AppendArrayHeader(o, uint32(len(z.TopWarehouses)))
-			for za0001 := range z.TopWarehouses {
-				o, err = z.TopWarehouses[za0001].MarshalMsg(o)
+			if z.TopWarehouses == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.TopWarehouses.MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					err = msgp.WrapError(err, "TopWarehouses")
 					return
 				}
 			}
@@ -38164,11 +38162,12 @@ func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// string "topN"
 			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x4e)
-			o = msgp.AppendArrayHeader(o, uint32(len(z.TopNamespaces)))
-			for za0002 := range z.TopNamespaces {
-				o, err = z.TopNamespaces[za0002].MarshalMsg(o)
+			if z.TopNamespaces == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.TopNamespaces.MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					err = msgp.WrapError(err, "TopNamespaces")
 					return
 				}
 			}
@@ -38176,11 +38175,12 @@ func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// string "topT"
 			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x54)
-			o = msgp.AppendArrayHeader(o, uint32(len(z.TopTables)))
-			for za0003 := range z.TopTables {
-				o, err = z.TopTables[za0003].MarshalMsg(o)
+			if z.TopTables == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.TopTables.MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "TopTables", za0003)
+					err = msgp.WrapError(err, "TopTables")
 					return
 				}
 			}
@@ -38276,61 +38276,55 @@ func (z *TableAPIMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x4
 		case "topW":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "TopWarehouses")
-				return
-			}
-			if cap(z.TopWarehouses) >= int(zb0002) {
-				z.TopWarehouses = (z.TopWarehouses)[:zb0002]
-			} else {
-				z.TopWarehouses = make([]TableIOMetrics, zb0002)
-			}
-			for za0001 := range z.TopWarehouses {
-				bts, err = z.TopWarehouses[za0001].UnmarshalMsg(bts)
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+				z.TopWarehouses = nil
+			} else {
+				if z.TopWarehouses == nil {
+					z.TopWarehouses = new(TopTableIO)
+				}
+				bts, err = z.TopWarehouses.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses")
 					return
 				}
 			}
 			zb0001Mask |= 0x8
 		case "topN":
-			var zb0003 uint32
-			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "TopNamespaces")
-				return
-			}
-			if cap(z.TopNamespaces) >= int(zb0003) {
-				z.TopNamespaces = (z.TopNamespaces)[:zb0003]
-			} else {
-				z.TopNamespaces = make([]TableIOMetrics, zb0003)
-			}
-			for za0002 := range z.TopNamespaces {
-				bts, err = z.TopNamespaces[za0002].UnmarshalMsg(bts)
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+				z.TopNamespaces = nil
+			} else {
+				if z.TopNamespaces == nil {
+					z.TopNamespaces = new(TopTableIO)
+				}
+				bts, err = z.TopNamespaces.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces")
 					return
 				}
 			}
 			zb0001Mask |= 0x10
 		case "topT":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "TopTables")
-				return
-			}
-			if cap(z.TopTables) >= int(zb0004) {
-				z.TopTables = (z.TopTables)[:zb0004]
-			} else {
-				z.TopTables = make([]TableIOMetrics, zb0004)
-			}
-			for za0003 := range z.TopTables {
-				bts, err = z.TopTables[za0003].UnmarshalMsg(bts)
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+				z.TopTables = nil
+			} else {
+				if z.TopTables == nil {
+					z.TopTables = new(TopTableIO)
+				}
+				bts, err = z.TopTables.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables")
 					return
 				}
 			}
@@ -38388,17 +38382,23 @@ func (z *TableAPIMetrics) Msgsize() (s int) {
 	} else {
 		s += z.LastDay.Msgsize()
 	}
-	s += 5 + msgp.ArrayHeaderSize
-	for za0001 := range z.TopWarehouses {
-		s += z.TopWarehouses[za0001].Msgsize()
+	s += 5
+	if z.TopWarehouses == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.TopWarehouses.Msgsize()
 	}
-	s += 5 + msgp.ArrayHeaderSize
-	for za0002 := range z.TopNamespaces {
-		s += z.TopNamespaces[za0002].Msgsize()
+	s += 5
+	if z.TopNamespaces == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.TopNamespaces.Msgsize()
 	}
-	s += 5 + msgp.ArrayHeaderSize
-	for za0003 := range z.TopTables {
-		s += z.TopTables[za0003].Msgsize()
+	s += 5
+	if z.TopTables == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.TopTables.Msgsize()
 	}
 	return
 }
@@ -38423,49 +38423,49 @@ func (z *TableAPIStat) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "reads":
+		case "r":
 			z.Reads, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Reads")
 				return
 			}
 			zb0001Mask |= 0x1
-		case "writes":
+		case "w":
 			z.Writes, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Writes")
 				return
 			}
 			zb0001Mask |= 0x2
-		case "bytesIn":
+		case "in":
 			z.BytesIn, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "BytesIn")
 				return
 			}
 			zb0001Mask |= 0x4
-		case "bytesOut":
+		case "out":
 			z.BytesOut, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "BytesOut")
 				return
 			}
 			zb0001Mask |= 0x8
-		case "notOK":
+		case "err":
 			z.NotOK, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "NotOK")
 				return
 			}
 			zb0001Mask |= 0x10
-		case "timeSecs":
+		case "rSecs":
 			z.RequestTimeSecs, err = dc.ReadFloat64()
 			if err != nil {
 				err = msgp.WrapError(err, "RequestTimeSecs")
 				return
 			}
 			zb0001Mask |= 0x20
-		case "ttfbSecs":
+		case "ttfb":
 			z.RespTTFBSecs, err = dc.ReadFloat64()
 			if err != nil {
 				err = msgp.WrapError(err, "RespTTFBSecs")
@@ -38550,8 +38550,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 	// skip if no fields are to be emitted
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x1) == 0 { // if not omitted
-			// write "reads"
-			err = en.Append(0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			// write "r"
+			err = en.Append(0xa1, 0x72)
 			if err != nil {
 				return
 			}
@@ -38562,8 +38562,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x2) == 0 { // if not omitted
-			// write "writes"
-			err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			// write "w"
+			err = en.Append(0xa1, 0x77)
 			if err != nil {
 				return
 			}
@@ -38574,8 +38574,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not omitted
-			// write "bytesIn"
-			err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			// write "in"
+			err = en.Append(0xa2, 0x69, 0x6e)
 			if err != nil {
 				return
 			}
@@ -38586,8 +38586,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
-			// write "bytesOut"
-			err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			// write "out"
+			err = en.Append(0xa3, 0x6f, 0x75, 0x74)
 			if err != nil {
 				return
 			}
@@ -38598,8 +38598,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// write "notOK"
-			err = en.Append(0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x4b)
+			// write "err"
+			err = en.Append(0xa3, 0x65, 0x72, 0x72)
 			if err != nil {
 				return
 			}
@@ -38610,8 +38610,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// write "timeSecs"
-			err = en.Append(0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			// write "rSecs"
+			err = en.Append(0xa5, 0x72, 0x53, 0x65, 0x63, 0x73)
 			if err != nil {
 				return
 			}
@@ -38622,8 +38622,8 @@ func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// write "ttfbSecs"
-			err = en.Append(0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			// write "ttfb"
+			err = en.Append(0xa4, 0x74, 0x74, 0x66, 0x62)
 			if err != nil {
 				return
 			}
@@ -38678,38 +38678,38 @@ func (z *TableAPIStat) MarshalMsg(b []byte) (o []byte, err error) {
 	// skip if no fields are to be emitted
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x1) == 0 { // if not omitted
-			// string "reads"
-			o = append(o, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			// string "r"
+			o = append(o, 0xa1, 0x72)
 			o = msgp.AppendInt64(o, z.Reads)
 		}
 		if (zb0001Mask & 0x2) == 0 { // if not omitted
-			// string "writes"
-			o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			// string "w"
+			o = append(o, 0xa1, 0x77)
 			o = msgp.AppendInt64(o, z.Writes)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not omitted
-			// string "bytesIn"
-			o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			// string "in"
+			o = append(o, 0xa2, 0x69, 0x6e)
 			o = msgp.AppendInt64(o, z.BytesIn)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
-			// string "bytesOut"
-			o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			// string "out"
+			o = append(o, 0xa3, 0x6f, 0x75, 0x74)
 			o = msgp.AppendInt64(o, z.BytesOut)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// string "notOK"
-			o = append(o, 0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x4b)
+			// string "err"
+			o = append(o, 0xa3, 0x65, 0x72, 0x72)
 			o = msgp.AppendInt64(o, z.NotOK)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// string "timeSecs"
-			o = append(o, 0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			// string "rSecs"
+			o = append(o, 0xa5, 0x72, 0x53, 0x65, 0x63, 0x73)
 			o = msgp.AppendFloat64(o, z.RequestTimeSecs)
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// string "ttfbSecs"
-			o = append(o, 0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			// string "ttfb"
+			o = append(o, 0xa4, 0x74, 0x74, 0x66, 0x62)
 			o = msgp.AppendFloat64(o, z.RespTTFBSecs)
 		}
 	}
@@ -38736,49 +38736,49 @@ func (z *TableAPIStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "reads":
+		case "r":
 			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Reads")
 				return
 			}
 			zb0001Mask |= 0x1
-		case "writes":
+		case "w":
 			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Writes")
 				return
 			}
 			zb0001Mask |= 0x2
-		case "bytesIn":
+		case "in":
 			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "BytesIn")
 				return
 			}
 			zb0001Mask |= 0x4
-		case "bytesOut":
+		case "out":
 			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "BytesOut")
 				return
 			}
 			zb0001Mask |= 0x8
-		case "notOK":
+		case "err":
 			z.NotOK, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "NotOK")
 				return
 			}
 			zb0001Mask |= 0x10
-		case "timeSecs":
+		case "rSecs":
 			z.RequestTimeSecs, bts, err = msgp.ReadFloat64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "RequestTimeSecs")
 				return
 			}
 			zb0001Mask |= 0x20
-		case "ttfbSecs":
+		case "ttfb":
 			z.RespTTFBSecs, bts, err = msgp.ReadFloat64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "RespTTFBSecs")
@@ -38823,7 +38823,7 @@ func (z *TableAPIStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *TableAPIStat) Msgsize() (s int) {
-	s = 1 + 6 + msgp.Int64Size + 7 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Int64Size + 6 + msgp.Int64Size + 9 + msgp.Float64Size + 9 + msgp.Float64Size
+	s = 1 + 2 + msgp.Int64Size + 2 + msgp.Int64Size + 3 + msgp.Int64Size + 4 + msgp.Int64Size + 4 + msgp.Int64Size + 6 + msgp.Float64Size + 5 + msgp.Float64Size
 	return
 }
 
@@ -38837,7 +38837,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 3 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -38901,63 +38901,55 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "lastMinute":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "LastMinute")
-					return
-				}
-				z.LastMinute = nil
-			} else {
-				if z.LastMinute == nil {
-					z.LastMinute = new(TableAPIStat)
-				}
-				err = z.LastMinute.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "LastMinute")
-					return
-				}
+		case "r":
+			z.Reads, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
 			}
 			zb0001Mask |= 0x1
-		case "lastHour":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "LastHour")
-					return
-				}
-				z.LastHour = nil
-			} else {
-				if z.LastHour == nil {
-					z.LastHour = new(TableAPIStat)
-				}
-				err = z.LastHour.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "LastHour")
-					return
-				}
+		case "w":
+			z.Writes, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
 			}
 			zb0001Mask |= 0x2
-		case "lastDay":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "LastDay")
-					return
-				}
-				z.LastDay = nil
-			} else {
-				if z.LastDay == nil {
-					z.LastDay = new(TableAPIStat)
-				}
-				err = z.LastDay.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "LastDay")
-					return
-				}
+		case "in":
+			z.BytesIn, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
 			}
 			zb0001Mask |= 0x4
+		case "out":
+			z.BytesOut, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "err":
+			z.NotOK, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "rSecs":
+			z.RequestTimeSecs, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "ttfb":
+			z.RespTTFBSecs, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			zb0001Mask |= 0x40
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -38967,15 +38959,27 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7 {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
-			z.LastMinute = nil
+			z.Reads = 0
 		}
 		if (zb0001Mask & 0x2) == 0 {
-			z.LastHour = nil
+			z.Writes = 0
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.LastDay = nil
+			z.BytesIn = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = 0
 		}
 	}
 	return
@@ -38984,20 +38988,36 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
-	if z.LastMinute == nil {
+	if z.Reads == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.LastHour == nil {
+	if z.Writes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.LastDay == nil {
+	if z.BytesIn == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if z.BytesOut == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.NotOK == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.RequestTimeSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.RespTTFBSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -39059,60 +39079,87 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
-			// write "lastMinute"
-			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			// write "r"
+			err = en.Append(0xa1, 0x72)
 			if err != nil {
 				return
 			}
-			if z.LastMinute == nil {
-				err = en.WriteNil()
-				if err != nil {
-					return
-				}
-			} else {
-				err = z.LastMinute.EncodeMsg(en)
-				if err != nil {
-					err = msgp.WrapError(err, "LastMinute")
-					return
-				}
+			err = en.WriteInt64(z.Reads)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// write "lastHour"
-			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			// write "w"
+			err = en.Append(0xa1, 0x77)
 			if err != nil {
 				return
 			}
-			if z.LastHour == nil {
-				err = en.WriteNil()
-				if err != nil {
-					return
-				}
-			} else {
-				err = z.LastHour.EncodeMsg(en)
-				if err != nil {
-					err = msgp.WrapError(err, "LastHour")
-					return
-				}
+			err = en.WriteInt64(z.Writes)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
 			}
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// write "lastDay"
-			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			// write "in"
+			err = en.Append(0xa2, 0x69, 0x6e)
 			if err != nil {
 				return
 			}
-			if z.LastDay == nil {
-				err = en.WriteNil()
-				if err != nil {
-					return
-				}
-			} else {
-				err = z.LastDay.EncodeMsg(en)
-				if err != nil {
-					err = msgp.WrapError(err, "LastDay")
-					return
-				}
+			err = en.WriteInt64(z.BytesIn)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "out"
+			err = en.Append(0xa3, 0x6f, 0x75, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.BytesOut)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "err"
+			err = en.Append(0xa3, 0x65, 0x72, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.NotOK)
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "rSecs"
+			err = en.Append(0xa5, 0x72, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.RequestTimeSecs)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "ttfb"
+			err = en.Append(0xa4, 0x74, 0x74, 0x66, 0x62)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.RespTTFBSecs)
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
 			}
 		}
 	}
@@ -39123,20 +39170,36 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
-	if z.LastMinute == nil {
+	if z.Reads == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.LastHour == nil {
+	if z.Writes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.LastDay == nil {
+	if z.BytesIn == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if z.BytesOut == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.NotOK == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.RequestTimeSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.RespTTFBSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -39165,43 +39228,39 @@ func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendString(o, *z.Warehouse)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
-			// string "lastMinute"
-			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
-			if z.LastMinute == nil {
-				o = msgp.AppendNil(o)
-			} else {
-				o, err = z.LastMinute.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "LastMinute")
-					return
-				}
-			}
+			// string "r"
+			o = append(o, 0xa1, 0x72)
+			o = msgp.AppendInt64(o, z.Reads)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// string "lastHour"
-			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
-			if z.LastHour == nil {
-				o = msgp.AppendNil(o)
-			} else {
-				o, err = z.LastHour.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "LastHour")
-					return
-				}
-			}
+			// string "w"
+			o = append(o, 0xa1, 0x77)
+			o = msgp.AppendInt64(o, z.Writes)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// string "lastDay"
-			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
-			if z.LastDay == nil {
-				o = msgp.AppendNil(o)
-			} else {
-				o, err = z.LastDay.MarshalMsg(o)
-				if err != nil {
-					err = msgp.WrapError(err, "LastDay")
-					return
-				}
-			}
+			// string "in"
+			o = append(o, 0xa2, 0x69, 0x6e)
+			o = msgp.AppendInt64(o, z.BytesIn)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "out"
+			o = append(o, 0xa3, 0x6f, 0x75, 0x74)
+			o = msgp.AppendInt64(o, z.BytesOut)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "err"
+			o = append(o, 0xa3, 0x65, 0x72, 0x72)
+			o = msgp.AppendInt64(o, z.NotOK)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "rSecs"
+			o = append(o, 0xa5, 0x72, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendFloat64(o, z.RequestTimeSecs)
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "ttfb"
+			o = append(o, 0xa4, 0x74, 0x74, 0x66, 0x62)
+			o = msgp.AppendFloat64(o, z.RespTTFBSecs)
 		}
 	}
 	return
@@ -39217,7 +39276,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 3 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -39278,60 +39337,55 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-		case "lastMinute":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.LastMinute = nil
-			} else {
-				if z.LastMinute == nil {
-					z.LastMinute = new(TableAPIStat)
-				}
-				bts, err = z.LastMinute.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "LastMinute")
-					return
-				}
+		case "r":
+			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
 			}
 			zb0001Mask |= 0x1
-		case "lastHour":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.LastHour = nil
-			} else {
-				if z.LastHour == nil {
-					z.LastHour = new(TableAPIStat)
-				}
-				bts, err = z.LastHour.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "LastHour")
-					return
-				}
+		case "w":
+			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
 			}
 			zb0001Mask |= 0x2
-		case "lastDay":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.LastDay = nil
-			} else {
-				if z.LastDay == nil {
-					z.LastDay = new(TableAPIStat)
-				}
-				bts, err = z.LastDay.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "LastDay")
-					return
-				}
+		case "in":
+			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
 			}
 			zb0001Mask |= 0x4
+		case "out":
+			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "err":
+			z.NotOK, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "rSecs":
+			z.RequestTimeSecs, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "ttfb":
+			z.RespTTFBSecs, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			zb0001Mask |= 0x40
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -39341,15 +39395,27 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7 {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
-			z.LastMinute = nil
+			z.Reads = 0
 		}
 		if (zb0001Mask & 0x2) == 0 {
-			z.LastHour = nil
+			z.Writes = 0
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.LastDay = nil
+			z.BytesIn = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = 0
 		}
 	}
 	o = bts
@@ -39376,23 +39442,648 @@ func (z *TableIOMetrics) Msgsize() (s int) {
 	} else {
 		s += msgp.StringPrefixSize + len(*z.Warehouse)
 	}
-	s += 11
-	if z.LastMinute == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.LastMinute.Msgsize()
+	s += 2 + msgp.Int64Size + 2 + msgp.Int64Size + 3 + msgp.Int64Size + 4 + msgp.Int64Size + 4 + msgp.Int64Size + 6 + msgp.Float64Size + 5 + msgp.Float64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TopTableIO) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
 	}
-	s += 9
-	if z.LastHour == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.LastHour.Msgsize()
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reqMin":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsMin")
+				return
+			}
+			if cap(z.ByRequestsMin) >= int(zb0002) {
+				z.ByRequestsMin = (z.ByRequestsMin)[:zb0002]
+			} else {
+				z.ByRequestsMin = make([]TableIOMetrics, zb0002)
+			}
+			for za0001 := range z.ByRequestsMin {
+				err = z.ByRequestsMin[za0001].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsMin", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "thrMin":
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputMin")
+				return
+			}
+			if cap(z.ByThroughputMin) >= int(zb0003) {
+				z.ByThroughputMin = (z.ByThroughputMin)[:zb0003]
+			} else {
+				z.ByThroughputMin = make([]TableIOMetrics, zb0003)
+			}
+			for za0002 := range z.ByThroughputMin {
+				err = z.ByThroughputMin[za0002].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputMin", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "reqHour":
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsHour")
+				return
+			}
+			if cap(z.ByRequestsHour) >= int(zb0004) {
+				z.ByRequestsHour = (z.ByRequestsHour)[:zb0004]
+			} else {
+				z.ByRequestsHour = make([]TableIOMetrics, zb0004)
+			}
+			for za0003 := range z.ByRequestsHour {
+				err = z.ByRequestsHour[za0003].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsHour", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "thrHour":
+			var zb0005 uint32
+			zb0005, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputHour")
+				return
+			}
+			if cap(z.ByThroughputHour) >= int(zb0005) {
+				z.ByThroughputHour = (z.ByThroughputHour)[:zb0005]
+			} else {
+				z.ByThroughputHour = make([]TableIOMetrics, zb0005)
+			}
+			for za0004 := range z.ByThroughputHour {
+				err = z.ByThroughputHour[za0004].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputHour", za0004)
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "reqDay":
+			var zb0006 uint32
+			zb0006, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsDay")
+				return
+			}
+			if cap(z.ByRequestsDay) >= int(zb0006) {
+				z.ByRequestsDay = (z.ByRequestsDay)[:zb0006]
+			} else {
+				z.ByRequestsDay = make([]TableIOMetrics, zb0006)
+			}
+			for za0005 := range z.ByRequestsDay {
+				err = z.ByRequestsDay[za0005].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsDay", za0005)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "thrDay":
+			var zb0007 uint32
+			zb0007, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputDay")
+				return
+			}
+			if cap(z.ByThroughputDay) >= int(zb0007) {
+				z.ByThroughputDay = (z.ByThroughputDay)[:zb0007]
+			} else {
+				z.ByThroughputDay = make([]TableIOMetrics, zb0007)
+			}
+			for za0006 := range z.ByThroughputDay {
+				err = z.ByThroughputDay[za0006].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputDay", za0006)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
 	}
-	s += 8
-	if z.LastDay == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.LastDay.Msgsize()
+	// Clear omitted fields.
+	if zb0001Mask != 0x3f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ByRequestsMin = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.ByThroughputMin = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.ByRequestsHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.ByThroughputHour = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.ByRequestsDay = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.ByThroughputDay = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TopTableIO) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	if z.ByRequestsMin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.ByThroughputMin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.ByRequestsHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.ByThroughputHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.ByRequestsDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.ByThroughputDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "reqMin"
+			err = en.Append(0xa6, 0x72, 0x65, 0x71, 0x4d, 0x69, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByRequestsMin)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsMin")
+				return
+			}
+			for za0001 := range z.ByRequestsMin {
+				err = z.ByRequestsMin[za0001].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsMin", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "thrMin"
+			err = en.Append(0xa6, 0x74, 0x68, 0x72, 0x4d, 0x69, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByThroughputMin)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputMin")
+				return
+			}
+			for za0002 := range z.ByThroughputMin {
+				err = z.ByThroughputMin[za0002].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputMin", za0002)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "reqHour"
+			err = en.Append(0xa7, 0x72, 0x65, 0x71, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByRequestsHour)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsHour")
+				return
+			}
+			for za0003 := range z.ByRequestsHour {
+				err = z.ByRequestsHour[za0003].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsHour", za0003)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "thrHour"
+			err = en.Append(0xa7, 0x74, 0x68, 0x72, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByThroughputHour)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputHour")
+				return
+			}
+			for za0004 := range z.ByThroughputHour {
+				err = z.ByThroughputHour[za0004].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputHour", za0004)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "reqDay"
+			err = en.Append(0xa6, 0x72, 0x65, 0x71, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByRequestsDay)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsDay")
+				return
+			}
+			for za0005 := range z.ByRequestsDay {
+				err = z.ByRequestsDay[za0005].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsDay", za0005)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "thrDay"
+			err = en.Append(0xa6, 0x74, 0x68, 0x72, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.ByThroughputDay)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputDay")
+				return
+			}
+			for za0006 := range z.ByThroughputDay {
+				err = z.ByThroughputDay[za0006].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputDay", za0006)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TopTableIO) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	if z.ByRequestsMin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.ByThroughputMin == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.ByRequestsHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.ByThroughputHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.ByRequestsDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.ByThroughputDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "reqMin"
+			o = append(o, 0xa6, 0x72, 0x65, 0x71, 0x4d, 0x69, 0x6e)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByRequestsMin)))
+			for za0001 := range z.ByRequestsMin {
+				o, err = z.ByRequestsMin[za0001].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsMin", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "thrMin"
+			o = append(o, 0xa6, 0x74, 0x68, 0x72, 0x4d, 0x69, 0x6e)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByThroughputMin)))
+			for za0002 := range z.ByThroughputMin {
+				o, err = z.ByThroughputMin[za0002].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputMin", za0002)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "reqHour"
+			o = append(o, 0xa7, 0x72, 0x65, 0x71, 0x48, 0x6f, 0x75, 0x72)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByRequestsHour)))
+			for za0003 := range z.ByRequestsHour {
+				o, err = z.ByRequestsHour[za0003].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsHour", za0003)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "thrHour"
+			o = append(o, 0xa7, 0x74, 0x68, 0x72, 0x48, 0x6f, 0x75, 0x72)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByThroughputHour)))
+			for za0004 := range z.ByThroughputHour {
+				o, err = z.ByThroughputHour[za0004].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputHour", za0004)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "reqDay"
+			o = append(o, 0xa6, 0x72, 0x65, 0x71, 0x44, 0x61, 0x79)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByRequestsDay)))
+			for za0005 := range z.ByRequestsDay {
+				o, err = z.ByRequestsDay[za0005].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsDay", za0005)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "thrDay"
+			o = append(o, 0xa6, 0x74, 0x68, 0x72, 0x44, 0x61, 0x79)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ByThroughputDay)))
+			for za0006 := range z.ByThroughputDay {
+				o, err = z.ByThroughputDay[za0006].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputDay", za0006)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TopTableIO) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reqMin":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsMin")
+				return
+			}
+			if cap(z.ByRequestsMin) >= int(zb0002) {
+				z.ByRequestsMin = (z.ByRequestsMin)[:zb0002]
+			} else {
+				z.ByRequestsMin = make([]TableIOMetrics, zb0002)
+			}
+			for za0001 := range z.ByRequestsMin {
+				bts, err = z.ByRequestsMin[za0001].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsMin", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "thrMin":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputMin")
+				return
+			}
+			if cap(z.ByThroughputMin) >= int(zb0003) {
+				z.ByThroughputMin = (z.ByThroughputMin)[:zb0003]
+			} else {
+				z.ByThroughputMin = make([]TableIOMetrics, zb0003)
+			}
+			for za0002 := range z.ByThroughputMin {
+				bts, err = z.ByThroughputMin[za0002].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputMin", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "reqHour":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsHour")
+				return
+			}
+			if cap(z.ByRequestsHour) >= int(zb0004) {
+				z.ByRequestsHour = (z.ByRequestsHour)[:zb0004]
+			} else {
+				z.ByRequestsHour = make([]TableIOMetrics, zb0004)
+			}
+			for za0003 := range z.ByRequestsHour {
+				bts, err = z.ByRequestsHour[za0003].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsHour", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "thrHour":
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputHour")
+				return
+			}
+			if cap(z.ByThroughputHour) >= int(zb0005) {
+				z.ByThroughputHour = (z.ByThroughputHour)[:zb0005]
+			} else {
+				z.ByThroughputHour = make([]TableIOMetrics, zb0005)
+			}
+			for za0004 := range z.ByThroughputHour {
+				bts, err = z.ByThroughputHour[za0004].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputHour", za0004)
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "reqDay":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByRequestsDay")
+				return
+			}
+			if cap(z.ByRequestsDay) >= int(zb0006) {
+				z.ByRequestsDay = (z.ByRequestsDay)[:zb0006]
+			} else {
+				z.ByRequestsDay = make([]TableIOMetrics, zb0006)
+			}
+			for za0005 := range z.ByRequestsDay {
+				bts, err = z.ByRequestsDay[za0005].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByRequestsDay", za0005)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "thrDay":
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByThroughputDay")
+				return
+			}
+			if cap(z.ByThroughputDay) >= int(zb0007) {
+				z.ByThroughputDay = (z.ByThroughputDay)[:zb0007]
+			} else {
+				z.ByThroughputDay = make([]TableIOMetrics, zb0007)
+			}
+			for za0006 := range z.ByThroughputDay {
+				bts, err = z.ByThroughputDay[za0006].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByThroughputDay", za0006)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ByRequestsMin = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.ByThroughputMin = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.ByRequestsHour = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.ByThroughputHour = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.ByRequestsDay = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.ByThroughputDay = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TopTableIO) Msgsize() (s int) {
+	s = 1 + 7 + msgp.ArrayHeaderSize
+	for za0001 := range z.ByRequestsMin {
+		s += z.ByRequestsMin[za0001].Msgsize()
+	}
+	s += 7 + msgp.ArrayHeaderSize
+	for za0002 := range z.ByThroughputMin {
+		s += z.ByThroughputMin[za0002].Msgsize()
+	}
+	s += 8 + msgp.ArrayHeaderSize
+	for za0003 := range z.ByRequestsHour {
+		s += z.ByRequestsHour[za0003].Msgsize()
+	}
+	s += 8 + msgp.ArrayHeaderSize
+	for za0004 := range z.ByThroughputHour {
+		s += z.ByThroughputHour[za0004].Msgsize()
+	}
+	s += 7 + msgp.ArrayHeaderSize
+	for za0005 := range z.ByRequestsDay {
+		s += z.ByRequestsDay[za0005].Msgsize()
+	}
+	s += 7 + msgp.ArrayHeaderSize
+	for za0006 := range z.ByThroughputDay {
+		s += z.ByThroughputDay[za0006].Msgsize()
 	}
 	return
 }

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -18259,76 +18259,23 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
-		case "tables":
+		case "tables_api":
 			if dc.IsNil() {
 				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "Tables")
+					err = msgp.WrapError(err, "TablesAPI")
 					return
 				}
-				z.Tables = nil
+				z.TablesAPI = nil
 			} else {
-				if z.Tables == nil {
-					z.Tables = new(TableAPIMetrics)
+				if z.TablesAPI == nil {
+					z.TablesAPI = new(TableAPIMetrics)
 				}
-				var zb0002 uint32
-				zb0002, err = dc.ReadMapHeader()
+				err = z.TablesAPI.DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "Tables")
+					err = msgp.WrapError(err, "TablesAPI")
 					return
 				}
-				var zb0002Mask uint8 /* 1 bits */
-				_ = zb0002Mask
-				for zb0002 > 0 {
-					zb0002--
-					field, err = dc.ReadMapKeyPtr()
-					if err != nil {
-						err = msgp.WrapError(err, "Tables")
-						return
-					}
-					switch msgp.UnsafeString(field) {
-					case "tables":
-						var zb0003 uint32
-						zb0003, err = dc.ReadMapHeader()
-						if err != nil {
-							err = msgp.WrapError(err, "Tables", "Tables")
-							return
-						}
-						if z.Tables.Tables == nil {
-							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
-						} else if len(z.Tables.Tables) > 0 {
-							clear(z.Tables.Tables)
-						}
-						for zb0003 > 0 {
-							zb0003--
-							var za0001 string
-							za0001, err = dc.ReadString()
-							if err != nil {
-								err = msgp.WrapError(err, "Tables", "Tables")
-								return
-							}
-							var za0002 TableIOMetrics
-							err = za0002.DecodeMsg(dc)
-							if err != nil {
-								err = msgp.WrapError(err, "Tables", "Tables", za0001)
-								return
-							}
-							z.Tables.Tables[za0001] = za0002
-						}
-						zb0002Mask |= 0x1
-					default:
-						err = dc.Skip()
-						if err != nil {
-							err = msgp.WrapError(err, "Tables")
-							return
-						}
-					}
-				}
-				// Clear omitted fields.
-				if (zb0002Mask & 0x1) == 0 {
-					z.Tables.Tables = nil
-				}
-
 			}
 			zb0001Mask |= 0x10000
 		default:
@@ -18390,7 +18337,7 @@ func (z *Metrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.KMS = nil
 		}
 		if (zb0001Mask & 0x10000) == 0 {
-			z.Tables = nil
+			z.TablesAPI = nil
 		}
 	}
 	return
@@ -18466,7 +18413,7 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8000
 	}
-	if z.Tables == nil {
+	if z.TablesAPI == nil {
 		zb0001Len--
 		zb0001Mask |= 0x10000
 	}
@@ -18783,53 +18730,21 @@ func (z *Metrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x10000) == 0 { // if not omitted
-			// write "tables"
-			err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
+			// write "tables_api"
+			err = en.Append(0xaa, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x5f, 0x61, 0x70, 0x69)
 			if err != nil {
 				return
 			}
-			if z.Tables == nil {
+			if z.TablesAPI == nil {
 				err = en.WriteNil()
 				if err != nil {
 					return
 				}
 			} else {
-				// check for omitted fields
-				zb0002Len := uint32(1)
-				var zb0002Mask uint8 /* 1 bits */
-				_ = zb0002Mask
-				if z.Tables.Tables == nil {
-					zb0002Len--
-					zb0002Mask |= 0x1
-				}
-				// variable map header, size zb0002Len
-				err = en.Append(0x80 | uint8(zb0002Len))
+				err = z.TablesAPI.EncodeMsg(en)
 				if err != nil {
+					err = msgp.WrapError(err, "TablesAPI")
 					return
-				}
-				if (zb0002Mask & 0x1) == 0 { // if not omitted
-					// write "tables"
-					err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-					if err != nil {
-						return
-					}
-					err = en.WriteMapHeader(uint32(len(z.Tables.Tables)))
-					if err != nil {
-						err = msgp.WrapError(err, "Tables", "Tables")
-						return
-					}
-					for za0001, za0002 := range z.Tables.Tables {
-						err = en.WriteString(za0001)
-						if err != nil {
-							err = msgp.WrapError(err, "Tables", "Tables")
-							return
-						}
-						err = za0002.EncodeMsg(en)
-						if err != nil {
-							err = msgp.WrapError(err, "Tables", "Tables", za0001)
-							return
-						}
-					}
 				}
 			}
 		}
@@ -18908,7 +18823,7 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8000
 	}
-	if z.Tables == nil {
+	if z.TablesAPI == nil {
 		zb0001Len--
 		zb0001Mask |= 0x10000
 	}
@@ -19126,33 +19041,15 @@ func (z *Metrics) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x10000) == 0 { // if not omitted
-			// string "tables"
-			o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-			if z.Tables == nil {
+			// string "tables_api"
+			o = append(o, 0xaa, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x5f, 0x61, 0x70, 0x69)
+			if z.TablesAPI == nil {
 				o = msgp.AppendNil(o)
 			} else {
-				// check for omitted fields
-				zb0002Len := uint32(1)
-				var zb0002Mask uint8 /* 1 bits */
-				_ = zb0002Mask
-				if z.Tables.Tables == nil {
-					zb0002Len--
-					zb0002Mask |= 0x1
-				}
-				// variable map header, size zb0002Len
-				o = append(o, 0x80|uint8(zb0002Len))
-				if (zb0002Mask & 0x1) == 0 { // if not omitted
-					// string "tables"
-					o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-					o = msgp.AppendMapHeader(o, uint32(len(z.Tables.Tables)))
-					for za0001, za0002 := range z.Tables.Tables {
-						o = msgp.AppendString(o, za0001)
-						o, err = za0002.MarshalMsg(o)
-						if err != nil {
-							err = msgp.WrapError(err, "Tables", "Tables", za0001)
-							return
-						}
-					}
+				o, err = z.TablesAPI.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "TablesAPI")
+					return
 				}
 			}
 		}
@@ -19468,75 +19365,22 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x8000
-		case "tables":
+		case "tables_api":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
 					return
 				}
-				z.Tables = nil
+				z.TablesAPI = nil
 			} else {
-				if z.Tables == nil {
-					z.Tables = new(TableAPIMetrics)
+				if z.TablesAPI == nil {
+					z.TablesAPI = new(TableAPIMetrics)
 				}
-				var zb0002 uint32
-				zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+				bts, err = z.TablesAPI.UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Tables")
+					err = msgp.WrapError(err, "TablesAPI")
 					return
 				}
-				var zb0002Mask uint8 /* 1 bits */
-				_ = zb0002Mask
-				for zb0002 > 0 {
-					zb0002--
-					field, bts, err = msgp.ReadMapKeyZC(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "Tables")
-						return
-					}
-					switch msgp.UnsafeString(field) {
-					case "tables":
-						var zb0003 uint32
-						zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "Tables", "Tables")
-							return
-						}
-						if z.Tables.Tables == nil {
-							z.Tables.Tables = make(map[string]TableIOMetrics, zb0003)
-						} else if len(z.Tables.Tables) > 0 {
-							clear(z.Tables.Tables)
-						}
-						for zb0003 > 0 {
-							var za0002 TableIOMetrics
-							zb0003--
-							var za0001 string
-							za0001, bts, err = msgp.ReadStringBytes(bts)
-							if err != nil {
-								err = msgp.WrapError(err, "Tables", "Tables")
-								return
-							}
-							bts, err = za0002.UnmarshalMsg(bts)
-							if err != nil {
-								err = msgp.WrapError(err, "Tables", "Tables", za0001)
-								return
-							}
-							z.Tables.Tables[za0001] = za0002
-						}
-						zb0002Mask |= 0x1
-					default:
-						bts, err = msgp.Skip(bts)
-						if err != nil {
-							err = msgp.WrapError(err, "Tables")
-							return
-						}
-					}
-				}
-				// Clear omitted fields.
-				if (zb0002Mask & 0x1) == 0 {
-					z.Tables.Tables = nil
-				}
-
 			}
 			zb0001Mask |= 0x10000
 		default:
@@ -19598,7 +19442,7 @@ func (z *Metrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.KMS = nil
 		}
 		if (zb0001Mask & 0x10000) == 0 {
-			z.Tables = nil
+			z.TablesAPI = nil
 		}
 	}
 	o = bts
@@ -19703,17 +19547,11 @@ func (z *Metrics) Msgsize() (s int) {
 	} else {
 		s += z.KMS.Msgsize()
 	}
-	s += 7
-	if z.Tables == nil {
+	s += 11
+	if z.TablesAPI == nil {
 		s += msgp.NilSize
 	} else {
-		s += 1 + 7 + msgp.MapHeaderSize
-		if z.Tables.Tables != nil {
-			for za0001, za0002 := range z.Tables.Tables {
-				_ = za0002
-				s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
-			}
-		}
+		s += z.TablesAPI.Msgsize()
 	}
 	return
 }
@@ -36337,6 +36175,732 @@ func (z *SegmentedBucketStats) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *SegmentedTableIO) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "intervalSecs":
+			z.IntervalSecs, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "IntervalSecs")
+				return
+			}
+		case "firstTime":
+			z.FirstTime, err = dc.ReadTimeUTC()
+			if err != nil {
+				err = msgp.WrapError(err, "FirstTime")
+				return
+			}
+		case "reads":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+			if cap(z.Reads) >= int(zb0002) {
+				z.Reads = (z.Reads)[:zb0002]
+			} else {
+				z.Reads = make([]int64, zb0002)
+			}
+			for za0001 := range z.Reads {
+				z.Reads[za0001], err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "Reads", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "writes":
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+			if cap(z.Writes) >= int(zb0003) {
+				z.Writes = (z.Writes)[:zb0003]
+			} else {
+				z.Writes = make([]int64, zb0003)
+			}
+			for za0002 := range z.Writes {
+				z.Writes[za0002], err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "Writes", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "bytesIn":
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+			if cap(z.BytesIn) >= int(zb0004) {
+				z.BytesIn = (z.BytesIn)[:zb0004]
+			} else {
+				z.BytesIn = make([]int64, zb0004)
+			}
+			for za0003 := range z.BytesIn {
+				z.BytesIn[za0003], err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "BytesIn", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "bytesOut":
+			var zb0005 uint32
+			zb0005, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			if cap(z.BytesOut) >= int(zb0005) {
+				z.BytesOut = (z.BytesOut)[:zb0005]
+			} else {
+				z.BytesOut = make([]int64, zb0005)
+			}
+			for za0004 := range z.BytesOut {
+				z.BytesOut[za0004], err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "BytesOut", za0004)
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "errors":
+			var zb0006 uint32
+			zb0006, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			if cap(z.NotOK) >= int(zb0006) {
+				z.NotOK = (z.NotOK)[:zb0006]
+			} else {
+				z.NotOK = make([]int64, zb0006)
+			}
+			for za0005 := range z.NotOK {
+				z.NotOK[za0005], err = dc.ReadInt64()
+				if err != nil {
+					err = msgp.WrapError(err, "NotOK", za0005)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "timeSecs":
+			var zb0007 uint32
+			zb0007, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			if cap(z.RequestTimeSecs) >= int(zb0007) {
+				z.RequestTimeSecs = (z.RequestTimeSecs)[:zb0007]
+			} else {
+				z.RequestTimeSecs = make([]float32, zb0007)
+			}
+			for za0006 := range z.RequestTimeSecs {
+				z.RequestTimeSecs[za0006], err = dc.ReadFloat32()
+				if err != nil {
+					err = msgp.WrapError(err, "RequestTimeSecs", za0006)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		case "ttfbSecs":
+			var zb0008 uint32
+			zb0008, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			if cap(z.RespTTFBSecs) >= int(zb0008) {
+				z.RespTTFBSecs = (z.RespTTFBSecs)[:zb0008]
+			} else {
+				z.RespTTFBSecs = make([]float32, zb0008)
+			}
+			for za0007 := range z.RespTTFBSecs {
+				z.RespTTFBSecs[za0007], err = dc.ReadFloat32()
+				if err != nil {
+					err = msgp.WrapError(err, "RespTTFBSecs", za0007)
+					return
+				}
+			}
+			zb0001Mask |= 0x40
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Reads = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Writes = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.BytesIn = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *SegmentedTableIO) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
+	_ = zb0001Mask
+	if z.Reads == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.Writes == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.BytesIn == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.BytesOut == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.NotOK == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.RequestTimeSecs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.RespTTFBSecs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// write "intervalSecs"
+		err = en.Append(0xac, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c, 0x53, 0x65, 0x63, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.IntervalSecs)
+		if err != nil {
+			err = msgp.WrapError(err, "IntervalSecs")
+			return
+		}
+		// write "firstTime"
+		err = en.Append(0xa9, 0x66, 0x69, 0x72, 0x73, 0x74, 0x54, 0x69, 0x6d, 0x65)
+		if err != nil {
+			return
+		}
+		err = en.WriteTime(z.FirstTime)
+		if err != nil {
+			err = msgp.WrapError(err, "FirstTime")
+			return
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "reads"
+			err = en.Append(0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.Reads)))
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+			for za0001 := range z.Reads {
+				err = en.WriteInt64(z.Reads[za0001])
+				if err != nil {
+					err = msgp.WrapError(err, "Reads", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "writes"
+			err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.Writes)))
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+			for za0002 := range z.Writes {
+				err = en.WriteInt64(z.Writes[za0002])
+				if err != nil {
+					err = msgp.WrapError(err, "Writes", za0002)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "bytesIn"
+			err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.BytesIn)))
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+			for za0003 := range z.BytesIn {
+				err = en.WriteInt64(z.BytesIn[za0003])
+				if err != nil {
+					err = msgp.WrapError(err, "BytesIn", za0003)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "bytesOut"
+			err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.BytesOut)))
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			for za0004 := range z.BytesOut {
+				err = en.WriteInt64(z.BytesOut[za0004])
+				if err != nil {
+					err = msgp.WrapError(err, "BytesOut", za0004)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "errors"
+			err = en.Append(0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.NotOK)))
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			for za0005 := range z.NotOK {
+				err = en.WriteInt64(z.NotOK[za0005])
+				if err != nil {
+					err = msgp.WrapError(err, "NotOK", za0005)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "timeSecs"
+			err = en.Append(0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.RequestTimeSecs)))
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			for za0006 := range z.RequestTimeSecs {
+				err = en.WriteFloat32(z.RequestTimeSecs[za0006])
+				if err != nil {
+					err = msgp.WrapError(err, "RequestTimeSecs", za0006)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "ttfbSecs"
+			err = en.Append(0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.RespTTFBSecs)))
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			for za0007 := range z.RespTTFBSecs {
+				err = en.WriteFloat32(z.RespTTFBSecs[za0007])
+				if err != nil {
+					err = msgp.WrapError(err, "RespTTFBSecs", za0007)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *SegmentedTableIO) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
+	_ = zb0001Mask
+	if z.Reads == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.Writes == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.BytesIn == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.BytesOut == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.NotOK == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.RequestTimeSecs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.RespTTFBSecs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// string "intervalSecs"
+		o = append(o, 0xac, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c, 0x53, 0x65, 0x63, 0x73)
+		o = msgp.AppendInt(o, z.IntervalSecs)
+		// string "firstTime"
+		o = append(o, 0xa9, 0x66, 0x69, 0x72, 0x73, 0x74, 0x54, 0x69, 0x6d, 0x65)
+		o = msgp.AppendTime(o, z.FirstTime)
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "reads"
+			o = append(o, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.Reads)))
+			for za0001 := range z.Reads {
+				o = msgp.AppendInt64(o, z.Reads[za0001])
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "writes"
+			o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.Writes)))
+			for za0002 := range z.Writes {
+				o = msgp.AppendInt64(o, z.Writes[za0002])
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "bytesIn"
+			o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.BytesIn)))
+			for za0003 := range z.BytesIn {
+				o = msgp.AppendInt64(o, z.BytesIn[za0003])
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "bytesOut"
+			o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.BytesOut)))
+			for za0004 := range z.BytesOut {
+				o = msgp.AppendInt64(o, z.BytesOut[za0004])
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "errors"
+			o = append(o, 0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.NotOK)))
+			for za0005 := range z.NotOK {
+				o = msgp.AppendInt64(o, z.NotOK[za0005])
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "timeSecs"
+			o = append(o, 0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.RequestTimeSecs)))
+			for za0006 := range z.RequestTimeSecs {
+				o = msgp.AppendFloat32(o, z.RequestTimeSecs[za0006])
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "ttfbSecs"
+			o = append(o, 0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.RespTTFBSecs)))
+			for za0007 := range z.RespTTFBSecs {
+				o = msgp.AppendFloat32(o, z.RespTTFBSecs[za0007])
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SegmentedTableIO) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "intervalSecs":
+			z.IntervalSecs, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "IntervalSecs")
+				return
+			}
+		case "firstTime":
+			z.FirstTime, bts, err = msgp.ReadTimeUTCBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "FirstTime")
+				return
+			}
+		case "reads":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+			if cap(z.Reads) >= int(zb0002) {
+				z.Reads = (z.Reads)[:zb0002]
+			} else {
+				z.Reads = make([]int64, zb0002)
+			}
+			for za0001 := range z.Reads {
+				z.Reads[za0001], bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Reads", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "writes":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+			if cap(z.Writes) >= int(zb0003) {
+				z.Writes = (z.Writes)[:zb0003]
+			} else {
+				z.Writes = make([]int64, zb0003)
+			}
+			for za0002 := range z.Writes {
+				z.Writes[za0002], bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Writes", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "bytesIn":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+			if cap(z.BytesIn) >= int(zb0004) {
+				z.BytesIn = (z.BytesIn)[:zb0004]
+			} else {
+				z.BytesIn = make([]int64, zb0004)
+			}
+			for za0003 := range z.BytesIn {
+				z.BytesIn[za0003], bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BytesIn", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "bytesOut":
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			if cap(z.BytesOut) >= int(zb0005) {
+				z.BytesOut = (z.BytesOut)[:zb0005]
+			} else {
+				z.BytesOut = make([]int64, zb0005)
+			}
+			for za0004 := range z.BytesOut {
+				z.BytesOut[za0004], bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "BytesOut", za0004)
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "errors":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			if cap(z.NotOK) >= int(zb0006) {
+				z.NotOK = (z.NotOK)[:zb0006]
+			} else {
+				z.NotOK = make([]int64, zb0006)
+			}
+			for za0005 := range z.NotOK {
+				z.NotOK[za0005], bts, err = msgp.ReadInt64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "NotOK", za0005)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "timeSecs":
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			if cap(z.RequestTimeSecs) >= int(zb0007) {
+				z.RequestTimeSecs = (z.RequestTimeSecs)[:zb0007]
+			} else {
+				z.RequestTimeSecs = make([]float32, zb0007)
+			}
+			for za0006 := range z.RequestTimeSecs {
+				z.RequestTimeSecs[za0006], bts, err = msgp.ReadFloat32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RequestTimeSecs", za0006)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		case "ttfbSecs":
+			var zb0008 uint32
+			zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			if cap(z.RespTTFBSecs) >= int(zb0008) {
+				z.RespTTFBSecs = (z.RespTTFBSecs)[:zb0008]
+			} else {
+				z.RespTTFBSecs = make([]float32, zb0008)
+			}
+			for za0007 := range z.RespTTFBSecs {
+				z.RespTTFBSecs[za0007], bts, err = msgp.ReadFloat32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RespTTFBSecs", za0007)
+					return
+				}
+			}
+			zb0001Mask |= 0x40
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Reads = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Writes = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.BytesIn = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *SegmentedTableIO) Msgsize() (s int) {
+	s = 1 + 13 + msgp.IntSize + 10 + msgp.TimeSize + 6 + msgp.ArrayHeaderSize + (len(z.Reads) * (msgp.Int64Size)) + 7 + msgp.ArrayHeaderSize + (len(z.Writes) * (msgp.Int64Size)) + 8 + msgp.ArrayHeaderSize + (len(z.BytesIn) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.BytesOut) * (msgp.Int64Size)) + 7 + msgp.ArrayHeaderSize + (len(z.NotOK) * (msgp.Int64Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RequestTimeSecs) * (msgp.Float32Size)) + 9 + msgp.ArrayHeaderSize + (len(z.RespTTFBSecs) * (msgp.Float32Size))
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *SensorMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -37157,7 +37721,7 @@ func (z *TableAPIMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 1 bits */
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -37167,227 +37731,18 @@ func (z *TableAPIMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "tables":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+		case "collected":
+			z.CollectedAt, err = dc.ReadTimeUTC()
 			if err != nil {
-				err = msgp.WrapError(err, "Tables")
+				err = msgp.WrapError(err, "CollectedAt")
 				return
 			}
-			if z.Tables == nil {
-				z.Tables = make(map[string]TableIOMetrics, zb0002)
-			} else if len(z.Tables) > 0 {
-				clear(z.Tables)
-			}
-			for zb0002 > 0 {
-				zb0002--
-				var za0001 string
-				za0001, err = dc.ReadString()
-				if err != nil {
-					err = msgp.WrapError(err, "Tables")
-					return
-				}
-				var za0002 TableIOMetrics
-				err = za0002.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "Tables", za0001)
-					return
-				}
-				z.Tables[za0001] = za0002
-			}
-			zb0001Mask |= 0x1
-		default:
-			err = dc.Skip()
+		case "nodes":
+			z.Nodes, err = dc.ReadInt()
 			if err != nil {
-				err = msgp.WrapError(err)
+				err = msgp.WrapError(err, "Nodes")
 				return
 			}
-		}
-	}
-	// Clear omitted fields.
-	if (zb0001Mask & 0x1) == 0 {
-		z.Tables = nil
-	}
-
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
-	// check for omitted fields
-	zb0001Len := uint32(1)
-	var zb0001Mask uint8 /* 1 bits */
-	_ = zb0001Mask
-	if z.Tables == nil {
-		zb0001Len--
-		zb0001Mask |= 0x1
-	}
-	// variable map header, size zb0001Len
-	err = en.Append(0x80 | uint8(zb0001Len))
-	if err != nil {
-		return
-	}
-	if (zb0001Mask & 0x1) == 0 { // if not omitted
-		// write "tables"
-		err = en.Append(0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-		if err != nil {
-			return
-		}
-		err = en.WriteMapHeader(uint32(len(z.Tables)))
-		if err != nil {
-			err = msgp.WrapError(err, "Tables")
-			return
-		}
-		for za0001, za0002 := range z.Tables {
-			err = en.WriteString(za0001)
-			if err != nil {
-				err = msgp.WrapError(err, "Tables")
-				return
-			}
-			err = za0002.EncodeMsg(en)
-			if err != nil {
-				err = msgp.WrapError(err, "Tables", za0001)
-				return
-			}
-		}
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// check for omitted fields
-	zb0001Len := uint32(1)
-	var zb0001Mask uint8 /* 1 bits */
-	_ = zb0001Mask
-	if z.Tables == nil {
-		zb0001Len--
-		zb0001Mask |= 0x1
-	}
-	// variable map header, size zb0001Len
-	o = append(o, 0x80|uint8(zb0001Len))
-	if (zb0001Mask & 0x1) == 0 { // if not omitted
-		// string "tables"
-		o = append(o, 0xa6, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x73)
-		o = msgp.AppendMapHeader(o, uint32(len(z.Tables)))
-		for za0001, za0002 := range z.Tables {
-			o = msgp.AppendString(o, za0001)
-			o, err = za0002.MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Tables", za0001)
-				return
-			}
-		}
-	}
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *TableAPIMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	var zb0001Mask uint8 /* 1 bits */
-	_ = zb0001Mask
-	for zb0001 > 0 {
-		zb0001--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "tables":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Tables")
-				return
-			}
-			if z.Tables == nil {
-				z.Tables = make(map[string]TableIOMetrics, zb0002)
-			} else if len(z.Tables) > 0 {
-				clear(z.Tables)
-			}
-			for zb0002 > 0 {
-				var za0002 TableIOMetrics
-				zb0002--
-				var za0001 string
-				za0001, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Tables")
-					return
-				}
-				bts, err = za0002.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Tables", za0001)
-					return
-				}
-				z.Tables[za0001] = za0002
-			}
-			zb0001Mask |= 0x1
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				err = msgp.WrapError(err)
-				return
-			}
-		}
-	}
-	// Clear omitted fields.
-	if (zb0001Mask & 0x1) == 0 {
-		z.Tables = nil
-	}
-
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *TableAPIMetrics) Msgsize() (s int) {
-	s = 1 + 7 + msgp.MapHeaderSize
-	if z.Tables != nil {
-		for za0001, za0002 := range z.Tables {
-			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
-		}
-	}
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
-func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	var zb0001Mask uint8 /* 4 bits */
-	_ = zb0001Mask
-	for zb0001 > 0 {
-		zb0001--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "warehouse":
-			z.Warehouse, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "Warehouse")
-				return
-			}
-			zb0001Mask |= 0x1
 		case "lastMinute":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -37398,7 +37753,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.LastMinute = nil
 			} else {
 				if z.LastMinute == nil {
-					z.LastMinute = new(TableIOStat)
+					z.LastMinute = new(TableAPIStat)
 				}
 				err = z.LastMinute.DecodeMsg(dc)
 				if err != nil {
@@ -37406,7 +37761,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x1
 		case "lastHour":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -37417,7 +37772,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.LastHour = nil
 			} else {
 				if z.LastHour == nil {
-					z.LastHour = new(TableIOStat)
+					z.LastHour = new(SegmentedTableIO)
 				}
 				err = z.LastHour.DecodeMsg(dc)
 				if err != nil {
@@ -37425,7 +37780,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x4
+			zb0001Mask |= 0x2
 		case "lastDay":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -37436,7 +37791,7 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.LastDay = nil
 			} else {
 				if z.LastDay == nil {
-					z.LastDay = new(TableIOStat)
+					z.LastDay = new(SegmentedTableIO)
 				}
 				err = z.LastDay.DecodeMsg(dc)
 				if err != nil {
@@ -37444,7 +37799,67 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
+			zb0001Mask |= 0x4
+		case "topW":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "TopWarehouses")
+				return
+			}
+			if cap(z.TopWarehouses) >= int(zb0002) {
+				z.TopWarehouses = (z.TopWarehouses)[:zb0002]
+			} else {
+				z.TopWarehouses = make([]TableIOMetrics, zb0002)
+			}
+			for za0001 := range z.TopWarehouses {
+				err = z.TopWarehouses[za0001].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+			}
 			zb0001Mask |= 0x8
+		case "topN":
+			var zb0003 uint32
+			zb0003, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "TopNamespaces")
+				return
+			}
+			if cap(z.TopNamespaces) >= int(zb0003) {
+				z.TopNamespaces = (z.TopNamespaces)[:zb0003]
+			} else {
+				z.TopNamespaces = make([]TableIOMetrics, zb0003)
+			}
+			for za0002 := range z.TopNamespaces {
+				err = z.TopNamespaces[za0002].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "topT":
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "TopTables")
+				return
+			}
+			if cap(z.TopTables) >= int(zb0004) {
+				z.TopTables = (z.TopTables)[:zb0004]
+			} else {
+				z.TopTables = make([]TableIOMetrics, zb0004)
+			}
+			for za0003 := range z.TopTables {
+				err = z.TopTables[za0003].DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -37454,44 +37869,58 @@ func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xf {
+	if zb0001Mask != 0x3f {
 		if (zb0001Mask & 0x1) == 0 {
-			z.Warehouse = ""
-		}
-		if (zb0001Mask & 0x2) == 0 {
 			z.LastMinute = nil
 		}
-		if (zb0001Mask & 0x4) == 0 {
+		if (zb0001Mask & 0x2) == 0 {
 			z.LastHour = nil
 		}
-		if (zb0001Mask & 0x8) == 0 {
+		if (zb0001Mask & 0x4) == 0 {
 			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.TopWarehouses = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.TopNamespaces = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.TopTables = nil
 		}
 	}
 	return
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+func (z *TableAPIMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
-	if z.Warehouse == "" {
-		zb0001Len--
-		zb0001Mask |= 0x1
-	}
 	if z.LastMinute == nil {
-		zb0001Len--
-		zb0001Mask |= 0x2
-	}
-	if z.LastHour == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.LastDay == nil {
+	if z.LastHour == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.TopWarehouses == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.TopNamespaces == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.TopTables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -37501,19 +37930,27 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 
 	// skip if no fields are to be emitted
 	if zb0001Len != 0 {
-		if (zb0001Mask & 0x1) == 0 { // if not omitted
-			// write "warehouse"
-			err = en.Append(0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
-			if err != nil {
-				return
-			}
-			err = en.WriteString(z.Warehouse)
-			if err != nil {
-				err = msgp.WrapError(err, "Warehouse")
-				return
-			}
+		// write "collected"
+		err = en.Append(0xa9, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x65, 0x64)
+		if err != nil {
+			return
 		}
-		if (zb0001Mask & 0x2) == 0 { // if not omitted
+		err = en.WriteTime(z.CollectedAt)
+		if err != nil {
+			err = msgp.WrapError(err, "CollectedAt")
+			return
+		}
+		// write "nodes"
+		err = en.Append(0xa5, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.Nodes)
+		if err != nil {
+			err = msgp.WrapError(err, "Nodes")
+			return
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
 			// write "lastMinute"
 			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
 			if err != nil {
@@ -37532,7 +37969,7 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x4) == 0 { // if not omitted
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
 			// write "lastHour"
 			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
 			if err != nil {
@@ -37551,7 +37988,1115 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastDay.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "topW"
+			err = en.Append(0xa4, 0x74, 0x6f, 0x70, 0x57)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.TopWarehouses)))
+			if err != nil {
+				err = msgp.WrapError(err, "TopWarehouses")
+				return
+			}
+			for za0001 := range z.TopWarehouses {
+				err = z.TopWarehouses[za0001].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "topN"
+			err = en.Append(0xa4, 0x74, 0x6f, 0x70, 0x4e)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.TopNamespaces)))
+			if err != nil {
+				err = msgp.WrapError(err, "TopNamespaces")
+				return
+			}
+			for za0002 := range z.TopNamespaces {
+				err = z.TopNamespaces[za0002].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "topT"
+			err = en.Append(0xa4, 0x74, 0x6f, 0x70, 0x54)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.TopTables)))
+			if err != nil {
+				err = msgp.WrapError(err, "TopTables")
+				return
+			}
+			for za0003 := range z.TopTables {
+				err = z.TopTables[za0003].EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableAPIMetrics) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
+	_ = zb0001Mask
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.TopWarehouses == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.TopNamespaces == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.TopTables == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// string "collected"
+		o = append(o, 0xa9, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x65, 0x64)
+		o = msgp.AppendTime(o, z.CollectedAt)
+		// string "nodes"
+		o = append(o, 0xa5, 0x6e, 0x6f, 0x64, 0x65, 0x73)
+		o = msgp.AppendInt(o, z.Nodes)
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "lastMinute"
+			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if z.LastMinute == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastMinute.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastHour.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.LastDay.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "topW"
+			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x57)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.TopWarehouses)))
+			for za0001 := range z.TopWarehouses {
+				o, err = z.TopWarehouses[za0001].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "topN"
+			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x4e)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.TopNamespaces)))
+			for za0002 := range z.TopNamespaces {
+				o, err = z.TopNamespaces[za0002].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "topT"
+			o = append(o, 0xa4, 0x74, 0x6f, 0x70, 0x54)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.TopTables)))
+			for za0003 := range z.TopTables {
+				o, err = z.TopTables[za0003].MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableAPIMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "collected":
+			z.CollectedAt, bts, err = msgp.ReadTimeUTCBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CollectedAt")
+				return
+			}
+		case "nodes":
+			z.Nodes, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Nodes")
+				return
+			}
+		case "lastMinute":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableAPIStat)
+				}
+				bts, err = z.LastMinute.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedTableIO)
+				}
+				bts, err = z.LastHour.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedTableIO)
+				}
+				bts, err = z.LastDay.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "topW":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TopWarehouses")
+				return
+			}
+			if cap(z.TopWarehouses) >= int(zb0002) {
+				z.TopWarehouses = (z.TopWarehouses)[:zb0002]
+			} else {
+				z.TopWarehouses = make([]TableIOMetrics, zb0002)
+			}
+			for za0001 := range z.TopWarehouses {
+				bts, err = z.TopWarehouses[za0001].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopWarehouses", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "topN":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TopNamespaces")
+				return
+			}
+			if cap(z.TopNamespaces) >= int(zb0003) {
+				z.TopNamespaces = (z.TopNamespaces)[:zb0003]
+			} else {
+				z.TopNamespaces = make([]TableIOMetrics, zb0003)
+			}
+			for za0002 := range z.TopNamespaces {
+				bts, err = z.TopNamespaces[za0002].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopNamespaces", za0002)
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		case "topT":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TopTables")
+				return
+			}
+			if cap(z.TopTables) >= int(zb0004) {
+				z.TopTables = (z.TopTables)[:zb0004]
+			} else {
+				z.TopTables = make([]TableIOMetrics, zb0004)
+			}
+			for za0003 := range z.TopTables {
+				bts, err = z.TopTables[za0003].UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TopTables", za0003)
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.TopWarehouses = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.TopNamespaces = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.TopTables = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableAPIMetrics) Msgsize() (s int) {
+	s = 1 + 10 + msgp.TimeSize + 6 + msgp.IntSize + 11
+	if z.LastMinute == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastMinute.Msgsize()
+	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastHour.Msgsize()
+	}
+	s += 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.LastDay.Msgsize()
+	}
+	s += 5 + msgp.ArrayHeaderSize
+	for za0001 := range z.TopWarehouses {
+		s += z.TopWarehouses[za0001].Msgsize()
+	}
+	s += 5 + msgp.ArrayHeaderSize
+	for za0002 := range z.TopNamespaces {
+		s += z.TopNamespaces[za0002].Msgsize()
+	}
+	s += 5 + msgp.ArrayHeaderSize
+	for za0003 := range z.TopTables {
+		s += z.TopTables[za0003].Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableAPIStat) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "writes":
+			z.Writes, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "bytesIn":
+			z.BytesIn, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "bytesOut":
+			z.BytesOut, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "notOK":
+			z.NotOK, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "timeSecs":
+			z.RequestTimeSecs, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "ttfbSecs":
+			z.RespTTFBSecs, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			zb0001Mask |= 0x40
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Reads = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Writes = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.BytesIn = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableAPIStat) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	if z.Reads == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Writes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.BytesIn == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.BytesOut == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.NotOK == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.RequestTimeSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.RespTTFBSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "reads"
+			err = en.Append(0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Reads)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "writes"
+			err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.Writes)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "bytesIn"
+			err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.BytesIn)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "bytesOut"
+			err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.BytesOut)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "notOK"
+			err = en.Append(0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x4b)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt64(z.NotOK)
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "timeSecs"
+			err = en.Append(0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.RequestTimeSecs)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "ttfbSecs"
+			err = en.Append(0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.RespTTFBSecs)
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TableAPIStat) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	if z.Reads == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Writes == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.BytesIn == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.BytesOut == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.NotOK == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.RequestTimeSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.RespTTFBSecs == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "reads"
+			o = append(o, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
+			o = msgp.AppendInt64(o, z.Reads)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "writes"
+			o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
+			o = msgp.AppendInt64(o, z.Writes)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "bytesIn"
+			o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
+			o = msgp.AppendInt64(o, z.BytesIn)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "bytesOut"
+			o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
+			o = msgp.AppendInt64(o, z.BytesOut)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "notOK"
+			o = append(o, 0xa5, 0x6e, 0x6f, 0x74, 0x4f, 0x4b)
+			o = msgp.AppendInt64(o, z.NotOK)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "timeSecs"
+			o = append(o, 0xa8, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendFloat64(o, z.RequestTimeSecs)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "ttfbSecs"
+			o = append(o, 0xa8, 0x74, 0x74, 0x66, 0x62, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendFloat64(o, z.RespTTFBSecs)
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TableAPIStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 7 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "reads":
+			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Reads")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "writes":
+			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Writes")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "bytesIn":
+			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesIn")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "bytesOut":
+			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BytesOut")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "notOK":
+			z.NotOK, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NotOK")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "timeSecs":
+			z.RequestTimeSecs, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestTimeSecs")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "ttfbSecs":
+			z.RespTTFBSecs, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RespTTFBSecs")
+				return
+			}
+			zb0001Mask |= 0x40
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Reads = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Writes = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.BytesIn = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.BytesOut = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.NotOK = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.RequestTimeSecs = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.RespTTFBSecs = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TableAPIStat) Msgsize() (s int) {
+	s = 1 + 6 + msgp.Int64Size + 7 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Int64Size + 6 + msgp.Int64Size + 9 + msgp.Float64Size + 9 + msgp.Float64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TableIOMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "table":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Table")
+					return
+				}
+				z.Table = nil
+			} else {
+				if z.Table == nil {
+					z.Table = new(string)
+				}
+				*z.Table, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Table")
+					return
+				}
+			}
+		case "namespace":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Namespace")
+					return
+				}
+				z.Namespace = nil
+			} else {
+				if z.Namespace == nil {
+					z.Namespace = new(string)
+				}
+				*z.Namespace, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Namespace")
+					return
+				}
+			}
+		case "warehouse":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Warehouse")
+					return
+				}
+				z.Warehouse = nil
+			} else {
+				if z.Warehouse == nil {
+					z.Warehouse = new(string)
+				}
+				*z.Warehouse, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Warehouse")
+					return
+				}
+			}
+		case "lastMinute":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+				z.LastMinute = nil
+			} else {
+				if z.LastMinute == nil {
+					z.LastMinute = new(TableAPIStat)
+				}
+				err = z.LastMinute.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(TableAPIStat)
+				}
+				err = z.LastHour.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(TableAPIStat)
+				}
+				err = z.LastDay.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.LastMinute = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.LastDay = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	if z.LastMinute == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// write "table"
+		err = en.Append(0xa5, 0x74, 0x61, 0x62, 0x6c, 0x65)
+		if err != nil {
+			return
+		}
+		if z.Table == nil {
+			err = en.WriteNil()
+			if err != nil {
+				return
+			}
+		} else {
+			err = en.WriteString(*z.Table)
+			if err != nil {
+				err = msgp.WrapError(err, "Table")
+				return
+			}
+		}
+		// write "namespace"
+		err = en.Append(0xa9, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65)
+		if err != nil {
+			return
+		}
+		if z.Namespace == nil {
+			err = en.WriteNil()
+			if err != nil {
+				return
+			}
+		} else {
+			err = en.WriteString(*z.Namespace)
+			if err != nil {
+				err = msgp.WrapError(err, "Namespace")
+				return
+			}
+		}
+		// write "warehouse"
+		err = en.Append(0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+		if err != nil {
+			return
+		}
+		if z.Warehouse == nil {
+			err = en.WriteNil()
+			if err != nil {
+				return
+			}
+		} else {
+			err = en.WriteString(*z.Warehouse)
+			if err != nil {
+				err = msgp.WrapError(err, "Warehouse")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "lastMinute"
+			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
+			if err != nil {
+				return
+			}
+			if z.LastMinute == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastMinute.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastMinute")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.LastHour.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
 			// write "lastDay"
 			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
 			if err != nil {
@@ -37578,36 +39123,48 @@ func (z *TableIOMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
-	if z.Warehouse == "" {
-		zb0001Len--
-		zb0001Mask |= 0x1
-	}
 	if z.LastMinute == nil {
 		zb0001Len--
-		zb0001Mask |= 0x2
+		zb0001Mask |= 0x8
 	}
 	if z.LastHour == nil {
 		zb0001Len--
-		zb0001Mask |= 0x4
+		zb0001Mask |= 0x10
 	}
 	if z.LastDay == nil {
 		zb0001Len--
-		zb0001Mask |= 0x8
+		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 
 	// skip if no fields are to be emitted
 	if zb0001Len != 0 {
-		if (zb0001Mask & 0x1) == 0 { // if not omitted
-			// string "warehouse"
-			o = append(o, 0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
-			o = msgp.AppendString(o, z.Warehouse)
+		// string "table"
+		o = append(o, 0xa5, 0x74, 0x61, 0x62, 0x6c, 0x65)
+		if z.Table == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o = msgp.AppendString(o, *z.Table)
 		}
-		if (zb0001Mask & 0x2) == 0 { // if not omitted
+		// string "namespace"
+		o = append(o, 0xa9, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65)
+		if z.Namespace == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o = msgp.AppendString(o, *z.Namespace)
+		}
+		// string "warehouse"
+		o = append(o, 0xa9, 0x77, 0x61, 0x72, 0x65, 0x68, 0x6f, 0x75, 0x73, 0x65)
+		if z.Warehouse == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o = msgp.AppendString(o, *z.Warehouse)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
 			// string "lastMinute"
 			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x4d, 0x69, 0x6e, 0x75, 0x74, 0x65)
 			if z.LastMinute == nil {
@@ -37620,7 +39177,7 @@ func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x4) == 0 { // if not omitted
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
 			// string "lastHour"
 			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
 			if z.LastHour == nil {
@@ -37633,7 +39190,7 @@ func (z *TableIOMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not omitted
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
 			// string "lastDay"
 			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
 			if z.LastDay == nil {
@@ -37660,7 +39217,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 4 bits */
+	var zb0001Mask uint8 /* 3 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -37670,13 +39227,57 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "warehouse":
-			z.Warehouse, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Warehouse")
-				return
+		case "table":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Table = nil
+			} else {
+				if z.Table == nil {
+					z.Table = new(string)
+				}
+				*z.Table, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Table")
+					return
+				}
 			}
-			zb0001Mask |= 0x1
+		case "namespace":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Namespace = nil
+			} else {
+				if z.Namespace == nil {
+					z.Namespace = new(string)
+				}
+				*z.Namespace, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Namespace")
+					return
+				}
+			}
+		case "warehouse":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Warehouse = nil
+			} else {
+				if z.Warehouse == nil {
+					z.Warehouse = new(string)
+				}
+				*z.Warehouse, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Warehouse")
+					return
+				}
+			}
 		case "lastMinute":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -37686,7 +39287,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.LastMinute = nil
 			} else {
 				if z.LastMinute == nil {
-					z.LastMinute = new(TableIOStat)
+					z.LastMinute = new(TableAPIStat)
 				}
 				bts, err = z.LastMinute.UnmarshalMsg(bts)
 				if err != nil {
@@ -37694,7 +39295,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x1
 		case "lastHour":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -37704,7 +39305,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.LastHour = nil
 			} else {
 				if z.LastHour == nil {
-					z.LastHour = new(TableIOStat)
+					z.LastHour = new(TableAPIStat)
 				}
 				bts, err = z.LastHour.UnmarshalMsg(bts)
 				if err != nil {
@@ -37712,7 +39313,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x4
+			zb0001Mask |= 0x2
 		case "lastDay":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -37722,7 +39323,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.LastDay = nil
 			} else {
 				if z.LastDay == nil {
-					z.LastDay = new(TableIOStat)
+					z.LastDay = new(TableAPIStat)
 				}
 				bts, err = z.LastDay.UnmarshalMsg(bts)
 				if err != nil {
@@ -37730,7 +39331,7 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x4
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -37740,17 +39341,14 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0xf {
+	if zb0001Mask != 0x7 {
 		if (zb0001Mask & 0x1) == 0 {
-			z.Warehouse = ""
-		}
-		if (zb0001Mask & 0x2) == 0 {
 			z.LastMinute = nil
 		}
-		if (zb0001Mask & 0x4) == 0 {
+		if (zb0001Mask & 0x2) == 0 {
 			z.LastHour = nil
 		}
-		if (zb0001Mask & 0x8) == 0 {
+		if (zb0001Mask & 0x4) == 0 {
 			z.LastDay = nil
 		}
 	}
@@ -37760,7 +39358,25 @@ func (z *TableIOMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *TableIOMetrics) Msgsize() (s int) {
-	s = 1 + 10 + msgp.StringPrefixSize + len(z.Warehouse) + 11
+	s = 1 + 6
+	if z.Table == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.StringPrefixSize + len(*z.Table)
+	}
+	s += 10
+	if z.Namespace == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.StringPrefixSize + len(*z.Namespace)
+	}
+	s += 10
+	if z.Warehouse == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.StringPrefixSize + len(*z.Warehouse)
+	}
+	s += 11
 	if z.LastMinute == nil {
 		s += msgp.NilSize
 	} else {
@@ -37778,184 +39394,6 @@ func (z *TableIOMetrics) Msgsize() (s int) {
 	} else {
 		s += z.LastDay.Msgsize()
 	}
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
-func (z *TableIOStat) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var zb0001 uint32
-	zb0001, err = dc.ReadMapHeader()
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	for zb0001 > 0 {
-		zb0001--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "reads":
-			z.Reads, err = dc.ReadInt64()
-			if err != nil {
-				err = msgp.WrapError(err, "Reads")
-				return
-			}
-		case "writes":
-			z.Writes, err = dc.ReadInt64()
-			if err != nil {
-				err = msgp.WrapError(err, "Writes")
-				return
-			}
-		case "bytesIn":
-			z.BytesIn, err = dc.ReadInt64()
-			if err != nil {
-				err = msgp.WrapError(err, "BytesIn")
-				return
-			}
-		case "bytesOut":
-			z.BytesOut, err = dc.ReadInt64()
-			if err != nil {
-				err = msgp.WrapError(err, "BytesOut")
-				return
-			}
-		default:
-			err = dc.Skip()
-			if err != nil {
-				err = msgp.WrapError(err)
-				return
-			}
-		}
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *TableIOStat) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
-	// write "reads"
-	err = en.Append(0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
-	if err != nil {
-		return
-	}
-	err = en.WriteInt64(z.Reads)
-	if err != nil {
-		err = msgp.WrapError(err, "Reads")
-		return
-	}
-	// write "writes"
-	err = en.Append(0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
-	if err != nil {
-		return
-	}
-	err = en.WriteInt64(z.Writes)
-	if err != nil {
-		err = msgp.WrapError(err, "Writes")
-		return
-	}
-	// write "bytesIn"
-	err = en.Append(0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
-	if err != nil {
-		return
-	}
-	err = en.WriteInt64(z.BytesIn)
-	if err != nil {
-		err = msgp.WrapError(err, "BytesIn")
-		return
-	}
-	// write "bytesOut"
-	err = en.Append(0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
-	if err != nil {
-		return
-	}
-	err = en.WriteInt64(z.BytesOut)
-	if err != nil {
-		err = msgp.WrapError(err, "BytesOut")
-		return
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *TableIOStat) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
-	// string "reads"
-	o = append(o, 0x84, 0xa5, 0x72, 0x65, 0x61, 0x64, 0x73)
-	o = msgp.AppendInt64(o, z.Reads)
-	// string "writes"
-	o = append(o, 0xa6, 0x77, 0x72, 0x69, 0x74, 0x65, 0x73)
-	o = msgp.AppendInt64(o, z.Writes)
-	// string "bytesIn"
-	o = append(o, 0xa7, 0x62, 0x79, 0x74, 0x65, 0x73, 0x49, 0x6e)
-	o = msgp.AppendInt64(o, z.BytesIn)
-	// string "bytesOut"
-	o = append(o, 0xa8, 0x62, 0x79, 0x74, 0x65, 0x73, 0x4f, 0x75, 0x74)
-	o = msgp.AppendInt64(o, z.BytesOut)
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *TableIOStat) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var zb0001 uint32
-	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		err = msgp.WrapError(err)
-		return
-	}
-	for zb0001 > 0 {
-		zb0001--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "reads":
-			z.Reads, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Reads")
-				return
-			}
-		case "writes":
-			z.Writes, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Writes")
-				return
-			}
-		case "bytesIn":
-			z.BytesIn, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "BytesIn")
-				return
-			}
-		case "bytesOut":
-			z.BytesOut, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "BytesOut")
-				return
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				err = msgp.WrapError(err)
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *TableIOStat) Msgsize() (s int) {
-	s = 1 + 6 + msgp.Int64Size + 7 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Int64Size
 	return
 }
 

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -7015,6 +7015,119 @@ func BenchmarkDecodeTableIOMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalTopTableIO(t *testing.T) {
+	v := TopTableIO{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTopTableIO(b *testing.B) {
+	v := TopTableIO{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTopTableIO(b *testing.B) {
+	v := TopTableIO{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTopTableIO(b *testing.B) {
+	v := TopTableIO{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTopTableIO(t *testing.T) {
+	v := TopTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTopTableIO Msgsize() is inaccurate")
+	}
+
+	vn := TopTableIO{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTopTableIO(b *testing.B) {
+	v := TopTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTopTableIO(b *testing.B) {
+	v := TopTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTotalMinMaxUint64(t *testing.T) {
 	v := TotalMinMaxUint64{}
 	bts, err := v.MarshalMsg(nil)

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -6337,6 +6337,119 @@ func BenchmarkDecodeSegmentedBucketStats(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalSegmentedTableIO(t *testing.T) {
+	v := SegmentedTableIO{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgSegmentedTableIO(b *testing.B) {
+	v := SegmentedTableIO{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSegmentedTableIO(b *testing.B) {
+	v := SegmentedTableIO{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSegmentedTableIO(b *testing.B) {
+	v := SegmentedTableIO{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeSegmentedTableIO(t *testing.T) {
+	v := SegmentedTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeSegmentedTableIO Msgsize() is inaccurate")
+	}
+
+	vn := SegmentedTableIO{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeSegmentedTableIO(b *testing.B) {
+	v := SegmentedTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeSegmentedTableIO(b *testing.B) {
+	v := SegmentedTableIO{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalSensorMetrics(t *testing.T) {
 	v := SensorMetrics{}
 	bts, err := v.MarshalMsg(nil)
@@ -6676,6 +6789,119 @@ func BenchmarkDecodeTableAPIMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalTableAPIStat(t *testing.T) {
+	v := TableAPIStat{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableAPIStat(b *testing.B) {
+	v := TableAPIStat{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableAPIStat(b *testing.B) {
+	v := TableAPIStat{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableAPIStat(b *testing.B) {
+	v := TableAPIStat{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableAPIStat(t *testing.T) {
+	v := TableAPIStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableAPIStat Msgsize() is inaccurate")
+	}
+
+	vn := TableAPIStat{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableAPIStat(b *testing.B) {
+	v := TableAPIStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableAPIStat(b *testing.B) {
+	v := TableAPIStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTableIOMetrics(t *testing.T) {
 	v := TableIOMetrics{}
 	bts, err := v.MarshalMsg(nil)
@@ -6774,119 +7000,6 @@ func BenchmarkEncodeTableIOMetrics(b *testing.B) {
 
 func BenchmarkDecodeTableIOMetrics(b *testing.B) {
 	v := TableIOMetrics{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	rd := msgp.NewEndlessReader(buf.Bytes(), b)
-	dc := msgp.NewReader(rd)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := v.DecodeMsg(dc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestMarshalUnmarshalTableIOStat(t *testing.T) {
-	v := TableIOStat{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgTableIOStat(b *testing.B) {
-	v := TableIOStat{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgTableIOStat(b *testing.B) {
-	v := TableIOStat{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalTableIOStat(b *testing.B) {
-	v := TableIOStat{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestEncodeDecodeTableIOStat(t *testing.T) {
-	v := TableIOStat{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-
-	m := v.Msgsize()
-	if buf.Len() > m {
-		t.Log("WARNING: TestEncodeDecodeTableIOStat Msgsize() is inaccurate")
-	}
-
-	vn := TableIOStat{}
-	err := msgp.Decode(&buf, &vn)
-	if err != nil {
-		t.Error(err)
-	}
-
-	buf.Reset()
-	msgp.Encode(&buf, &v)
-	err = msgp.NewReader(&buf).Skip()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func BenchmarkEncodeTableIOStat(b *testing.B) {
-	v := TableIOStat{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	en := msgp.NewWriter(msgp.Nowhere)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.EncodeMsg(en)
-	}
-	en.Flush()
-}
-
-func BenchmarkDecodeTableIOStat(b *testing.B) {
-	v := TableIOStat{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/metrics_gen_test.go
+++ b/metrics_gen_test.go
@@ -6563,6 +6563,345 @@ func BenchmarkDecodeSiteResyncMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalTableAPIMetrics(t *testing.T) {
+	v := TableAPIMetrics{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableAPIMetrics(t *testing.T) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableAPIMetrics Msgsize() is inaccurate")
+	}
+
+	vn := TableAPIMetrics{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableAPIMetrics(b *testing.B) {
+	v := TableAPIMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTableIOMetrics(t *testing.T) {
+	v := TableIOMetrics{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableIOMetrics(t *testing.T) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableIOMetrics Msgsize() is inaccurate")
+	}
+
+	vn := TableIOMetrics{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableIOMetrics(b *testing.B) {
+	v := TableIOMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTableIOStat(t *testing.T) {
+	v := TableIOStat{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTableIOStat(t *testing.T) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTableIOStat Msgsize() is inaccurate")
+	}
+
+	vn := TableIOStat{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTableIOStat(b *testing.B) {
+	v := TableIOStat{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTotalMinMaxUint64(t *testing.T) {
 	v := TotalMinMaxUint64{}
 	bts, err := v.MarshalMsg(nil)

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -178,6 +178,7 @@ func (node *RealtimeMetricsNode) GetChildren() []MetricChild {
 		{Name: "batch_jobs", Description: "Batch job execution metrics"},
 		{Name: "site_resync", Description: "Site replication resync metrics"},
 		{Name: "kms", Description: "KMS operation metrics"},
+		{Name: "tables", Description: "Iceberg table API metrics"},
 		{Name: "by_host", Description: "Metrics broken down by individual host"},
 		{Name: "by_drive", Description: "Metrics broken down by individual drive"},
 		{Name: "by_drive_set", Description: "Metrics broken down by drive set"},
@@ -257,6 +258,8 @@ func (node *RealtimeMetricsNode) GetChild(name string) (MetricNode, error) {
 		return NewProcessMetricsNode(node.metrics.Aggregated.Process, node, "process"), nil
 	case "kms":
 		return NewKMSMetricsNode(node.metrics.Aggregated.KMS, node, "kms"), nil
+	case "tables":
+		return NewTableMetricsNode(node.metrics.Aggregated.TablesAPI, node, "tables"), nil
 
 	// Grouping nodes - preserved as-is
 	case "by_host":
@@ -340,6 +343,7 @@ func (node *MetricsNode) GetChildren() []MetricChild {
 		{Name: "batch_jobs", Description: "Batch job execution metrics"},
 		{Name: "site_resync", Description: "Site replication resync metrics"},
 		{Name: "kms", Description: "KMS operation metrics"},
+		{Name: "tables", Description: "Iceberg table API metrics"},
 	}
 }
 
@@ -399,6 +403,8 @@ func (node *MetricsNode) GetChild(name string) (MetricNode, error) {
 		return NewProcessMetricsNode(node.metrics.Process, node, fmt.Sprintf("%s/process", node.path)), nil
 	case "kms":
 		return NewKMSMetricsNode(node.metrics.KMS, node, fmt.Sprintf("%s/kms", node.path)), nil
+	case "tables":
+		return NewTableMetricsNode(node.metrics.TablesAPI, node, fmt.Sprintf("%s/tables", node.path)), nil
 	default:
 		return nil, fmt.Errorf("child not found: %s", name)
 	}

--- a/mnav/tables.go
+++ b/mnav/tables.go
@@ -1,0 +1,479 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/minio/madmin-go/v4"
+)
+
+// TableMetricsNode is the root navigation node for table API metrics.
+type TableMetricsNode struct {
+	tables *madmin.TableAPIMetrics
+	parent MetricNode
+	path   string
+}
+
+// NewTableMetricsNode constructs a new TableMetricsNode.
+func NewTableMetricsNode(tables *madmin.TableAPIMetrics, parent MetricNode, path string) *TableMetricsNode {
+	return &TableMetricsNode{tables: tables, parent: parent, path: path}
+}
+
+func (node *TableMetricsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *TableMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *TableMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *TableMetricsNode) GetParent() MetricNode              { return node.parent }
+func (node *TableMetricsNode) GetPath() string                    { return node.path }
+func (node *TableMetricsNode) ShouldPauseRefresh() bool           { return false }
+
+func (node *TableMetricsNode) GetChildren() []MetricChild {
+	if node.tables == nil {
+		return []MetricChild{}
+	}
+	children := []MetricChild{
+		{Name: "last_minute", Description: "Cluster table API totals over the last minute"},
+		{Name: "last_hour", Description: "Per-minute segments over the last hour"},
+		{Name: "last_day", Description: "15-minute segments over the last day"},
+		{Name: "top_warehouses", Description: "Top warehouses by request count"},
+		{Name: "top_namespaces", Description: "Top namespaces by request count"},
+		{Name: "top_tables", Description: "Top tables by request count"},
+	}
+	return children
+}
+
+func (node *TableMetricsNode) GetLeafData() map[string]string {
+	if node.tables == nil {
+		return map[string]string{"Status": "No table metrics available"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	add("Responding Nodes", fmt.Sprintf("%d", node.tables.Nodes))
+	if !node.tables.CollectedAt.IsZero() {
+		add("Collection Time", node.tables.CollectedAt.Format("15:04:05"))
+	}
+	if node.tables.LastMinute != nil {
+		add("Last Minute", describeTableAPIStat(node.tables.LastMinute, 60))
+	}
+	if len(node.tables.TopWarehouses) > 0 {
+		add("Top Warehouses", fmt.Sprintf("%d entries", len(node.tables.TopWarehouses)))
+	}
+	if len(node.tables.TopNamespaces) > 0 {
+		add("Top Namespaces", fmt.Sprintf("%d entries", len(node.tables.TopNamespaces)))
+	}
+	if len(node.tables.TopTables) > 0 {
+		add("Top Tables", fmt.Sprintf("%d entries", len(node.tables.TopTables)))
+	}
+	return data
+}
+
+func (node *TableMetricsNode) GetChild(name string) (MetricNode, error) {
+	if node.tables == nil {
+		return nil, fmt.Errorf("no table metrics available")
+	}
+	switch name {
+	case "last_minute":
+		return &tableLastMinuteNode{stat: node.tables.LastMinute, parent: node, path: node.path + "/last_minute"}, nil
+	case "last_hour":
+		return &tableSegmentedNode{
+			seg: node.tables.LastHour, windowSecs: 3600,
+			flag: madmin.MetricsHourStats, parent: node, path: node.path + "/last_hour",
+		}, nil
+	case "last_day":
+		return &tableSegmentedNode{
+			seg: node.tables.LastDay, windowSecs: 86400,
+			flag: madmin.MetricsDayStats, parent: node, path: node.path + "/last_day",
+		}, nil
+	case "top_warehouses":
+		return &tableTopListNode{
+			entries: node.tables.TopWarehouses, label: "warehouse",
+			flag: madmin.MetricsTopWarehouses, parent: node, path: node.path + "/top_warehouses",
+		}, nil
+	case "top_namespaces":
+		return &tableTopListNode{
+			entries: node.tables.TopNamespaces, label: "namespace",
+			flag: madmin.MetricsTopNamespaces, parent: node, path: node.path + "/top_namespaces",
+		}, nil
+	case "top_tables":
+		return &tableTopListNode{
+			entries: node.tables.TopTables, label: "table",
+			flag: madmin.MetricsTopTables, parent: node, path: node.path + "/top_tables",
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown table child: %s", name)
+}
+
+// tableLastMinuteNode shows cluster-wide totals over the last minute.
+type tableLastMinuteNode struct {
+	stat   *madmin.TableAPIStat
+	parent MetricNode
+	path   string
+}
+
+func (node *tableLastMinuteNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableLastMinuteNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableLastMinuteNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *tableLastMinuteNode) GetParent() MetricNode              { return node.parent }
+func (node *tableLastMinuteNode) GetPath() string                    { return node.path }
+func (node *tableLastMinuteNode) ShouldPauseRefresh() bool           { return false }
+func (node *tableLastMinuteNode) GetChildren() []MetricChild         { return []MetricChild{} }
+func (node *tableLastMinuteNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *tableLastMinuteNode) GetLeafData() map[string]string {
+	if node.stat == nil || node.stat.IsZero() {
+		return map[string]string{"Status": "No table activity in the last minute"}
+	}
+	return tableStatLeafData(node.stat, 60)
+}
+
+// tableSegmentedNode displays a SegmentedTableIO window as a summary leaf plus
+// one child per non-empty time slot.
+type tableSegmentedNode struct {
+	seg        *madmin.SegmentedTableIO
+	windowSecs float64
+	flag       madmin.MetricFlags
+	parent     MetricNode
+	path       string
+}
+
+func (node *tableSegmentedNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableSegmentedNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableSegmentedNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableSegmentedNode) GetParent() MetricNode              { return node.parent }
+func (node *tableSegmentedNode) GetPath() string                    { return node.path }
+func (node *tableSegmentedNode) ShouldPauseRefresh() bool           { return true }
+
+func (node *tableSegmentedNode) GetChildren() []MetricChild {
+	if node.seg == nil {
+		return []MetricChild{}
+	}
+	stats := node.seg.AsTableIOStat()
+	if len(stats) == 0 {
+		return []MetricChild{}
+	}
+	interval := time.Duration(node.seg.IntervalSecs) * time.Second
+	var children []MetricChild
+	for i := len(stats) - 1; i >= 0; i-- {
+		if stats[i].IsZero() {
+			continue
+		}
+		t := node.seg.FirstTime.Add(time.Duration(i) * interval)
+		end := t.Add(interval)
+		day := ""
+		if !sameLocalDay(t, time.Now()) {
+			day = "Yesterday "
+		}
+		children = append(children, MetricChild{
+			Name: t.UTC().Format("15:04Z"),
+			Description: fmt.Sprintf("%s%s -> %s, %s", day,
+				t.Local().Format("15:04"), end.Local().Format("15:04"),
+				describeTableAPIStat(&stats[i], float64(node.seg.IntervalSecs))),
+		})
+	}
+	return children
+}
+
+func (node *tableSegmentedNode) GetLeafData() map[string]string {
+	if node.seg == nil {
+		return map[string]string{"Status": "No segmented data"}
+	}
+	stats := node.seg.AsTableIOStat()
+	if len(stats) == 0 {
+		return map[string]string{"Status": "No activity"}
+	}
+	var total madmin.TableAPIStat
+	for i := range stats {
+		total.Add(&stats[i])
+	}
+	return tableStatLeafData(&total, node.windowSecs)
+}
+
+func (node *tableSegmentedNode) GetChild(name string) (MetricNode, error) {
+	if node.seg == nil {
+		return nil, fmt.Errorf("no segmented data")
+	}
+	stats := node.seg.AsTableIOStat()
+	interval := time.Duration(node.seg.IntervalSecs) * time.Second
+	for i := range stats {
+		t := node.seg.FirstTime.Add(time.Duration(i) * interval)
+		if t.UTC().Format("15:04Z") == name {
+			return &tableSegmentEntryNode{
+				stat: stats[i], windowSecs: float64(node.seg.IntervalSecs),
+				flag: node.flag, parent: node, path: node.path + "/" + name,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("segment not found: %s", name)
+}
+
+// tableSegmentEntryNode is a leaf for one time slot of a SegmentedTableIO.
+type tableSegmentEntryNode struct {
+	stat       madmin.TableAPIStat
+	windowSecs float64
+	flag       madmin.MetricFlags
+	parent     MetricNode
+	path       string
+}
+
+func (node *tableSegmentEntryNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableSegmentEntryNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableSegmentEntryNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableSegmentEntryNode) GetParent() MetricNode              { return node.parent }
+func (node *tableSegmentEntryNode) GetPath() string                    { return node.path }
+func (node *tableSegmentEntryNode) ShouldPauseRefresh() bool           { return true }
+func (node *tableSegmentEntryNode) GetChildren() []MetricChild         { return []MetricChild{} }
+func (node *tableSegmentEntryNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *tableSegmentEntryNode) GetLeafData() map[string]string {
+	return tableStatLeafData(&node.stat, node.windowSecs)
+}
+
+// tableTopListNode shows a Top* slice: children are individual entries, leaf
+// data is a numbered summary of the same entries.
+type tableTopListNode struct {
+	entries []madmin.TableIOMetrics
+	label   string
+	flag    madmin.MetricFlags
+	parent  MetricNode
+	path    string
+}
+
+func (node *tableTopListNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableTopListNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableTopListNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableTopListNode) GetParent() MetricNode              { return node.parent }
+func (node *tableTopListNode) GetPath() string                    { return node.path }
+func (node *tableTopListNode) ShouldPauseRefresh() bool           { return false }
+
+func (node *tableTopListNode) GetChildren() []MetricChild {
+	children := make([]MetricChild, 0, len(node.entries))
+	for i := range node.entries {
+		e := &node.entries[i]
+		key := tableEntryKey(e)
+		children = append(children, MetricChild{
+			Name:        url.PathEscape(key),
+			DisplayName: key,
+			Description: describeTableIOMetrics(e),
+		})
+	}
+	return children
+}
+
+func (node *tableTopListNode) GetLeafData() map[string]string {
+	if len(node.entries) == 0 {
+		return map[string]string{"Status": "No " + node.label + " entries"}
+	}
+	data := map[string]string{
+		"00:Entries": fmt.Sprintf("%d", len(node.entries)),
+	}
+	for i := range node.entries {
+		key := fmt.Sprintf("%02d:%s", i+1, tableEntryKey(&node.entries[i]))
+		data[key] = describeTableIOMetrics(&node.entries[i])
+	}
+	return data
+}
+
+func (node *tableTopListNode) GetChild(name string) (MetricNode, error) {
+	decoded, err := url.PathUnescape(name)
+	if err != nil {
+		return nil, fmt.Errorf("invalid name: %s", name)
+	}
+	for i := range node.entries {
+		if tableEntryKey(&node.entries[i]) == decoded {
+			return &tableEntryNode{
+				entry: node.entries[i], flag: node.flag,
+				parent: node, path: node.path + "/" + name,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("entry not found: %s", decoded)
+}
+
+// tableEntryNode is a leaf for a single TableIOMetrics row.
+type tableEntryNode struct {
+	entry  madmin.TableIOMetrics
+	flag   madmin.MetricFlags
+	parent MetricNode
+	path   string
+}
+
+func (node *tableEntryNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableEntryNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableEntryNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableEntryNode) GetParent() MetricNode              { return node.parent }
+func (node *tableEntryNode) GetPath() string                    { return node.path }
+func (node *tableEntryNode) ShouldPauseRefresh() bool           { return false }
+func (node *tableEntryNode) GetChildren() []MetricChild         { return []MetricChild{} }
+func (node *tableEntryNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *tableEntryNode) GetLeafData() map[string]string {
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.entry.Warehouse != nil {
+		add("Warehouse", *node.entry.Warehouse)
+	}
+	if node.entry.Namespace != nil {
+		add("Namespace", *node.entry.Namespace)
+	}
+	if node.entry.Table != nil {
+		add("Table", *node.entry.Table)
+	}
+	if node.entry.LastMinute != nil {
+		add("Last Minute", describeTableAPIStat(node.entry.LastMinute, 60))
+	}
+	if node.entry.LastHour != nil {
+		add("Last Hour", describeTableAPIStat(node.entry.LastHour, 3600))
+	}
+	if node.entry.LastDay != nil {
+		add("Last Day", describeTableAPIStat(node.entry.LastDay, 86400))
+	}
+	if idx == 0 {
+		return map[string]string{"Status": "No data"}
+	}
+	return data
+}
+
+// tableEntryKey returns the path-safe identifier for a TableIOMetrics row.
+func tableEntryKey(e *madmin.TableIOMetrics) string {
+	parts := make([]string, 0, 3)
+	if e.Warehouse != nil {
+		parts = append(parts, *e.Warehouse)
+	}
+	if e.Namespace != nil {
+		parts = append(parts, *e.Namespace)
+	}
+	if e.Table != nil {
+		parts = append(parts, *e.Table)
+	}
+	if len(parts) == 0 {
+		return "(unnamed)"
+	}
+	return strings.Join(parts, ":")
+}
+
+// describeTableIOMetrics returns a compact one-line summary for a top-list
+// child, preferring the shortest available window.
+func describeTableIOMetrics(e *madmin.TableIOMetrics) string {
+	switch {
+	case e.LastMinute != nil:
+		return describeTableAPIStat(e.LastMinute, 60)
+	case e.LastHour != nil:
+		return describeTableAPIStat(e.LastHour, 3600)
+	case e.LastDay != nil:
+		return describeTableAPIStat(e.LastDay, 86400)
+	}
+	return "No data"
+}
+
+// describeTableAPIStat formats a TableAPIStat as a single line for use in
+// child descriptions. windowSecs is the window duration for rate display.
+func describeTableAPIStat(s *madmin.TableAPIStat, windowSecs float64) string {
+	if s == nil || s.IsZero() {
+		return "No activity"
+	}
+	total := s.Reads + s.Writes
+	parts := []string{fmt.Sprintf("%s req", humanize.Comma(total))}
+	if total > 0 && windowSecs > 0 {
+		parts = append(parts, fmt.Sprintf("%.1f req/s", float64(total)/windowSecs))
+	}
+	if s.Reads > 0 {
+		parts = append(parts, "R:"+humanize.Comma(s.Reads))
+	}
+	if s.Writes > 0 {
+		parts = append(parts, "W:"+humanize.Comma(s.Writes))
+	}
+	if s.NotOK > 0 {
+		parts = append(parts, humanize.Comma(s.NotOK)+" err")
+	}
+	if s.BytesIn > 0 {
+		parts = append(parts, "in:"+humanize.Bytes(uint64(s.BytesIn)))
+	}
+	if s.BytesOut > 0 {
+		parts = append(parts, "out:"+humanize.Bytes(uint64(s.BytesOut)))
+	}
+	if total > 0 && s.RequestTimeSecs > 0 {
+		parts = append(parts, fmt.Sprintf("%.1fms avg", (s.RequestTimeSecs/float64(total))*1000))
+	}
+	if total > 0 && s.RespTTFBSecs > 0 {
+		parts = append(parts, fmt.Sprintf("%.1fms ttfb", (s.RespTTFBSecs/float64(total))*1000))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// tableStatLeafData formats a TableAPIStat as the per-key leaf data shown in
+// a node's body. windowSecs is the window duration for rate display.
+func tableStatLeafData(s *madmin.TableAPIStat, windowSecs float64) map[string]string {
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	total := s.Reads + s.Writes
+	add("Requests", humanize.Comma(total))
+	if total > 0 && windowSecs > 0 {
+		add("Request Rate", fmt.Sprintf("%.1f req/s", float64(total)/windowSecs))
+	}
+	if s.Reads > 0 {
+		add("Reads", humanize.Comma(s.Reads))
+	}
+	if s.Writes > 0 {
+		add("Writes", humanize.Comma(s.Writes))
+	}
+	if s.NotOK > 0 {
+		v := humanize.Comma(s.NotOK)
+		if total > 0 {
+			v += fmt.Sprintf(" (%.1f%%)", float64(s.NotOK)/float64(total)*100)
+		}
+		add("Errors", v)
+	}
+	if s.BytesIn > 0 || s.BytesOut > 0 {
+		add("Throughput", humanize.Bytes(uint64(s.BytesIn+s.BytesOut)))
+		if s.BytesIn > 0 {
+			add("-> Incoming", humanize.Bytes(uint64(s.BytesIn)))
+		}
+		if s.BytesOut > 0 {
+			add("<- Outgoing", humanize.Bytes(uint64(s.BytesOut)))
+		}
+	}
+	if total > 0 && s.RequestTimeSecs > 0 {
+		add("Avg Latency", fmt.Sprintf("%.1fms", (s.RequestTimeSecs/float64(total))*1000))
+	}
+	if total > 0 && s.RespTTFBSecs > 0 {
+		add("Avg TTFB", fmt.Sprintf("%.1fms", (s.RespTTFBSecs/float64(total))*1000))
+	}
+	return data
+}

--- a/mnav/tables.go
+++ b/mnav/tables.go
@@ -50,15 +50,14 @@ func (node *TableMetricsNode) GetChildren() []MetricChild {
 	if node.tables == nil {
 		return []MetricChild{}
 	}
-	children := []MetricChild{
+	return []MetricChild{
 		{Name: "last_minute", Description: "Cluster table API totals over the last minute"},
 		{Name: "last_hour", Description: "Per-minute segments over the last hour"},
 		{Name: "last_day", Description: "15-minute segments over the last day"},
-		{Name: "top_warehouses", Description: "Top warehouses by request count"},
-		{Name: "top_namespaces", Description: "Top namespaces by request count"},
-		{Name: "top_tables", Description: "Top tables by request count"},
+		{Name: "top_warehouses", Description: "Top warehouses by requests and throughput"},
+		{Name: "top_namespaces", Description: "Top namespaces by requests and throughput"},
+		{Name: "top_tables", Description: "Top tables by requests and throughput"},
 	}
-	return children
 }
 
 func (node *TableMetricsNode) GetLeafData() map[string]string {
@@ -77,15 +76,6 @@ func (node *TableMetricsNode) GetLeafData() map[string]string {
 	}
 	if node.tables.LastMinute != nil {
 		add("Last Minute", describeTableAPIStat(node.tables.LastMinute, 60))
-	}
-	if len(node.tables.TopWarehouses) > 0 {
-		add("Top Warehouses", fmt.Sprintf("%d entries", len(node.tables.TopWarehouses)))
-	}
-	if len(node.tables.TopNamespaces) > 0 {
-		add("Top Namespaces", fmt.Sprintf("%d entries", len(node.tables.TopNamespaces)))
-	}
-	if len(node.tables.TopTables) > 0 {
-		add("Top Tables", fmt.Sprintf("%d entries", len(node.tables.TopTables)))
 	}
 	return data
 }
@@ -108,18 +98,18 @@ func (node *TableMetricsNode) GetChild(name string) (MetricNode, error) {
 			flag: madmin.MetricsDayStats, parent: node, path: node.path + "/last_day",
 		}, nil
 	case "top_warehouses":
-		return &tableTopListNode{
-			entries: node.tables.TopWarehouses, label: "warehouse",
+		return &tableTopGroupNode{
+			top: node.tables.TopWarehouses, label: "warehouse",
 			flag: madmin.MetricsTopWarehouses, parent: node, path: node.path + "/top_warehouses",
 		}, nil
 	case "top_namespaces":
-		return &tableTopListNode{
-			entries: node.tables.TopNamespaces, label: "namespace",
+		return &tableTopGroupNode{
+			top: node.tables.TopNamespaces, label: "namespace",
 			flag: madmin.MetricsTopNamespaces, parent: node, path: node.path + "/top_namespaces",
 		}, nil
 	case "top_tables":
-		return &tableTopListNode{
-			entries: node.tables.TopTables, label: "table",
+		return &tableTopGroupNode{
+			top: node.tables.TopTables, label: "table",
 			flag: madmin.MetricsTopTables, parent: node, path: node.path + "/top_tables",
 		}, nil
 	}
@@ -255,24 +245,117 @@ func (node *tableSegmentEntryNode) GetLeafData() map[string]string {
 	return tableStatLeafData(&node.stat, node.windowSecs)
 }
 
-// tableTopListNode shows a Top* slice: children are individual entries, leaf
-// data is a numbered summary of the same entries.
-type tableTopListNode struct {
-	entries []madmin.TableIOMetrics
-	label   string
-	flag    madmin.MetricFlags
-	parent  MetricNode
-	path    string
+// rankedList describes one of the six TopTableIO ranked slices.
+type rankedList struct {
+	name        string
+	description string
+	entries     []madmin.TableIOMetrics
+	windowSecs  float64
+	flag        madmin.MetricFlags // additional flag beyond the parent's MetricsTopXxx
 }
 
-func (node *tableTopListNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *tableTopListNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
-func (node *tableTopListNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
-func (node *tableTopListNode) GetParent() MetricNode              { return node.parent }
-func (node *tableTopListNode) GetPath() string                    { return node.path }
-func (node *tableTopListNode) ShouldPauseRefresh() bool           { return false }
+// tableTopGroupNode exposes one of the three top categories (warehouses,
+// namespaces, tables) and routes to the six ranked sub-lists inside its
+// TopTableIO.
+type tableTopGroupNode struct {
+	top    *madmin.TopTableIO
+	label  string
+	flag   madmin.MetricFlags
+	parent MetricNode
+	path   string
+}
 
-func (node *tableTopListNode) GetChildren() []MetricChild {
+func (node *tableTopGroupNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableTopGroupNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableTopGroupNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableTopGroupNode) GetParent() MetricNode              { return node.parent }
+func (node *tableTopGroupNode) GetPath() string                    { return node.path }
+func (node *tableTopGroupNode) ShouldPauseRefresh() bool           { return false }
+
+func (node *tableTopGroupNode) rankedLists() []rankedList {
+	if node.top == nil {
+		return nil
+	}
+	lbl := node.label
+	return []rankedList{
+		{"reqs_minute", "Last-minute " + lbl + "s by requests", node.top.ByRequestsMin, 60, 0},
+		{"throughput_minute", "Last-minute " + lbl + "s by throughput", node.top.ByThroughputMin, 60, 0},
+		{"reqs_hour", "Last-hour " + lbl + "s by requests", node.top.ByRequestsHour, 3600, madmin.MetricsHourStats},
+		{"throughput_hour", "Last-hour " + lbl + "s by throughput", node.top.ByThroughputHour, 3600, madmin.MetricsHourStats},
+		{"reqs_day", "Last-day " + lbl + "s by requests", node.top.ByRequestsDay, 86400, madmin.MetricsDayStats},
+		{"throughput_day", "Last-day " + lbl + "s by throughput", node.top.ByThroughputDay, 86400, madmin.MetricsDayStats},
+	}
+}
+
+func (node *tableTopGroupNode) GetChildren() []MetricChild {
+	lists := node.rankedLists()
+	children := make([]MetricChild, 0, len(lists))
+	for _, l := range lists {
+		desc := l.description
+		if len(l.entries) > 0 {
+			desc = fmt.Sprintf("%s (%d entries)", desc, len(l.entries))
+		} else {
+			desc = desc + " (no data)"
+		}
+		children = append(children, MetricChild{Name: l.name, Description: desc})
+	}
+	return children
+}
+
+func (node *tableTopGroupNode) GetLeafData() map[string]string {
+	if node.top == nil {
+		return map[string]string{"Status": "No " + node.label + " data"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	for _, l := range node.rankedLists() {
+		if len(l.entries) == 0 {
+			continue
+		}
+		add(l.description, fmt.Sprintf("%d entries; top: %s",
+			len(l.entries), tableEntryKey(&l.entries[0])))
+	}
+	if idx == 0 {
+		return map[string]string{"Status": "No " + node.label + " data"}
+	}
+	return data
+}
+
+func (node *tableTopGroupNode) GetChild(name string) (MetricNode, error) {
+	for _, l := range node.rankedLists() {
+		if l.name != name {
+			continue
+		}
+		return &tableRankedListNode{
+			entries: l.entries, windowSecs: l.windowSecs,
+			flag: l.flag, parent: node, path: node.path + "/" + name,
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown ranked list: %s", name)
+}
+
+// tableRankedListNode shows one ranked list (e.g., requests over the last
+// minute). Children are the individual entries.
+type tableRankedListNode struct {
+	entries    []madmin.TableIOMetrics
+	windowSecs float64
+	flag       madmin.MetricFlags
+	parent     MetricNode
+	path       string
+}
+
+func (node *tableRankedListNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *tableRankedListNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTablesAPI }
+func (node *tableRankedListNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *tableRankedListNode) GetParent() MetricNode              { return node.parent }
+func (node *tableRankedListNode) GetPath() string                    { return node.path }
+func (node *tableRankedListNode) ShouldPauseRefresh() bool           { return node.windowSecs > 60 }
+
+func (node *tableRankedListNode) GetChildren() []MetricChild {
 	children := make([]MetricChild, 0, len(node.entries))
 	for i := range node.entries {
 		e := &node.entries[i]
@@ -280,27 +363,27 @@ func (node *tableTopListNode) GetChildren() []MetricChild {
 		children = append(children, MetricChild{
 			Name:        url.PathEscape(key),
 			DisplayName: key,
-			Description: describeTableIOMetrics(e),
+			Description: describeTableAPIStat(&e.TableAPIStat, node.windowSecs),
 		})
 	}
 	return children
 }
 
-func (node *tableTopListNode) GetLeafData() map[string]string {
+func (node *tableRankedListNode) GetLeafData() map[string]string {
 	if len(node.entries) == 0 {
-		return map[string]string{"Status": "No " + node.label + " entries"}
+		return map[string]string{"Status": "No entries"}
 	}
 	data := map[string]string{
 		"00:Entries": fmt.Sprintf("%d", len(node.entries)),
 	}
 	for i := range node.entries {
 		key := fmt.Sprintf("%02d:%s", i+1, tableEntryKey(&node.entries[i]))
-		data[key] = describeTableIOMetrics(&node.entries[i])
+		data[key] = describeTableAPIStat(&node.entries[i].TableAPIStat, node.windowSecs)
 	}
 	return data
 }
 
-func (node *tableTopListNode) GetChild(name string) (MetricNode, error) {
+func (node *tableRankedListNode) GetChild(name string) (MetricNode, error) {
 	decoded, err := url.PathUnescape(name)
 	if err != nil {
 		return nil, fmt.Errorf("invalid name: %s", name)
@@ -308,20 +391,21 @@ func (node *tableTopListNode) GetChild(name string) (MetricNode, error) {
 	for i := range node.entries {
 		if tableEntryKey(&node.entries[i]) == decoded {
 			return &tableEntryNode{
-				entry: node.entries[i], flag: node.flag,
-				parent: node, path: node.path + "/" + name,
+				entry: node.entries[i], windowSecs: node.windowSecs,
+				flag: node.flag, parent: node, path: node.path + "/" + name,
 			}, nil
 		}
 	}
 	return nil, fmt.Errorf("entry not found: %s", decoded)
 }
 
-// tableEntryNode is a leaf for a single TableIOMetrics row.
+// tableEntryNode is a leaf for a single TableIOMetrics row from a ranked list.
 type tableEntryNode struct {
-	entry  madmin.TableIOMetrics
-	flag   madmin.MetricFlags
-	parent MetricNode
-	path   string
+	entry      madmin.TableIOMetrics
+	windowSecs float64
+	flag       madmin.MetricFlags
+	parent     MetricNode
+	path       string
 }
 
 func (node *tableEntryNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
@@ -329,7 +413,7 @@ func (node *tableEntryNode) GetMetricType() madmin.MetricType   { return madmin.
 func (node *tableEntryNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
 func (node *tableEntryNode) GetParent() MetricNode              { return node.parent }
 func (node *tableEntryNode) GetPath() string                    { return node.path }
-func (node *tableEntryNode) ShouldPauseRefresh() bool           { return false }
+func (node *tableEntryNode) ShouldPauseRefresh() bool           { return node.windowSecs > 60 }
 func (node *tableEntryNode) GetChildren() []MetricChild         { return []MetricChild{} }
 func (node *tableEntryNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children")
@@ -351,15 +435,7 @@ func (node *tableEntryNode) GetLeafData() map[string]string {
 	if node.entry.Table != nil {
 		add("Table", *node.entry.Table)
 	}
-	if node.entry.LastMinute != nil {
-		add("Last Minute", describeTableAPIStat(node.entry.LastMinute, 60))
-	}
-	if node.entry.LastHour != nil {
-		add("Last Hour", describeTableAPIStat(node.entry.LastHour, 3600))
-	}
-	if node.entry.LastDay != nil {
-		add("Last Day", describeTableAPIStat(node.entry.LastDay, 86400))
-	}
+	addTableStatData(&node.entry.TableAPIStat, node.windowSecs, add)
 	if idx == 0 {
 		return map[string]string{"Status": "No data"}
 	}
@@ -382,20 +458,6 @@ func tableEntryKey(e *madmin.TableIOMetrics) string {
 		return "(unnamed)"
 	}
 	return strings.Join(parts, ":")
-}
-
-// describeTableIOMetrics returns a compact one-line summary for a top-list
-// child, preferring the shortest available window.
-func describeTableIOMetrics(e *madmin.TableIOMetrics) string {
-	switch {
-	case e.LastMinute != nil:
-		return describeTableAPIStat(e.LastMinute, 60)
-	case e.LastHour != nil:
-		return describeTableAPIStat(e.LastHour, 3600)
-	case e.LastDay != nil:
-		return describeTableAPIStat(e.LastDay, 86400)
-	}
-	return "No data"
 }
 
 // describeTableAPIStat formats a TableAPIStat as a single line for use in
@@ -442,6 +504,13 @@ func tableStatLeafData(s *madmin.TableAPIStat, windowSecs float64) map[string]st
 		data[fmt.Sprintf("%02d:%s", idx, k)] = v
 		idx++
 	}
+	addTableStatData(s, windowSecs, add)
+	return data
+}
+
+// addTableStatData emits leaf entries for a TableAPIStat through add. The
+// caller controls ordering and key prefixing via its closure.
+func addTableStatData(s *madmin.TableAPIStat, windowSecs float64, add func(k, v string)) {
 	total := s.Reads + s.Writes
 	add("Requests", humanize.Comma(total))
 	if total > 0 && windowSecs > 0 {
@@ -475,5 +544,4 @@ func tableStatLeafData(s *madmin.TableAPIStat, windowSecs float64) map[string]st
 	if total > 0 && s.RespTTFBSecs > 0 {
 		add("Avg TTFB", fmt.Sprintf("%.1fms", (s.RespTTFBSecs/float64(total))*1000))
 	}
-	return data
 }


### PR DESCRIPTION
This is the *external* api for collecting table stats.

Based off https://github.com/minio/madmin-go/pull/614

* Added accumulated request times.
* Added accumulated ttfb.
* Added `NotOK` for status codes >= 400.
* Last minute - all tables.
* Last hour/day - all tables time segmented.
* Added minute/hour/day top 25 (by request count) for Warehouses/NameSpaces/Tables. May contain more, but at least 25 when they have data.

Made the name `MetricsTablesAPI`, since I would imagine we'd want a separate type that collects metrics on more common table things.

Note that we already collect and return Table API calls segmented by handler in `MetricsAPI`, so trying to not duplicate too much from there.

If this covers the data we are looking for I will modify the EOS PR to provide these values. Request times seemed obvious. Some sort of "ok", "not ok" seemed appropriate.