### PR TITLE
tables: add rebuild statuses for the tables status API

### DIFF
--- a/tables-replication.go
+++ b/tables-replication.go
@@ -29,11 +29,26 @@ import (
 	"time"
 )
 
+// TablesRebuildState is the lifecycle state of a post-failover catalog rebuild,
+// reported in TablesReplicationStatus.RebuildState.
+type TablesRebuildState string
+
+const (
+	TablesRebuildPending      TablesRebuildState = "Pending"
+	TablesRebuildInProgress   TablesRebuildState = "InProgress"
+	TablesRebuildFailureRetry TablesRebuildState = "FailureRetry"
+	TablesRebuildFailed       TablesRebuildState = "Failed"
+	TablesRebuildCompleted    TablesRebuildState = "Completed"
+)
+
 // TablesReplicationStatus is one page of the tables replication status admin API.
 type TablesReplicationStatus struct {
 	Status                string                 `json:"status"`
 	Tables                []TableReplicationInfo `json:"tables"`
 	NextContinuationToken string                 `json:"nextContinuationToken,omitempty"`
+	RebuildState          TablesRebuildState     `json:"rebuildState,omitempty"`
+	RebuildAttempts       int                    `json:"rebuildAttempts,omitempty"`
+	RebuildLastError      string                 `json:"rebuildLastError,omitempty"`
 }
 
 // TableReplicationInfo is the per-table replication status.


### PR DESCRIPTION
When rebuilding the tables catalog, surface any errors and the current status using the tables status API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Tables Replication Status API with new rebuild state tracking fields. The API response now provides visibility into current rebuild state status, number of rebuild attempts made, and details of the most recent rebuild error if encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->