### PR TITLE
feat: add MakeWarehouseBktOp for gated warehouse-bucket site replication

### DIFF
--- a/cluster-commands.go
+++ b/cluster-commands.go
@@ -238,6 +238,10 @@ type BktOp string
 const (
 	// make bucket and enable versioning
 	MakeWithVersioningBktOp BktOp = "make-with-versioning"
+	// make an AIStor Tables warehouse bucket and enable versioning; a peer that
+	// predates warehouse replication has no route for this op and rejects it, so
+	// the warehouse is withheld until that peer is upgraded
+	MakeWarehouseBktOp BktOp = "make-warehouse"
 	// add replication configuration
 	ConfigureReplBktOp BktOp = "configure-replication"
 	// delete bucket (forceDelete = off)
@@ -255,7 +259,7 @@ func (adm *AdminClient) SRPeerBucketOps(ctx context.Context, bucket string, op B
 	v.Add("operation", string(op))
 
 	// For make-bucket, bucket options may be sent via `opts`
-	if op == MakeWithVersioningBktOp || op == DeleteBucketBktOp {
+	if op == MakeWithVersioningBktOp || op == MakeWarehouseBktOp || op == DeleteBucketBktOp {
 		for k, val := range opts {
 			v.Add(k, val)
 		}


### PR DESCRIPTION
## Description

Adds a dedicated `MakeWarehouseBktOp` bucket-op for site replication of
AIStor Tables warehouse buckets, and forwards bucket options for it in
`SRPeerBucketOps` (same as `MakeWithVersioningBktOp`).

## Motivation

Warehouse buckets were replicated through the generic
`MakeWithVersioningBktOp` with an `isWarehouse=true` form key. A peer
that predates warehouse-bucket support silently ignores the unknown key
and creates a plain bucket, which can never be registered as a warehouse
(the catalog scanner only scans buckets flagged `IsWarehouse`) — an
unrecoverable orphan.

Routing warehouse creation through its own op lets an older peer reject
it (the op has no route on that server), so the sender can withhold the
warehouse until the peer is upgraded. Consumed by aistor.

## How to test

Server-side consumer (aistor) maps this op to a warehouse bucket create
and relies on older peers returning an error for the unknown op.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Compiles and `go vet` passes
- [x] Backward compatible (additive op constant; opts forwarding extended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating warehouse buckets through cluster bucket operations.
  * Warehouse bucket requests now accept the relevant bucket options.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->