### PR TITLE
feat: add MakeCortexBktOp for gated cortex-bucket site replication

### DIFF
--- a/cluster-commands.go
+++ b/cluster-commands.go
@@ -242,6 +242,12 @@ const (
 	// predates warehouse replication has no route for this op and rejects it, so
 	// the warehouse is withheld until that peer is upgraded
 	MakeWarehouseBktOp BktOp = "make-warehouse"
+	// make an AIStor Memory cortex bucket and enable versioning. A cortex is
+	// always also a Tables warehouse (a super-bucket), so this op implies the
+	// warehouse capability too. A peer that predates cortex replication has no
+	// route for this op and rejects it, so the cortex is withheld until that peer
+	// is upgraded.
+	MakeCortexBktOp BktOp = "make-cortex"
 	// add replication configuration
 	ConfigureReplBktOp BktOp = "configure-replication"
 	// delete bucket (forceDelete = off)
@@ -259,7 +265,7 @@ func (adm *AdminClient) SRPeerBucketOps(ctx context.Context, bucket string, op B
 	v.Add("operation", string(op))
 
 	// For make-bucket, bucket options may be sent via `opts`
-	if op == MakeWithVersioningBktOp || op == MakeWarehouseBktOp || op == DeleteBucketBktOp {
+	if op == MakeWithVersioningBktOp || op == MakeWarehouseBktOp || op == MakeCortexBktOp || op == DeleteBucketBktOp {
 		for k, val := range opts {
 			v.Add(k, val)
 		}

--- a/cluster-commands_test.go
+++ b/cluster-commands_test.go
@@ -33,9 +33,12 @@ import (
 // alongside the operation, so a cortex is provisioned with the right config on
 // the peer.
 func TestSRPeerBucketOpsForwardsCortexOpts(t *testing.T) {
-	var captured url.Values
+	// The handler runs in the server's goroutine; hand the captured query back
+	// over a buffered channel so the read below has a clean happens-before edge
+	// (no shared variable across goroutines).
+	capturedCh := make(chan url.Values, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		captured = r.URL.Query()
+		capturedCh <- r.URL.Query()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -54,6 +57,7 @@ func TestSRPeerBucketOpsForwardsCortexOpts(t *testing.T) {
 		t.Fatalf("SRPeerBucketOps: %v", err)
 	}
 
+	captured := <-capturedCh
 	if got := captured.Get("operation"); got != string(MakeCortexBktOp) {
 		t.Fatalf("operation: expected %q, got %q", MakeCortexBktOp, got)
 	}

--- a/cluster-commands_test.go
+++ b/cluster-commands_test.go
@@ -21,8 +21,48 @@ package madmin
 
 import (
 	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 )
+
+// TestSRPeerBucketOpsForwardsCortexOpts verifies that a MakeCortexBktOp peer
+// request forwards the bucket options (versioning, force-create, created-at)
+// alongside the operation, so a cortex is provisioned with the right config on
+// the peer.
+func TestSRPeerBucketOpsForwardsCortexOpts(t *testing.T) {
+	var captured url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	adm, err := New(server.URL[len("http://"):], "access", "secret", false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	opts := map[string]string{
+		"versioningEnabled": "true",
+		"forceCreate":       "true",
+		"createdAt":         "2026-01-02T15:04:05Z",
+	}
+	if err := adm.SRPeerBucketOps(context.Background(), "my-cortex", MakeCortexBktOp, opts); err != nil {
+		t.Fatalf("SRPeerBucketOps: %v", err)
+	}
+
+	if got := captured.Get("operation"); got != string(MakeCortexBktOp) {
+		t.Fatalf("operation: expected %q, got %q", MakeCortexBktOp, got)
+	}
+	for k, want := range opts {
+		if got := captured.Get(k); got != want {
+			t.Fatalf("option %q not forwarded for MakeCortexBktOp: expected %q, got %q", k, want, got)
+		}
+	}
+}
 
 func TestSRSessionPolicy_MarshalUnmarshalJSON(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Adds a `MakeCortexBktOp` peer bucket-create operation for AIStor Memory
cortex buckets, mirroring `MakeWarehouseBktOp` (#637).

A Memory **cortex** is always also a Tables **warehouse** (a super-bucket),
so this single op provisions both capabilities on the peer. Encoding the
bucket type as the operation — rather than an ad-hoc `isCortex` form field —
matches the pattern established for warehouses in #637.

## Changes

- `MakeCortexBktOp BktOp = "make-cortex"` constant.
- `SRPeerBucketOps` forwards bucket options (`versioningEnabled`,
  `forceCreate`, `createdAt`, …) for the new op.

## Compatibility

Like `MakeWarehouseBktOp`, a peer that predates cortex replication has no
route for this op and rejects it, so the cortex is withheld until that peer
is upgraded — no partial/broken state on old peers.

## Consumer

Used by MinIO AIStor's Memory API (super-bucket site replication); the
server side switches its SR make-bucket op to `MakeCortexBktOp` once this is
released, replacing the interim `isCortex` opts field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating Cortex buckets through cluster bucket operations.
  * Cortex creation now includes the related tables warehouse capability.
  * Bucket operation options are now forwarded correctly when creating Cortex buckets.
* **Tests**
  * Added coverage to verify Cortex bucket operation query parameters and options forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->