### PR TITLE
tables: add filter to compaction config

### DIFF
--- a/table-maintenance.go
+++ b/table-maintenance.go
@@ -19,6 +19,8 @@
 
 package madmin
 
+import "encoding/json"
+
 // Table maintenance type constants
 const (
 	MaintenanceTypeIcebergSnapshotManagement      = "icebergSnapshotManagement"
@@ -49,6 +51,11 @@ type IcebergCompactionSettings struct {
 	// Inherits: table -> warehouse -> server if nil.
 	// Must be >= 1.
 	Interval *int `json:"interval,omitempty"`
+	// Filter is an optional Iceberg expression, in the REST spec's JSON filter
+	// form, that scopes compaction to the data files it can match; matched files
+	// are rewritten in full so no rows are dropped. It is table-scoped only (it
+	// names a table's columns/partitions) and is rejected at the warehouse level.
+	Filter json.RawMessage `json:"filter,omitempty"`
 }
 
 // IcebergUnreferencedFileRemovalSettings contains settings for Iceberg unreferenced file removal.


### PR DESCRIPTION
This adds a filter expression to the table-override compaction config, it allows exclusion of active partitions from compaction to reduce the likelihood of conflicts under streaming workloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an optional filter expression to scope Iceberg table compaction.
  * Invalid filters configured at the warehouse level are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->