### PR TITLE
Improve the per-pool stats

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"net/http"
 	"net/url"
 	"runtime/metrics"
@@ -769,7 +770,9 @@ type DiskIOStatsLegacy struct {
 
 // Add 'other' to 'd'.
 func (d *DiskIOStats) Add(other *DiskIOStats) {
-	if other == nil {
+	if other == nil || other.overflowed() {
+		// Discard segments carrying a uint64 underflow artifact (see overflowed)
+		// instead of polluting the aggregate.
 		return
 	}
 	d.N += other.N
@@ -793,6 +796,28 @@ func (d *DiskIOStats) Add(other *DiskIOStats) {
 	d.FlushTicks += other.FlushTicks
 	d.BitrotDetected += other.BitrotDetected
 	d.BitrotHealed += other.BitrotHealed
+}
+
+// overflowed reports whether any counter has its high bit set (value >
+// math.MaxInt64) — the signature of a uint64 underflow. Kernel iostat deltas
+// underflow to ~MaxUint64 on counter resets (reboot, drive hot-swap, wrap),
+// which is nonsensical as an IO count, so such segments are discarded on merge.
+func (d *DiskIOStats) overflowed() bool {
+	return (d.ReadIOs | d.ReadMerges | d.ReadSectors | d.ReadTicks |
+		d.WriteIOs | d.WriteMerges | d.WriteSectors | d.WriteTicks |
+		d.CurrentIOs | d.TotalTicks | d.ReqTicks |
+		d.DiscardIOs | d.DiscardMerges | d.DiscardSectors | d.DiscardTicks |
+		d.FlushIOs | d.FlushTicks | d.BitrotDetected | d.BitrotHealed) > math.MaxInt64
+}
+
+// discardOverflowedSegments zeroes IO segments carrying a uint64 underflow
+// artifact (see DiskIOStats.overflowed) so they do not survive a merge.
+func discardOverflowedSegments(segs []DiskIOStats) {
+	for i := range segs {
+		if segs[i].overflowed() {
+			segs[i] = DiskIOStats{}
+		}
+	}
 }
 
 type (
@@ -927,6 +952,13 @@ func (d *DiskMetric) Merge(other *DiskMetric) {
 	}
 	if d.NDisks == 0 {
 		*d = *other
+		// *d = *other aliases the IO segment slices; take independent copies and
+		// drop overflowed segments so a corrupt source segment neither survives
+		// the merge nor is mutated by it.
+		d.IOStatsDay.Segments = slices.Clone(other.IOStatsDay.Segments)
+		discardOverflowedSegments(d.IOStatsDay.Segments)
+		d.IOStatsHour.Segments = slices.Clone(other.IOStatsHour.Segments)
+		discardOverflowedSegments(d.IOStatsHour.Segments)
 		d.State = maps.Clone(other.State)
 		d.FSType = maps.Clone(other.FSType)
 		d.LifetimeOps = maps.Clone(other.LifetimeOps)
@@ -1006,9 +1038,11 @@ func (d *DiskMetric) Merge(other *DiskMetric) {
 	d.Hanging += other.Hanging
 	if other.Cache != nil {
 		if d.Cache == nil {
-			d.Cache = other.Cache
+			c := *other.Cache
+			d.Cache = &c
+		} else {
+			d.Cache.Merge(other.Cache)
 		}
-		d.Cache.Merge(other.Cache)
 	}
 	d.Space.Merge(other.Space)
 
@@ -1059,7 +1093,9 @@ func (d *DiskMetric) Merge(other *DiskMetric) {
 	}
 	d.IOStatsMinute.Add(&other.IOStatsMinute)
 	d.IOStatsDay.Add(&other.IOStatsDay)
+	discardOverflowedSegments(d.IOStatsDay.Segments)
 	d.IOStatsHour.Add(&other.IOStatsHour)
+	discardOverflowedSegments(d.IOStatsHour.Segments)
 	// Merge SMART data
 	if other.SMART != nil {
 		if d.SMART == nil {

--- a/metrics.go
+++ b/metrics.go
@@ -775,6 +775,12 @@ func (d *DiskIOStats) Add(other *DiskIOStats) {
 		// instead of polluting the aggregate.
 		return
 	}
+	if d.overflowed() {
+		// A corrupt receiver would otherwise drag its uint64 underflow artifact
+		// into every subsequent sum; reset it and restart the aggregate from the
+		// valid other value.
+		*d = DiskIOStats{}
+	}
 	d.N += other.N
 	d.WithIOStats += other.WithIOStats
 	d.ReadIOs += other.ReadIOs

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -21,6 +21,7 @@ package madmin
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -317,6 +318,60 @@ func TestSegmentedAddCopySlice(t *testing.T) {
 	}
 	if empty.Segments[1].Events != 888 {
 		t.Errorf("empty.Segments[1].Events = %d, want 888", empty.Segments[1].Events)
+	}
+}
+
+func TestDiskMetricMergeDiscardsOverflowSegments(t *testing.T) {
+	ft := time.Unix(1700000000, 0).UTC()
+	dayWith := func(readIOs uint64) SegmentedDiskIO {
+		return SegmentedDiskIO{Interval: 900, FirstTime: ft, Segments: []DiskIOStats{{N: 1, ReadIOs: readIOs}}}
+	}
+	const overflow = uint64(math.MaxUint64) - 100 // uint64 underflow artifact (bit 63 set)
+
+	// Overflowed segment in an accumulated set is discarded; the good base stays.
+	merged := DiskMetric{}
+	merged.Merge(&DiskMetric{NDisks: 1, IOStatsDay: dayWith(1000)}) // clone path
+	merged.Merge(&DiskMetric{NDisks: 1, IOStatsDay: dayWith(overflow)})
+	if got := merged.IOStatsDay.Segments[0].ReadIOs; got != 1000 {
+		t.Errorf("accumulate: ReadIOs = %d, want 1000 (overflow discarded)", got)
+	}
+
+	// Overflowed segment in the first (cloned) set is discarded and not aliased.
+	merged2 := DiskMetric{}
+	badFirst := &DiskMetric{NDisks: 1, IOStatsDay: dayWith(overflow)}
+	merged2.Merge(badFirst) // clone path -> overflow zeroed
+	merged2.Merge(&DiskMetric{NDisks: 1, IOStatsDay: dayWith(2000)})
+	if got := merged2.IOStatsDay.Segments[0].ReadIOs; got != 2000 {
+		t.Errorf("clone: ReadIOs = %d, want 2000 (first-set overflow discarded)", got)
+	}
+	if got := badFirst.IOStatsDay.Segments[0].ReadIOs; got != overflow {
+		t.Errorf("clone: source mutated, ReadIOs = %d, want %d", got, overflow)
+	}
+}
+
+func TestDiskMetricMergeCacheNoDouble(t *testing.T) {
+	// Accumulate path (base already has drives) where the base has no cache but
+	// a later metric does: the cache must be copied, not aliased-and-self-merged
+	// (which doubled the values and corrupted the source metric).
+	base := &DiskMetric{NDisks: 1}
+	other := &DiskMetric{
+		NDisks: 1,
+		Cache:  &CacheStats{N: 1, Capacity: 1000, Used: 400, Hits: 80, Misses: 20},
+	}
+
+	base.Merge(other)
+
+	if base.Cache == nil {
+		t.Fatal("merged Cache = nil, want copied cache")
+	}
+	if base.Cache.Capacity != 1000 || base.Cache.Hits != 80 {
+		t.Errorf("merged Cache = %+v, want Capacity 1000 / Hits 80 (not doubled)", *base.Cache)
+	}
+	if other.Cache.Capacity != 1000 || other.Cache.Hits != 80 {
+		t.Errorf("source Cache mutated = %+v, want unchanged Capacity 1000 / Hits 80", *other.Cache)
+	}
+	if base.Cache == other.Cache {
+		t.Error("merged Cache aliases source Cache; want an independent copy")
 	}
 }
 

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -223,6 +223,16 @@ func (node *DiskMetricsNavigator) GetLeafData() map[string]string {
 		}
 	}
 
+	// Cache summary (if drive caching is enabled).
+	if c := node.disk.Cache; c != nil {
+		if c.Capacity > 0 {
+			data["Cache Capacity"] = humanize.Bytes(uint64(c.Capacity))
+		}
+		if reqs := c.Hits + c.Misses; reqs > 0 {
+			data["Cache Hit Rate"] = fmt.Sprintf("%.1f%%", float64(c.Hits)/float64(reqs)*100)
+		}
+	}
+
 	// Additional Features
 	var features []string
 	if node.disk.Cache != nil {

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -146,6 +146,7 @@ func getNodeOpts(node MetricNode) madmin.MetricsOptions {
 		opts.Flags |= pOpts.Flags
 		opts.Hosts = append(opts.Hosts, pOpts.Hosts...)
 		opts.Disks = append(opts.Disks, pOpts.Disks...)
+		opts.PoolIdx = append(opts.PoolIdx, pOpts.PoolIdx...)
 		opts.DrivePoolIdx = append(opts.DrivePoolIdx, pOpts.DrivePoolIdx...)
 		opts.DriveSetIdx = append(opts.DriveSetIdx, pOpts.DriveSetIdx...)
 	}
@@ -576,7 +577,13 @@ func (node *DiskSetMapNode) ShouldPauseUpdates() bool {
 
 func (node *DiskSetMapNode) GetChildren() []MetricChild {
 	children := make([]MetricChild, 0, len(node.data))
-	for poolID, pool := range node.data {
+	poolIDs := make([]int, 0, len(node.data))
+	for poolID := range node.data {
+		poolIDs = append(poolIDs, poolID)
+	}
+	sort.Ints(poolIDs)
+	for _, poolID := range poolIDs {
+		pool := node.data[poolID]
 		// Calculate pool-level statistics for better description
 		var poolDisks int
 		poolSets := len(pool)
@@ -592,7 +599,7 @@ func (node *DiskSetMapNode) GetChildren() []MetricChild {
 			poolID, poolSets, poolDisks, poolHealthyDisks, poolCurrentIOs)
 
 		children = append(children, MetricChild{
-			Name:        fmt.Sprintf("pool_%d", poolID),
+			Name:        fmt.Sprintf("pool_%02d", poolID),
 			Description: description,
 		})
 	}
@@ -615,11 +622,11 @@ func (node *DiskSetMapNode) GetLeafData() map[string]string {
 
 	// First pass: calculate pool-level aggregated metrics
 	poolMetrics := make(map[int]struct {
-		sets    int
-		ops     uint64
-		accTime float64
-		ioOps   uint64
-		ioBytes uint64
+		sets      int
+		ops       uint64
+		accTime   float64
+		ioOps     uint64
+		ioSectors uint64
 	})
 
 	for poolID, pool := range node.data {
@@ -650,7 +657,7 @@ func (node *DiskSetMapNode) GetLeafData() map[string]string {
 			// Aggregate current IO statistics for this pool
 			ioStat := diskSet.IOStatsMinute
 			poolStat.ioOps += ioStat.ReadIOs + ioStat.WriteIOs + ioStat.DiscardIOs + ioStat.FlushIOs
-			poolStat.ioBytes += ioStat.ReadSectors + ioStat.WriteSectors + ioStat.DiscardSectors // Sectors represent data transferred
+			poolStat.ioSectors += ioStat.ReadSectors + ioStat.WriteSectors + ioStat.DiscardSectors
 
 			_ = setID // Mark as used
 		}
@@ -671,9 +678,11 @@ func (node *DiskSetMapNode) GetLeafData() map[string]string {
 			opsDisplay = "No recent activity"
 		}
 
-		// Calculate current IO metrics for this pool
-		if poolStat.ioOps > 0 || poolStat.ioBytes > 0 {
-			ioDisplay = fmt.Sprintf(", %s IO/s", humanize.Bytes(poolStat.ioBytes))
+		// Calculate current IO metrics for this pool (last-minute rolling window).
+		if poolStat.ioOps > 0 || poolStat.ioSectors > 0 {
+			iosPerSec := float64(poolStat.ioOps) / 60.0
+			mbPerSec := float64(poolStat.ioSectors*512) / 60.0 / (1024 * 1024)
+			ioDisplay = fmt.Sprintf(", %.1f IO/s, %.2f MB/s", iosPerSec, mbPerSec)
 		} else {
 			ioDisplay = ", No current IO"
 		}
@@ -767,7 +776,7 @@ func (node *DiskSetMapNode) GetChild(name string) (MetricNode, error) {
 	}
 
 	if sets, exists := node.data[poolID]; exists {
-		return NewDiskSetPoolNavigator(poolID, sets, node.metricType, node.metricFlags, node, fmt.Sprintf("%s/pool_%d", node.path, poolID)), nil
+		return NewDiskSetPoolNavigator(poolID, sets, node.metricType, node.metricFlags, node, fmt.Sprintf("%s/pool_%02d", node.path, poolID)), nil
 	}
 
 	return nil, fmt.Errorf("pool not found: %d", poolID)
@@ -802,7 +811,7 @@ func (node *DiskSetPoolNavigator) GetChildren() []MetricChild {
 	if node.poolSets == nil {
 		return []MetricChild{}
 	}
-	children := make([]MetricChild, 0, len(node.poolSets))
+	children := make([]MetricChild, 0, len(node.poolSets)+1)
 	for setID, diskSet := range node.poolSets {
 		healthyDisks := diskSet.NDisks - diskSet.Offline - diskSet.Hanging - diskSet.Healing
 		currentIOs := diskSet.IOStatsMinute.CurrentIOs
@@ -810,7 +819,7 @@ func (node *DiskSetPoolNavigator) GetChildren() []MetricChild {
 			setID, diskSet.NDisks, healthyDisks, currentIOs)
 
 		children = append(children, MetricChild{
-			Name:        fmt.Sprintf("set_%d", setID),
+			Name:        fmt.Sprintf("set_%04d", setID),
 			Description: description,
 		})
 	}
@@ -820,7 +829,15 @@ func (node *DiskSetPoolNavigator) GetChildren() []MetricChild {
 		return children[i].Name < children[j].Name
 	})
 
-	return children
+	// Prepend an _ALL entry that merges every set in this pool into one.
+	merged := node.mergedSets()
+	healthyDisks := merged.NDisks - merged.Offline - merged.Hanging - merged.Healing
+	allChild := MetricChild{
+		Name: "_ALL",
+		Description: fmt.Sprintf("All %d sets merged: %d drives (%d healthy), %d current IOs",
+			len(node.poolSets), merged.NDisks, healthyDisks, merged.IOStatsMinute.CurrentIOs),
+	}
+	return append([]MetricChild{allChild}, children...)
 }
 
 func (node *DiskSetPoolNavigator) GetLeafData() map[string]string {
@@ -920,7 +937,21 @@ func (node *DiskSetPoolNavigator) GetParent() MetricNode              { return n
 func (node *DiskSetPoolNavigator) GetPath() string                    { return node.path }
 func (node *DiskSetPoolNavigator) ShouldPauseRefresh() bool           { return false }
 
+func (node *DiskSetPoolNavigator) mergedSets() madmin.DiskMetric {
+	var merged madmin.DiskMetric
+	for setID := range node.poolSets {
+		ds := node.poolSets[setID]
+		merged.Merge(&ds)
+	}
+	return merged
+}
+
 func (node *DiskSetPoolNavigator) GetChild(name string) (MetricNode, error) {
+	if name == "_ALL" {
+		merged := node.mergedSets()
+		return NewDiskMetricsNavigator(&merged, node, fmt.Sprintf("%s/_ALL", node.path), getNodeOpts(node)), nil
+	}
+
 	if !strings.HasPrefix(name, "set_") {
 		return nil, fmt.Errorf("invalid set name format: %s", name)
 	}
@@ -934,7 +965,7 @@ func (node *DiskSetPoolNavigator) GetChild(name string) (MetricNode, error) {
 	if diskMetric, exists := node.poolSets[setID]; exists {
 		opts := getNodeOpts(node)
 		opts.DriveSetIdx = append(opts.DriveSetIdx, setID)
-		return NewDiskMetricsNavigator(&diskMetric, node, fmt.Sprintf("%s/set_%d", node.path, setID), opts), nil
+		return NewDiskMetricsNavigator(&diskMetric, node, fmt.Sprintf("%s/set_%04d", node.path, setID), opts), nil
 	}
 
 	return nil, fmt.Errorf("set not found: %d", setID)

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -681,7 +681,7 @@ func (node *DiskSetMapNode) GetLeafData() map[string]string {
 		// Calculate current IO metrics for this pool (last-minute rolling window).
 		if poolStat.ioOps > 0 || poolStat.ioSectors > 0 {
 			iosPerSec := float64(poolStat.ioOps) / 60.0
-			mbPerSec := float64(poolStat.ioSectors*512) / 60.0 / (1024 * 1024)
+			mbPerSec := float64(poolStat.ioSectors) * 512 / 60.0 / (1024 * 1024)
 			ioDisplay = fmt.Sprintf(", %.1f IO/s, %.2f MB/s", iosPerSec, mbPerSec)
 		} else {
 			ioDisplay = ", No current IO"
@@ -811,7 +811,7 @@ func (node *DiskSetPoolNavigator) GetChildren() []MetricChild {
 	if node.poolSets == nil {
 		return []MetricChild{}
 	}
-	children := make([]MetricChild, 0, len(node.poolSets)+1)
+	children := make([]MetricChild, 0, len(node.poolSets))
 	for setID, diskSet := range node.poolSets {
 		healthyDisks := diskSet.NDisks - diskSet.Offline - diskSet.Hanging - diskSet.Healing
 		currentIOs := diskSet.IOStatsMinute.CurrentIOs

--- a/mnav/mnav_test.go
+++ b/mnav/mnav_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+func TestDiskSetNavigation(t *testing.T) {
+	m := &madmin.RealtimeMetrics{
+		ByDiskSet: map[int]map[int]madmin.DiskMetric{
+			2: {0: {NDisks: 4}, 1: {NDisks: 4}},
+			0: {0: {NDisks: 8}},
+			1: {0: {NDisks: 2}, 1: {NDisks: 2}, 2: {NDisks: 2}},
+		},
+	}
+	nav := NewRealtimeMetricsNavigator(m)
+
+	// Pools are listed in numeric order with zero-padded names.
+	bds, err := nav.Navigate("by_drive_set")
+	if err != nil {
+		t.Fatalf("navigate by_drive_set: %v", err)
+	}
+	if got, want := childNames(bds.GetChildren()), []string{"pool_00", "pool_01", "pool_02"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("pool order = %v, want %v", got, want)
+	}
+
+	// Inside a pool: _ALL first, then sets in numeric order with zero-padded names.
+	pool, err := nav.Navigate("by_drive_set/pool_01")
+	if err != nil {
+		t.Fatalf("navigate pool_01: %v", err)
+	}
+	if got, want := childNames(pool.GetChildren()), []string{"_ALL", "set_0000", "set_0001", "set_0002"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("set order = %v, want %v", got, want)
+	}
+
+	// A set node carries both its pool and set index in the refresh opts.
+	set, err := nav.Navigate("by_drive_set/pool_02/set_0001")
+	if err != nil {
+		t.Fatalf("navigate set_0001: %v", err)
+	}
+	if opts := set.GetOpts(); !reflect.DeepEqual(opts.PoolIdx, []int{2}) || !reflect.DeepEqual(opts.DriveSetIdx, []int{1}) {
+		t.Errorf("set opts PoolIdx=%v DriveSetIdx=%v, want [2] [1]", opts.PoolIdx, opts.DriveSetIdx)
+	}
+
+	// _ALL node is scoped to the whole pool: pool index set, no set restriction.
+	all, err := nav.Navigate("by_drive_set/pool_02/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	if opts := all.GetOpts(); !reflect.DeepEqual(opts.PoolIdx, []int{2}) || len(opts.DriveSetIdx) != 0 {
+		t.Errorf("_ALL opts PoolIdx=%v DriveSetIdx=%v, want [2] and empty", opts.PoolIdx, opts.DriveSetIdx)
+	}
+}
+
+func childNames(children []MetricChild) []string {
+	out := make([]string, len(children))
+	for i, c := range children {
+		out[i] = c.Name
+	}
+	return out
+}
+
+func TestDiskSetLeafData(t *testing.T) {
+	m := &madmin.RealtimeMetrics{
+		ByDiskSet: map[int]map[int]madmin.DiskMetric{
+			0: {
+				0: {
+					NDisks:        4,
+					IOStatsMinute: madmin.DiskIOStats{N: 4, ReadIOs: 3000, WriteIOs: 3000, ReadSectors: 60000, WriteSectors: 60000},
+					Cache:         &madmin.CacheStats{N: 4, Capacity: 1 << 30, Used: 1 << 29, Hits: 80, Misses: 20},
+				},
+			},
+		},
+	}
+	nav := NewRealtimeMetricsNavigator(m)
+
+	// Pool summary reports both IO rate and bandwidth.
+	bds, err := nav.Navigate("by_drive_set")
+	if err != nil {
+		t.Fatalf("navigate by_drive_set: %v", err)
+	}
+	if pool0 := bds.GetLeafData()["Pool 0"]; !strings.Contains(pool0, "IO/s") || !strings.Contains(pool0, "MB/s") {
+		t.Errorf("Pool 0 summary = %q, want both IO/s and MB/s", pool0)
+	}
+
+	// _ALL and individual sets surface cache capacity + hit rate.
+	for _, path := range []string{"by_drive_set/pool_00/_ALL", "by_drive_set/pool_00/set_0000"} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		d := node.GetLeafData()
+		if _, ok := d["Cache Capacity"]; !ok {
+			t.Errorf("%s: missing Cache Capacity", path)
+		}
+		if got := d["Cache Hit Rate"]; got != "80.0%" {
+			t.Errorf("%s: Cache Hit Rate = %q, want 80.0%%", path, got)
+		}
+	}
+}


### PR DESCRIPTION
Add pool-aggregated stats and fix underflows from some server versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disk cache capacity and hit-rate details to disk leaf views.
  * Added `_ALL` nodes for merged disk-set metrics within each pool.
  * Updated disk pool/set navigation to use consistent, zero-padded naming and deterministic ordering.
  * Improved pool summaries to show current I/O in **IO/s** and **MB/s**.
* **Bug Fixes**
  * Discarded corrupted/overflowed disk I/O segments during metric merges to prevent invalid aggregates.
  * Fixed cache merging to avoid aliasing and ensure correct, non-mutating accumulation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->