### PR TITLE
feat: add untier types and admin client methods

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -84,6 +84,8 @@ const (
 	TraceSystemInventory
 	// TraceTablesCompaction will trace table compaction operations.
 	TraceTablesCompaction
+	// TraceUntier will trace untier (warm-to-hot repatriation) operations.
+	TraceUntier
 	// Add more here...
 
 	// TraceAll contains all valid trace modes.

--- a/tracetype_string.go
+++ b/tracetype_string.go
@@ -34,39 +34,41 @@ func _() {
 	_ = x[TraceTablesScan-8388608]
 	_ = x[TraceSystemInventory-16777216]
 	_ = x[TraceTablesCompaction-33554432]
-	_ = x[TraceAll-67108863]
+	_ = x[TraceUntier-67108864]
+	_ = x[TraceAll-134217727]
 }
 
-const _TraceType_name = "OSStorageS3InternalScannerDecommissionHealingBatchReplicationBatchKeyRotationBatchExpireRebalanceReplicationResyncBootstrapFTPILMKMSFormattingAdminObjectReplicationIAMTablesPurgeOnDeleteTablesScanSystemInventoryTablesCompactionAll"
+const _TraceType_name = "OSStorageS3InternalScannerDecommissionHealingBatchReplicationBatchKeyRotationBatchExpireRebalanceReplicationResyncBootstrapFTPILMKMSFormattingAdminObjectReplicationIAMTablesPurgeOnDeleteTablesScanSystemInventoryTablesCompactionUntierAll"
 
 var _TraceType_map = map[TraceType]string{
-	1:        _TraceType_name[0:2],
-	2:        _TraceType_name[2:9],
-	4:        _TraceType_name[9:11],
-	8:        _TraceType_name[11:19],
-	16:       _TraceType_name[19:26],
-	32:       _TraceType_name[26:38],
-	64:       _TraceType_name[38:45],
-	128:      _TraceType_name[45:61],
-	256:      _TraceType_name[61:77],
-	512:      _TraceType_name[77:88],
-	1024:     _TraceType_name[88:97],
-	2048:     _TraceType_name[97:114],
-	4096:     _TraceType_name[114:123],
-	8192:     _TraceType_name[123:126],
-	16384:    _TraceType_name[126:129],
-	32768:    _TraceType_name[129:132],
-	65536:    _TraceType_name[132:142],
-	131072:   _TraceType_name[142:147],
-	262144:   _TraceType_name[147:153],
-	524288:   _TraceType_name[153:164],
-	1048576:  _TraceType_name[164:167],
-	2097152:  _TraceType_name[167:173],
-	4194304:  _TraceType_name[173:186],
-	8388608:  _TraceType_name[186:196],
-	16777216: _TraceType_name[196:211],
-	33554432: _TraceType_name[211:227],
-	67108863: _TraceType_name[227:230],
+	1:         _TraceType_name[0:2],
+	2:         _TraceType_name[2:9],
+	4:         _TraceType_name[9:11],
+	8:         _TraceType_name[11:19],
+	16:        _TraceType_name[19:26],
+	32:        _TraceType_name[26:38],
+	64:        _TraceType_name[38:45],
+	128:       _TraceType_name[45:61],
+	256:       _TraceType_name[61:77],
+	512:       _TraceType_name[77:88],
+	1024:      _TraceType_name[88:97],
+	2048:      _TraceType_name[97:114],
+	4096:      _TraceType_name[114:123],
+	8192:      _TraceType_name[123:126],
+	16384:     _TraceType_name[126:129],
+	32768:     _TraceType_name[129:132],
+	65536:     _TraceType_name[132:142],
+	131072:    _TraceType_name[142:147],
+	262144:    _TraceType_name[147:153],
+	524288:    _TraceType_name[153:164],
+	1048576:   _TraceType_name[164:167],
+	2097152:   _TraceType_name[167:173],
+	4194304:   _TraceType_name[173:186],
+	8388608:   _TraceType_name[186:196],
+	16777216:  _TraceType_name[196:211],
+	33554432:  _TraceType_name[211:227],
+	67108864:  _TraceType_name[227:233],
+	134217727: _TraceType_name[233:236],
 }
 
 func (i TraceType) String() string {

--- a/untier.go
+++ b/untier.go
@@ -1,0 +1,151 @@
+//
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// UntierStatus is the status of an untier session for a bucket.
+type UntierStatus string
+
+const (
+	// UntierStatusStarted indicates the session is running.
+	UntierStatusStarted UntierStatus = "started"
+	// UntierStatusCompleted indicates the session completed successfully.
+	UntierStatusCompleted UntierStatus = "completed"
+	// UntierStatusFailed indicates the session failed.
+	UntierStatusFailed UntierStatus = "failed"
+	// UntierStatusStopped indicates the session was stopped by the operator.
+	UntierStatusStopped UntierStatus = "stopped"
+)
+
+// UntierStartOptions contains options for starting an untier session.
+type UntierStartOptions struct {
+	Bucket string `json:"bucket"`
+}
+
+// UntierStopOptions contains options for stopping a running untier session.
+type UntierStopOptions struct {
+	Bucket string `json:"bucket"`
+}
+
+// UntierBucketStatus contains per-bucket progress metrics for an untier session.
+type UntierBucketStatus struct {
+	ID              string       `json:"id"`
+	Bucket          string       `json:"bucket"`
+	Status          UntierStatus `json:"status"`
+	StartTime       time.Time    `json:"startTime"`
+	EndTime         time.Time    `json:"endTime,omitempty"`
+	StoppedAt       time.Time    `json:"stoppedAt,omitempty"`
+	Object          string       `json:"object,omitempty"`
+	LastKey         string       `json:"lastKey,omitempty"`
+	NumObjectsTotal uint64       `json:"numObjectsTotal"`
+	NumObjects      uint64       `json:"numObjects"`
+	NumVersions     uint64       `json:"numVersions"`
+	BytesDone       uint64       `json:"bytesDone"`
+	BytesTotal      uint64       `json:"bytesTotal"`
+	ETASeconds      *int64       `json:"etaSeconds,omitempty"`
+}
+
+// UntierStatusInfo contains the status of all active or completed untier sessions.
+type UntierStatusInfo struct {
+	Buckets []UntierBucketStatus `json:"buckets"`
+}
+
+// UntierStart starts an untier operation for the given bucket.
+func (adm *AdminClient) UntierStart(ctx context.Context, opts UntierStartOptions) error {
+	body, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+	resp, err := adm.executeMethod(ctx,
+		http.MethodPost,
+		requestData{
+			relPath: adminAPIPrefix + "/untier/start",
+			content: body,
+		})
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+	return nil
+}
+
+// UntierStatus returns the status of ongoing or completed untier sessions.
+// If bucket is non-empty only that bucket's status is returned.
+func (adm *AdminClient) UntierStatus(ctx context.Context, bucket string) (UntierStatusInfo, error) {
+	var info UntierStatusInfo
+	queryValues := url.Values{}
+	if bucket != "" {
+		queryValues.Set("bucket", bucket)
+	}
+	resp, err := adm.executeMethod(ctx,
+		http.MethodGet,
+		requestData{
+			relPath:     adminAPIPrefix + "/untier/status",
+			queryValues: queryValues,
+		})
+	defer closeResponse(resp)
+	if err != nil {
+		return info, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return info, httpRespToErrorResponse(resp)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return info, err
+	}
+	if err = json.Unmarshal(b, &info); err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+// UntierStop stops a running untier session for the given bucket.
+func (adm *AdminClient) UntierStop(ctx context.Context, opts UntierStopOptions) error {
+	body, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+	resp, err := adm.executeMethod(ctx,
+		http.MethodPost,
+		requestData{
+			relPath: adminAPIPrefix + "/untier/stop",
+			content: body,
+		})
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+	return nil
+}


### PR DESCRIPTION
Add TraceUntier trace type, UntierStatus/UntierBucketStatus/UntierStatusInfo types, and UntierStart/UntierStop/UntierStatus admin client methods for warm-to-hot storage repatriation (untier) feature.

original pr: https://github.com/miniohq/aistor/pull/5620