### PR TITLE
tables: add method to allow catalog export

### DIFF
--- a/tables-replication.go
+++ b/tables-replication.go
@@ -171,7 +171,6 @@ func (adm *AdminClient) TablesCatalogExport(ctx context.Context) (io.ReadCloser,
 		closeResponse(resp)
 		return nil, err
 	}
-	}
 
 	return resp.Body, nil
 }

--- a/tables-replication.go
+++ b/tables-replication.go
@@ -151,6 +151,28 @@ func (adm *AdminClient) TablesReplicationResetCatalog(ctx context.Context) error
 	return nil
 }
 
+// TablesCatalogExport downloads the entire tables catalog as a zip archive.
+// Each msgp-encoded catalog file is decoded server-side and stored as a JSON
+// file, preserving the catalog directory layout. The returned reader streams the
+// zip body; the caller must close it.
+func (adm *AdminClient) TablesCatalogExport(ctx context.Context) (io.ReadCloser, error) {
+	reqData := requestData{
+		relPath: adminAPIPrefix + "/tables/catalog-export",
+	}
+
+	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		closeResponse(resp)
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	return resp.Body, nil
+}
+
 // TablesReplicationResyncCatalogOpen enters the post-failover resyncing
 // window (phase 1 of post-failover) on this site.
 func (adm *AdminClient) TablesReplicationResyncCatalogOpen(ctx context.Context) error {

--- a/tables-replication.go
+++ b/tables-replication.go
@@ -162,12 +162,15 @@ func (adm *AdminClient) TablesCatalogExport(ctx context.Context) (io.ReadCloser,
 
 	resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
 	if err != nil {
+		closeResponse(resp)
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		err = httpRespToErrorResponse(resp)
 		closeResponse(resp)
-		return nil, httpRespToErrorResponse(resp)
+		return nil, err
+	}
 	}
 
 	return resp.Body, nil


### PR DESCRIPTION
SDK method for dumping the contents of the catalog for debugging purposes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new admin capability to export the tables catalog as a compressed ZIP archive via the catalog-export endpoint. The export streams the ZIP download for efficient handling, and error responses are managed to help prevent resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->