### PR TITLE
mnav: Add "by time" aggregated

### DIFF
--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -459,6 +459,28 @@ func (node *APILastMinuteNode) GetChild(name string) (MetricNode, error) {
 	return nil, fmt.Errorf("endpoint not found: %s", name)
 }
 
+// apiView adapts API last-day data to the generic _by_time navigation.
+func apiView(ops map[string]madmin.SegmentedAPIMetrics) segView[madmin.APIStats, *madmin.APIStats] {
+	return segView[madmin.APIStats, *madmin.APIStats]{
+		ops:         ops,
+		metricType:  madmin.MetricsAPI,
+		metricFlags: madmin.MetricsDayStats,
+		empty:       func(s *madmin.APIStats) bool { return s.Requests == 0 },
+		segDesc: func(total madmin.APIStats, interval int, segTime, end time.Time) string {
+			return formatAPITimeSegmentDesc(total, interval, segTime, end)
+		},
+		opDesc: func(_ string, s madmin.APIStats, interval int) string {
+			return formatAPISegmentDesc(s, interval, 1)
+		},
+		opLeaf: func(op string, s madmin.APIStats, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &APIEndpointNode{endpoint: op, stats: s, parent: parent, path: path}
+		},
+		sumLeaf: func(s madmin.APIStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &APITimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
+		},
+	}
+}
+
 // APILastDayNode shows last day API statistics segmented
 type APILastDayNode struct {
 	api    *madmin.APIMetrics
@@ -479,13 +501,16 @@ func (node *APILastDayNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 
-	children := make([]MetricChild, 0, len(node.api.LastDayAPI)+1)
+	children := make([]MetricChild, 0, len(node.api.LastDayAPI)+2)
 
-	// Add "All" entry first - shows aggregated time segments
-	children = append(children, MetricChild{
-		Name:        "All",
-		Description: "Aggregated 24h statistics for all API endpoints",
-	})
+	// Time-first entry, then the aggregated per-operation "All".
+	children = append(children,
+		MetricChild{Name: byTimeName, Description: "Browse by time segment (all endpoints)"},
+		MetricChild{
+			Name:        "All",
+			Description: "Aggregated 24h statistics for all API endpoints",
+		},
+	)
 
 	// Add individual API endpoints, sorted alphabetically
 	apiNames := make([]string, 0, len(node.api.LastDayAPI))
@@ -524,6 +549,10 @@ func (node *APILastDayNode) GetParent() MetricNode              { return node.pa
 func (node *APILastDayNode) GetPath() string                    { return node.path }
 
 func (node *APILastDayNode) GetChild(name string) (MetricNode, error) {
+	if name == byTimeName {
+		return newByTimeNode(apiView(node.api.LastDayAPI), node, node.path+"/"+byTimeName), nil
+	}
+
 	// Handle "All" entry - shows aggregated time segments
 	if name == "All" {
 		return &APILastDayAllNode{

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -472,8 +472,8 @@ func apiView(ops map[string]madmin.SegmentedAPIMetrics) segView[madmin.APIStats,
 		opDesc: func(_ string, s madmin.APIStats, interval int) string {
 			return formatAPISegmentDesc(s, interval, 1)
 		},
-		opLeaf: func(op string, s madmin.APIStats, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
-			return &APIEndpointNode{endpoint: op, stats: s, parent: parent, path: path}
+		opLeaf: func(op string, s madmin.APIStats, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
+			return &APIEndpointNode{endpoint: op, stats: s, segmentTime: segTime, interval: interval, parent: parent, path: path}
 		},
 		sumLeaf: func(s madmin.APIStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
 			return &APITimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
@@ -934,10 +934,12 @@ func (node *APITimeSegmentNode) GetChild(name string) (MetricNode, error) {
 
 // APIEndpointNode shows detailed statistics for a specific endpoint
 type APIEndpointNode struct {
-	endpoint string
-	stats    madmin.APIStats
-	parent   MetricNode
-	path     string
+	endpoint    string
+	stats       madmin.APIStats
+	segmentTime time.Time
+	interval    int
+	parent      MetricNode
+	path        string
 }
 
 func (node *APIEndpointNode) GetOpts() madmin.MetricsOptions {
@@ -964,6 +966,13 @@ func (node *APIEndpointNode) GetLeafData() map[string]string {
 
 	// === ENDPOINT HEADER ===
 	entries = append(entries, struct{ key, value string }{"Endpoint", node.endpoint})
+	if !node.segmentTime.IsZero() && node.interval > 0 {
+		end := node.segmentTime.Add(time.Duration(node.interval) * time.Second)
+		entries = append(entries, struct{ key, value string }{
+			"Time Segment",
+			fmt.Sprintf("%s -> %s", node.segmentTime.Local().Format("15:04"), end.Local().Format("15:04")),
+		})
+	}
 	entries = append(entries, struct{ key, value string }{"Total Requests", humanize.Comma(node.stats.Requests)})
 
 	// Calculate RPS if we have wall time

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -968,9 +968,13 @@ func (node *APIEndpointNode) GetLeafData() map[string]string {
 	entries = append(entries, struct{ key, value string }{"Endpoint", node.endpoint})
 	if !node.segmentTime.IsZero() && node.interval > 0 {
 		end := node.segmentTime.Add(time.Duration(node.interval) * time.Second)
+		day := "Today "
+		if !sameLocalDay(node.segmentTime, time.Now()) {
+			day = "Yesterday "
+		}
 		entries = append(entries, struct{ key, value string }{
 			"Time Segment",
-			fmt.Sprintf("%s -> %s", node.segmentTime.Local().Format("15:04"), end.Local().Format("15:04")),
+			fmt.Sprintf("%s%s -> %s", day, node.segmentTime.Local().Format("15:04"), end.Local().Format("15:04")),
 		})
 	}
 	entries = append(entries, struct{ key, value string }{"Total Requests", humanize.Comma(node.stats.Requests)})

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -738,10 +738,12 @@ func (node *APILastDayEndpointNode) GetChild(name string) (MetricNode, error) {
 		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		if segmentTime.UTC().Format("15:04Z") == name {
 			return &APIEndpointNode{
-				endpoint: node.apiName,
-				stats:    node.segmented.Segments[i],
-				parent:   node,
-				path:     node.path + "/" + name,
+				endpoint:    node.apiName,
+				stats:       node.segmented.Segments[i],
+				segmentTime: segmentTime,
+				interval:    node.segmented.Interval,
+				parent:      node,
+				path:        node.path + "/" + name,
 			}, nil
 		}
 	}

--- a/mnav/bytime.go
+++ b/mnav/bytime.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// byTimeName is the navigation key for the time-first ("_by_time") entry added
+// under a last_day node. Leading underscore sorts/reads first, like _ALL.
+const byTimeName = "_by_time"
+
+// segPtr mirrors madmin.Segmented's own pointer constraint: a *T that can
+// accumulate another *T. Every last_day metric family is a map[op]Segmented[T,PT].
+type segPtr[T any] interface {
+	*T
+	madmin.Segmenter[T]
+}
+
+// segView adapts one metric family to the generic _by_time navigation. Only the
+// leaf construction and the description/empty helpers differ per family; the
+// tree logic in byTimeNode/byTimeSegmentNode is shared.
+type segView[T any, PT segPtr[T]] struct {
+	ops         map[string]madmin.Segmented[T, PT] // operation -> time-segmented stats
+	metricType  madmin.MetricType
+	metricFlags madmin.MetricFlags
+	empty       func(*T) bool                                              // no activity -> filtered out
+	segDesc     func(total T, interval int, segTime, end time.Time) string // _by_time list row
+	opDesc      func(op string, s T, interval int) string                  // per-segment op list row
+	opLeaf      func(op string, s T, segTime time.Time, interval int, parent MetricNode, path string) MetricNode
+	sumLeaf     func(total T, segTime time.Time, interval int, parent MetricNode, path string) MetricNode
+}
+
+// newByTimeNode returns the "_by_time" entry: pick a time segment first, then see
+// every operation active in it (with a cross-operation summary), then its stats.
+func newByTimeNode[T any, PT segPtr[T]](v segView[T, PT], parent MetricNode, path string) MetricNode {
+	return &byTimeNode[T, PT]{view: v, parent: parent, path: path}
+}
+
+// totalSegmented aligns every operation onto one timeline and sums them, giving
+// the reference grid for the segment list and each slot's cross-operation summary.
+// Segmented.Add handles operations whose FirstTime/length differ.
+func totalSegmented[T any, PT segPtr[T]](ops map[string]madmin.Segmented[T, PT]) madmin.Segmented[T, PT] {
+	var res madmin.Segmented[T, PT]
+	for _, op := range sortedKeys(ops) {
+		s := ops[op]
+		res.Add(&s)
+	}
+	return res
+}
+
+// segmentAt returns the value of s for the segment starting at segTime, matched by
+// timestamp against s's own FirstTime/Interval (not a shared slot index).
+func segmentAt[T any, PT segPtr[T]](s madmin.Segmented[T, PT], segTime time.Time) (T, bool) {
+	var zero T
+	if s.Interval <= 0 {
+		return zero, false
+	}
+	for i := range s.Segments {
+		if s.FirstTime.Add(time.Duration(i*s.Interval) * time.Second).Equal(segTime) {
+			return s.Segments[i], true
+		}
+	}
+	return zero, false
+}
+
+// segmentSummary sums every operation's value at segTime (== totalSegmented slot).
+func segmentSummary[T any, PT segPtr[T]](ops map[string]madmin.Segmented[T, PT], segTime time.Time) T {
+	var total T
+	pt := PT(&total)
+	for _, op := range sortedKeys(ops) {
+		if v, ok := segmentAt(ops[op], segTime); ok {
+			pt.Add(&v)
+		}
+	}
+	return total
+}
+
+// byTimeNode lists the last-day time segments, newest first, empties filtered.
+type byTimeNode[T any, PT segPtr[T]] struct {
+	view   segView[T, PT]
+	parent MetricNode
+	path   string
+}
+
+func (node *byTimeNode[T, PT]) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *byTimeNode[T, PT]) GetMetricType() madmin.MetricType   { return node.view.metricType }
+func (node *byTimeNode[T, PT]) GetMetricFlags() madmin.MetricFlags { return node.view.metricFlags }
+func (node *byTimeNode[T, PT]) GetParent() MetricNode              { return node.parent }
+func (node *byTimeNode[T, PT]) GetPath() string                    { return node.path }
+func (node *byTimeNode[T, PT]) ShouldPauseRefresh() bool           { return true }
+func (node *byTimeNode[T, PT]) GetLeafData() map[string]string     { return nil }
+
+func (node *byTimeNode[T, PT]) GetChildren() []MetricChild {
+	total := totalSegmented(node.view.ops)
+	var children []MetricChild
+	for i := len(total.Segments) - 1; i >= 0; i-- {
+		if node.view.empty(&total.Segments[i]) {
+			continue
+		}
+		segTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
+		end := segTime.Add(time.Duration(total.Interval) * time.Second)
+		children = append(children, MetricChild{
+			Name:        segTime.UTC().Format("15:04Z"),
+			Description: node.view.segDesc(total.Segments[i], total.Interval, segTime, end),
+		})
+	}
+	return children
+}
+
+func (node *byTimeNode[T, PT]) GetChild(name string) (MetricNode, error) {
+	total := totalSegmented(node.view.ops)
+	for i := range total.Segments {
+		segTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
+		if segTime.UTC().Format("15:04Z") == name {
+			return &byTimeSegmentNode[T, PT]{
+				view:     node.view,
+				segTime:  segTime,
+				interval: total.Interval,
+				parent:   node,
+				path:     node.path + "/" + name,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+// byTimeSegmentNode lists the operations active in one time segment (sorted, with an
+// _ALL summary first) and shows the cross-operation summary as its own leaf data.
+type byTimeSegmentNode[T any, PT segPtr[T]] struct {
+	view     segView[T, PT]
+	segTime  time.Time
+	interval int
+	parent   MetricNode
+	path     string
+}
+
+func (node *byTimeSegmentNode[T, PT]) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *byTimeSegmentNode[T, PT]) GetMetricType() madmin.MetricType { return node.view.metricType }
+func (node *byTimeSegmentNode[T, PT]) GetMetricFlags() madmin.MetricFlags {
+	return node.view.metricFlags
+}
+func (node *byTimeSegmentNode[T, PT]) GetParent() MetricNode    { return node.parent }
+func (node *byTimeSegmentNode[T, PT]) GetPath() string          { return node.path }
+func (node *byTimeSegmentNode[T, PT]) ShouldPauseRefresh() bool { return true }
+
+func (node *byTimeSegmentNode[T, PT]) GetChildren() []MetricChild {
+	children := []MetricChild{{Name: "_ALL", Description: "All operations combined for this time segment"}}
+	for _, op := range sortedKeys(node.view.ops) {
+		v, ok := segmentAt(node.view.ops[op], node.segTime)
+		if !ok || node.view.empty(&v) {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        op,
+			Description: node.view.opDesc(op, v, node.interval),
+		})
+	}
+	return children
+}
+
+func (node *byTimeSegmentNode[T, PT]) GetChild(name string) (MetricNode, error) {
+	if name == "_ALL" {
+		total := segmentSummary(node.view.ops, node.segTime)
+		return node.view.sumLeaf(total, node.segTime, node.interval, node, node.path+"/_ALL"), nil
+	}
+	seg, ok := node.view.ops[name]
+	if !ok {
+		return nil, fmt.Errorf("operation not found: %s", name)
+	}
+	v, ok := segmentAt(seg, node.segTime)
+	if !ok {
+		return nil, fmt.Errorf("operation %s has no data for this time segment", name)
+	}
+	return node.view.opLeaf(name, v, node.segTime, node.interval, node, node.path+"/"+name), nil
+}
+
+func (node *byTimeSegmentNode[T, PT]) GetLeafData() map[string]string {
+	total := segmentSummary(node.view.ops, node.segTime)
+	return node.view.sumLeaf(total, node.segTime, node.interval, node, node.path).GetLeafData()
+}

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -592,6 +592,44 @@ func (node *DiskLastMinuteNode) GetChild(name string) (MetricNode, error) {
 	return nil, fmt.Errorf("drive operation not found: %s", name)
 }
 
+// diskView adapts drive ops_last_day data to the generic _by_time navigation.
+func diskView(ops map[string]madmin.SegmentedDiskActions) segView[madmin.DiskAction, *madmin.DiskAction] {
+	return segView[madmin.DiskAction, *madmin.DiskAction]{
+		ops:         ops,
+		metricType:  madmin.MetricsDisk,
+		metricFlags: madmin.MetricsDayStats,
+		empty:       func(a *madmin.DiskAction) bool { return a.Count == 0 },
+		segDesc:     diskSegmentDesc,
+		opDesc:      diskOpDesc,
+		opLeaf: func(op string, a madmin.DiskAction, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &DiskLastDayAllLeafNode{action: a, label: op, parent: parent, path: path}
+		},
+		sumLeaf: func(a madmin.DiskAction, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &DiskLastDayAllLeafNode{action: a, label: "All operations", parent: parent, path: path}
+		},
+	}
+}
+
+func diskSegmentDesc(total madmin.DiskAction, _ int, segTime, end time.Time) string {
+	day := "Today "
+	if !sameLocalDay(segTime, time.Now()) {
+		day = "Yesterday "
+	}
+	avg := ""
+	if total.Count > 0 && total.AccTime > 0 {
+		avg = fmt.Sprintf(", %.1fms avg", (total.AccTime/float64(total.Count))*1000)
+	}
+	return fmt.Sprintf("%s%s -> %s (%d ops%s)", day, segTime.Local().Format("15:04"), end.Local().Format("15:04"), total.Count, avg)
+}
+
+func diskOpDesc(_ string, a madmin.DiskAction, _ int) string {
+	avg := ""
+	if a.Count > 0 && a.AccTime > 0 {
+		avg = fmt.Sprintf(", %.1fms avg", (a.AccTime/float64(a.Count))*1000)
+	}
+	return fmt.Sprintf("%d ops%s", a.Count, avg)
+}
+
 // DiskLastDayNode handles navigation for segmented last day operations
 type DiskLastDayNode struct {
 	segmented map[string]madmin.SegmentedDiskActions
@@ -612,13 +650,16 @@ func (node *DiskLastDayNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 
-	children := make([]MetricChild, 0, len(node.segmented)+1)
+	children := make([]MetricChild, 0, len(node.segmented)+2)
 
-	// Add _ALL entry first for aggregated time-segmented totals
-	children = append(children, MetricChild{
-		Name:        "_ALL",
-		Description: "All operations combined, time segmented",
-	})
+	// Time-first entry, then the aggregated per-operation _ALL.
+	children = append(children,
+		MetricChild{Name: byTimeName, Description: "Browse by time segment (all operations)"},
+		MetricChild{
+			Name:        "_ALL",
+			Description: "All operations combined, time segmented",
+		},
+	)
 
 	// Collect operation types with their total counts
 	type operationInfo struct {
@@ -746,6 +787,10 @@ func (node *DiskLastDayNode) ShouldPauseRefresh() bool {
 func (node *DiskLastDayNode) GetChild(name string) (MetricNode, error) {
 	if node.segmented == nil {
 		return nil, fmt.Errorf("no segmented data available")
+	}
+
+	if name == byTimeName {
+		return newByTimeNode(diskView(node.segmented), node, node.path+"/"+byTimeName), nil
 	}
 
 	if name == "_ALL" {

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -1248,39 +1248,25 @@ func (node *DiskLastDayAllNode) ShouldPauseRefresh() bool           { return tru
 func (node *DiskLastDayAllNode) GetLeafData() map[string]string     { return nil }
 
 func (node *DiskLastDayAllNode) GetChildren() []MetricChild {
-	// Find the reference segmented data (longest segment list) for time alignment
-	var refSeg *madmin.SegmentedDiskActions
-	for _, seg := range node.segmented {
-		s := seg
-		if refSeg == nil || len(s.Segments) > len(refSeg.Segments) {
-			refSeg = &s
-		}
-	}
-	if refSeg == nil || len(refSeg.Segments) == 0 {
+	// Align every operation onto one timeline; each slot is the cross-operation sum.
+	total := totalSegmented(node.segmented)
+	if len(total.Segments) == 0 {
 		return []MetricChild{}
 	}
 
 	children := []MetricChild{{Name: "Total", Description: "Aggregated totals across all time segments"}}
 
-	for i := len(refSeg.Segments) - 1; i >= 0; i-- {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
-		endTime := segmentTime.Add(time.Duration(refSeg.Interval) * time.Second)
-
-		var totalOps uint64
-		var totalTime float64
-		for _, seg := range node.segmented {
-			if i < len(seg.Segments) {
-				totalOps += seg.Segments[i].Count
-				totalTime += seg.Segments[i].AccTime
-			}
-		}
-		if totalOps == 0 {
+	for i := len(total.Segments) - 1; i >= 0; i-- {
+		seg := total.Segments[i]
+		if seg.Count == 0 {
 			continue
 		}
+		segmentTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
+		endTime := segmentTime.Add(time.Duration(total.Interval) * time.Second)
 
 		avg := ""
-		if totalTime > 0 {
-			avg = fmt.Sprintf(", %.1fms avg", (totalTime/float64(totalOps))*1000)
+		if seg.AccTime > 0 {
+			avg = fmt.Sprintf(", %.1fms avg", (seg.AccTime/float64(seg.Count))*1000)
 		}
 		day := "Today "
 		if !sameLocalDay(segmentTime, time.Now()) {
@@ -1290,46 +1276,28 @@ func (node *DiskLastDayAllNode) GetChildren() []MetricChild {
 			Name: segmentTime.UTC().Format("15:04Z"),
 			Description: fmt.Sprintf("%s%s -> %s (%d ops%s)",
 				day, segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"),
-				totalOps, avg),
+				seg.Count, avg),
 		})
 	}
 	return children
 }
 
 func (node *DiskLastDayAllNode) GetChild(name string) (MetricNode, error) {
-	var refSeg *madmin.SegmentedDiskActions
-	for _, seg := range node.segmented {
-		s := seg
-		if refSeg == nil || len(s.Segments) > len(refSeg.Segments) {
-			refSeg = &s
-		}
-	}
-	if refSeg == nil {
+	total := totalSegmented(node.segmented)
+	if len(total.Segments) == 0 {
 		return nil, fmt.Errorf("no segmented data available")
 	}
 
 	if name == "Total" {
-		var total madmin.DiskAction
-		for _, seg := range node.segmented {
-			for i := range seg.Segments {
-				total.Add(&seg.Segments[i])
-			}
-		}
-		return &DiskLastDayAllLeafNode{action: total, label: "Total", parent: node, path: node.path + "/Total"}, nil
+		return &DiskLastDayAllLeafNode{action: total.Total(), label: "Total", parent: node, path: node.path + "/Total"}, nil
 	}
 
-	for i := range refSeg.Segments {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
+	for i := range total.Segments {
+		segmentTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
 		if segmentTime.UTC().Format("15:04Z") == name {
-			var total madmin.DiskAction
-			for _, seg := range node.segmented {
-				if i < len(seg.Segments) {
-					total.Add(&seg.Segments[i])
-				}
-			}
-			endTime := segmentTime.Add(time.Duration(refSeg.Interval) * time.Second)
+			endTime := segmentTime.Add(time.Duration(total.Interval) * time.Second)
 			label := fmt.Sprintf("%s -> %s", segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
-			return &DiskLastDayAllLeafNode{action: total, label: label, parent: node, path: node.path + "/" + name}, nil
+			return &DiskLastDayAllLeafNode{action: total.Segments[i], label: label, parent: node, path: node.path + "/" + name}, nil
 		}
 	}
 	return nil, fmt.Errorf("time segment not found: %s", name)

--- a/mnav/kms.go
+++ b/mnav/kms.go
@@ -340,7 +340,7 @@ func kmsView(ops map[string]madmin.SegmentedKMSActions) segView[madmin.KMSAction
 		ops:         ops,
 		metricType:  madmin.MetricsKMS,
 		metricFlags: madmin.MetricsDayStats,
-		empty:       func(a *madmin.KMSAction) bool { return a.Count == 0 },
+		empty:       func(a *madmin.KMSAction) bool { return a.Count == 0 && a.ConnFails == 0 && a.RemoteErrs == 0 },
 		segDesc:     kmsSegmentDesc,
 		opDesc:      kmsOpDesc,
 		opLeaf: func(op string, a madmin.KMSAction, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
@@ -405,7 +405,7 @@ func (node *kmsActionLeafNode) GetChild(_ string) (MetricNode, error) {
 
 func (node *kmsActionLeafNode) GetLeafData() map[string]string {
 	a := node.action
-	if a.Count == 0 {
+	if a.Count == 0 && a.ConnFails == 0 && a.RemoteErrs == 0 {
 		return map[string]string{"Status": "No activity"}
 	}
 	data := map[string]string{}

--- a/mnav/kms.go
+++ b/mnav/kms.go
@@ -226,6 +226,7 @@ func (node *kmsSegmentedNode) GetChildren() []MetricChild {
 		totalCalls += s.Total().Count
 	}
 	children := []MetricChild{
+		{Name: byTimeName, Description: "Browse by time segment (all operations)"},
 		{Name: "_ALL", Description: fmt.Sprintf("All operations combined (%d calls)", totalCalls)},
 	}
 	ops := sortedKeys(node.data)
@@ -246,6 +247,9 @@ func (node *kmsSegmentedNode) GetLeafData() map[string]string {
 }
 
 func (node *kmsSegmentedNode) GetChild(name string) (MetricNode, error) {
+	if name == byTimeName {
+		return newByTimeNode(kmsView(node.data), node, node.path+"/"+byTimeName), nil
+	}
 	if name == "_ALL" {
 		var merged madmin.SegmentedKMSActions
 		for _, s := range node.data {
@@ -326,6 +330,109 @@ func (node *kmsOpSegmentedNode) GetLeafData() map[string]string {
 	}
 	if len(data) == 0 {
 		return map[string]string{"Status": "No activity"}
+	}
+	return data
+}
+
+// kmsView adapts KMS last-day data to the generic _by_time navigation.
+func kmsView(ops map[string]madmin.SegmentedKMSActions) segView[madmin.KMSAction, *madmin.KMSAction] {
+	return segView[madmin.KMSAction, *madmin.KMSAction]{
+		ops:         ops,
+		metricType:  madmin.MetricsKMS,
+		metricFlags: madmin.MetricsDayStats,
+		empty:       func(a *madmin.KMSAction) bool { return a.Count == 0 },
+		segDesc:     kmsSegmentDesc,
+		opDesc:      kmsOpDesc,
+		opLeaf: func(op string, a madmin.KMSAction, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
+			return &kmsActionLeafNode{op: op, action: a, segTime: segTime, interval: interval, parent: parent, path: path}
+		},
+		sumLeaf: func(a madmin.KMSAction, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
+			return &kmsActionLeafNode{op: "_ALL", action: a, segTime: segTime, interval: interval, parent: parent, path: path}
+		},
+	}
+}
+
+func kmsSegmentDesc(total madmin.KMSAction, interval int, segTime, end time.Time) string {
+	day := ""
+	if !sameLocalDay(segTime, time.Now()) {
+		day = "Yesterday "
+	}
+	var rps float64
+	if interval > 0 {
+		rps = float64(total.Count) / float64(interval)
+	}
+	desc := fmt.Sprintf("%s%s -> %s, %.1f req/s, %d calls", day, segTime.Local().Format("15:04"), end.Local().Format("15:04"), rps, total.Count)
+	if total.ConnFails+total.RemoteErrs > 0 {
+		desc += fmt.Sprintf(", %d errors", total.ConnFails+total.RemoteErrs)
+	}
+	return desc
+}
+
+func kmsOpDesc(_ string, a madmin.KMSAction, interval int) string {
+	var rps float64
+	if interval > 0 {
+		rps = float64(a.Count) / float64(interval)
+	}
+	desc := fmt.Sprintf("%.1f req/s, %d calls", rps, a.Count)
+	if a.ConnFails+a.RemoteErrs > 0 {
+		desc += fmt.Sprintf(", %d errors", a.ConnFails+a.RemoteErrs)
+	}
+	return desc
+}
+
+// kmsActionLeafNode renders a single KMSAction: one operation within one time
+// segment, or the cross-operation summary (op == "_ALL").
+type kmsActionLeafNode struct {
+	op       string
+	action   madmin.KMSAction
+	segTime  time.Time
+	interval int
+	parent   MetricNode
+	path     string
+}
+
+func (node *kmsActionLeafNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *kmsActionLeafNode) GetMetricType() madmin.MetricType   { return madmin.MetricsKMS }
+func (node *kmsActionLeafNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
+func (node *kmsActionLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *kmsActionLeafNode) GetPath() string                    { return node.path }
+func (node *kmsActionLeafNode) ShouldPauseRefresh() bool           { return true }
+func (node *kmsActionLeafNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *kmsActionLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *kmsActionLeafNode) GetLeafData() map[string]string {
+	a := node.action
+	if a.Count == 0 {
+		return map[string]string{"Status": "No activity"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.op != "" && node.op != "_ALL" {
+		add("Operation", node.op)
+	}
+	if !node.segTime.IsZero() && node.interval > 0 {
+		end := node.segTime.Add(time.Duration(node.interval) * time.Second)
+		add("Time Segment", fmt.Sprintf("%s -> %s", node.segTime.Local().Format("15:04"), end.Local().Format("15:04")))
+	}
+	add("Calls", strconv.FormatUint(a.Count, 10))
+	if node.interval > 0 {
+		add("Rate", fmt.Sprintf("%.2f req/s", float64(a.Count)/float64(node.interval)))
+	}
+	add("Avg", a.Avg().Round(time.Microsecond).String())
+	add("Min", time.Duration(a.MinTime*float64(time.Second)).Round(time.Microsecond).String())
+	add("Max", time.Duration(a.MaxTime*float64(time.Second)).Round(time.Microsecond).String())
+	if a.ConnFails > 0 {
+		add("Conn Fails", strconv.FormatUint(a.ConnFails, 10))
+	}
+	if a.RemoteErrs > 0 {
+		add("Remote Errors", strconv.FormatUint(a.RemoteErrs, 10))
 	}
 	return data
 }

--- a/mnav/kms.go
+++ b/mnav/kms.go
@@ -419,7 +419,11 @@ func (node *kmsActionLeafNode) GetLeafData() map[string]string {
 	}
 	if !node.segTime.IsZero() && node.interval > 0 {
 		end := node.segTime.Add(time.Duration(node.interval) * time.Second)
-		add("Time Segment", fmt.Sprintf("%s -> %s", node.segTime.Local().Format("15:04"), end.Local().Format("15:04")))
+		day := "Today "
+		if !sameLocalDay(node.segTime, time.Now()) {
+			day = "Yesterday "
+		}
+		add("Time Segment", fmt.Sprintf("%s%s -> %s", day, node.segTime.Local().Format("15:04"), end.Local().Format("15:04")))
 	}
 	add("Calls", strconv.FormatUint(a.Count, 10))
 	if node.interval > 0 {

--- a/mnav/mnav_test.go
+++ b/mnav/mnav_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/minio/madmin-go/v4"
 )
@@ -78,6 +79,133 @@ func childNames(children []MetricChild) []string {
 		out[i] = c.Name
 	}
 	return out
+}
+
+func leafValue(data map[string]string, key string) string {
+	for k, v := range data {
+		if k == key || strings.HasSuffix(k, ":"+key) {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestByTimeNavigation(t *testing.T) {
+	t0 := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	seg := func(reqs int64, secs float64) madmin.APIStats {
+		return madmin.APIStats{Requests: reqs, RequestTimeSecs: secs}
+	}
+	m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{API: &madmin.APIMetrics{
+		Nodes: 1,
+		LastDayAPI: map[string]madmin.SegmentedAPIMetrics{
+			// 3 segments starting at t0; the first is empty.
+			"s3.GetObject": {Interval: 900, FirstTime: t0, Segments: []madmin.APIStats{seg(0, 0), seg(10, 1.0), seg(20, 2.0)}},
+			// Starts one interval later, so its segment 0 aligns with GetObject's segment 1.
+			"s3.PutObject": {Interval: 900, FirstTime: t0.Add(15 * time.Minute), Segments: []madmin.APIStats{seg(5, 0.5), seg(7, 0.7)}},
+		},
+	}}}
+	nav := NewRealtimeMetricsNavigator(m)
+
+	seg15 := t0.Add(15 * time.Minute).UTC().Format("15:04Z")
+	seg30 := t0.Add(30 * time.Minute).UTC().Format("15:04Z")
+
+	// _by_time lists non-empty segments, newest first (the empty t0 slot is skipped).
+	bt, err := nav.Navigate("api/last_day/_by_time")
+	if err != nil {
+		t.Fatalf("navigate _by_time: %v", err)
+	}
+	if got, want := childNames(bt.GetChildren()), []string{seg30, seg15}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("_by_time segments = %v, want %v", got, want)
+	}
+
+	// A segment lists _ALL first, then the operations active in it, sorted.
+	s15, err := nav.Navigate("api/last_day/_by_time/" + seg15)
+	if err != nil {
+		t.Fatalf("navigate segment %s: %v", seg15, err)
+	}
+	if got, want := childNames(s15.GetChildren()), []string{"_ALL", "s3.GetObject", "s3.PutObject"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("segment ops = %v, want %v", got, want)
+	}
+
+	// Per-op stats are matched by timestamp, not slot index: at seg15 PutObject must
+	// use its own segment 0 (5 reqs), not grid slot index 1 (7 reqs).
+	put15, err := nav.Navigate("api/last_day/_by_time/" + seg15 + "/s3.PutObject")
+	if err != nil {
+		t.Fatalf("navigate PutObject@%s: %v", seg15, err)
+	}
+	if got := leafValue(put15.GetLeafData(), "Total Requests"); got != "5" {
+		t.Errorf("PutObject@%s Total Requests = %q, want 5 (timestamp match, not index)", seg15, got)
+	}
+
+	// Segment summary == sum of its operations (10+5 = 15), shown both via _ALL and
+	// as the segment node's own leaf data.
+	all15, err := nav.Navigate("api/last_day/_by_time/" + seg15 + "/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL@%s: %v", seg15, err)
+	}
+	if got := leafValue(all15.GetLeafData(), "Total Requests"); got != "15" {
+		t.Errorf("_ALL@%s Total Requests = %q, want 15", seg15, got)
+	}
+	if got := leafValue(s15.GetLeafData(), "Total Requests"); got != "15" {
+		t.Errorf("segment %s leaf Total Requests = %q, want 15", seg15, got)
+	}
+
+	// At seg30 the summary is 20+7 = 27 (index-based matching would drop PutObject -> 20).
+	all30, err := nav.Navigate("api/last_day/_by_time/" + seg30 + "/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL@%s: %v", seg30, err)
+	}
+	if got := leafValue(all30.GetLeafData(), "Total Requests"); got != "27" {
+		t.Errorf("_ALL@%s Total Requests = %q, want 27", seg30, got)
+	}
+
+	// Leaf carries API type + day-stats flag via opts propagation.
+	if opts := put15.GetOpts(); opts.Type&madmin.MetricsAPI == 0 || opts.Flags&madmin.MetricsDayStats == 0 {
+		t.Errorf("opts Type=%v Flags=%v, want MetricsAPI + MetricsDayStats", opts.Type, opts.Flags)
+	}
+}
+
+// TestByTimeAllViews checks that every wired view exposes _by_time as its first
+// last_day child and that the full segment -> operation -> stats path resolves.
+func TestByTimeAllViews(t *testing.T) {
+	t0 := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{
+		RPC: &madmin.RPCMetrics{LastDay: map[string]madmin.SegmentedRPCMetrics{
+			"storageRPC": {Interval: 900, FirstTime: t0, Segments: []madmin.RPCStats{{Requests: 3, RequestTimeSecs: 0.3}}},
+		}},
+		Disk: &madmin.DiskMetric{LastDaySegmented: map[string]madmin.SegmentedDiskActions{
+			"WalkDir": {Interval: 900, FirstTime: t0, Segments: []madmin.DiskAction{{Count: 4, AccTime: 0.4}}},
+		}},
+		KMS: &madmin.KMSRtMetrics{LastDay: map[string]madmin.SegmentedKMSActions{
+			"encrypt": {Interval: 900, FirstTime: t0, Segments: []madmin.KMSAction{{Count: 2}}},
+		}},
+	}}
+	nav := NewRealtimeMetricsNavigator(m)
+	segName := t0.UTC().Format("15:04Z")
+
+	for _, tc := range []struct{ lastDay, op string }{
+		{"rpc/last_day", "storageRPC"},
+		{"drive/ops_last_day", "WalkDir"},
+		{"kms/last_day", "encrypt"},
+	} {
+		ld, err := nav.Navigate(tc.lastDay)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.lastDay, err)
+		}
+		if got := childNames(ld.GetChildren()); len(got) == 0 || got[0] != "_by_time" {
+			t.Errorf("%s first child = %v, want _by_time first", tc.lastDay, got)
+		}
+		for _, leaf := range []string{tc.op, "_ALL"} {
+			path := tc.lastDay + "/_by_time/" + segName + "/" + leaf
+			node, err := nav.Navigate(path)
+			if err != nil {
+				t.Fatalf("navigate %s: %v", path, err)
+			}
+			if len(node.GetLeafData()) == 0 {
+				t.Errorf("%s: leaf has no data", path)
+			}
+		}
+	}
 }
 
 func TestDiskSetLeafData(t *testing.T) {

--- a/mnav/mnav_test.go
+++ b/mnav/mnav_test.go
@@ -165,47 +165,93 @@ func TestByTimeNavigation(t *testing.T) {
 	}
 }
 
-// TestByTimeAllViews checks that every wired view exposes _by_time as its first
-// last_day child and that the full segment -> operation -> stats path resolves.
+// TestByTimeAllViews checks each wired view (RPC, Disk, KMS) exposes _by_time as
+// its first last_day child and that navigation resolves segments by timestamp
+// across operations with staggered, non-contiguous FirstTime values — not by a
+// shared slot index. Each domain runs as an isolated subtest.
 func TestByTimeAllViews(t *testing.T) {
 	t0 := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
-	m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{
-		RPC: &madmin.RPCMetrics{LastDay: map[string]madmin.SegmentedRPCMetrics{
-			"storageRPC": {Interval: 900, FirstTime: t0, Segments: []madmin.RPCStats{{Requests: 3, RequestTimeSecs: 0.3}}},
-		}},
-		Disk: &madmin.DiskMetric{LastDaySegmented: map[string]madmin.SegmentedDiskActions{
-			"WalkDir": {Interval: 900, FirstTime: t0, Segments: []madmin.DiskAction{{Count: 4, AccTime: 0.4}}},
-		}},
-		KMS: &madmin.KMSRtMetrics{LastDay: map[string]madmin.SegmentedKMSActions{
-			"encrypt": {Interval: 900, FirstTime: t0, Segments: []madmin.KMSAction{{Count: 2}}},
-		}},
-	}}
-	nav := NewRealtimeMetricsNavigator(m)
-	segName := t0.UTC().Format("15:04Z")
+	seg00 := t0.UTC().Format("15:04Z")
+	seg15 := t0.Add(15 * time.Minute).UTC().Format("15:04Z")
+	seg30 := t0.Add(30 * time.Minute).UTC().Format("15:04Z")
+	// opA covers [t0, t0+15]; opB is staggered onto [t0+15, t0+30]. The union
+	// timeline (newest first) therefore spans three slots, and at seg15 both ops
+	// are active with distinct values (opA=2, opB=5) so a timestamp match must
+	// pick opB's own segment 0 (5), never grid slot index 1 (9).
+	wantSegs := []string{seg30, seg15, seg00}
 
-	for _, tc := range []struct{ lastDay, op string }{
-		{"rpc/last_day", "storageRPC"},
-		{"drive/ops_last_day", "WalkDir"},
-		{"kms/last_day", "encrypt"},
-	} {
-		ld, err := nav.Navigate(tc.lastDay)
+	// check drives one domain: _by_time-first, the staggered segment list, and the
+	// op / _ALL leaves at seg15 (staggered op value 5, cross-op summary 2+5=7).
+	check := func(t *testing.T, m *madmin.RealtimeMetrics, lastDay, op, leafKey string) {
+		t.Helper()
+		nav := NewRealtimeMetricsNavigator(m)
+
+		ld, err := nav.Navigate(lastDay)
 		if err != nil {
-			t.Fatalf("navigate %s: %v", tc.lastDay, err)
+			t.Fatalf("navigate %s: %v", lastDay, err)
 		}
 		if got := childNames(ld.GetChildren()); len(got) == 0 || got[0] != "_by_time" {
-			t.Errorf("%s first child = %v, want _by_time first", tc.lastDay, got)
+			t.Fatalf("%s first child = %v, want _by_time first", lastDay, got)
 		}
-		for _, leaf := range []string{tc.op, "_ALL"} {
-			path := tc.lastDay + "/_by_time/" + segName + "/" + leaf
-			node, err := nav.Navigate(path)
-			if err != nil {
-				t.Fatalf("navigate %s: %v", path, err)
-			}
-			if len(node.GetLeafData()) == 0 {
-				t.Errorf("%s: leaf has no data", path)
-			}
+
+		bt, err := nav.Navigate(lastDay + "/_by_time")
+		if err != nil {
+			t.Fatalf("navigate %s/_by_time: %v", lastDay, err)
+		}
+		if got := childNames(bt.GetChildren()); !reflect.DeepEqual(got, wantSegs) {
+			t.Fatalf("%s segments = %v, want %v", lastDay, got, wantSegs)
+		}
+
+		// Staggered op resolved by timestamp: opB's segment 0 lives at seg15.
+		opPath := lastDay + "/_by_time/" + seg15 + "/" + op
+		opNode, err := nav.Navigate(opPath)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", opPath, err)
+		}
+		if od := opNode.GetLeafData(); len(od) == 0 {
+			t.Fatalf("%s: op leaf has no data", opPath)
+		} else if got := leafValue(od, leafKey); got != "5" {
+			t.Errorf("%s %s = %q, want 5 (timestamp match, not slot index)", opPath, leafKey, got)
+		}
+
+		allPath := lastDay + "/_by_time/" + seg15 + "/_ALL"
+		allNode, err := nav.Navigate(allPath)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", allPath, err)
+		}
+		if ad := allNode.GetLeafData(); len(ad) == 0 {
+			t.Fatalf("%s: _ALL leaf has no data", allPath)
+		} else if got := leafValue(ad, leafKey); got != "7" {
+			t.Errorf("%s %s = %q, want 7 (2+5 timestamp-matched summary)", allPath, leafKey, got)
 		}
 	}
+
+	t.Run("rpc", func(t *testing.T) {
+		s := func(reqs int64) madmin.RPCStats { return madmin.RPCStats{Requests: reqs} }
+		m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{RPC: &madmin.RPCMetrics{LastDay: map[string]madmin.SegmentedRPCMetrics{
+			"storageRPC": {Interval: 900, FirstTime: t0, Segments: []madmin.RPCStats{s(1), s(2)}},
+			"lockRPC":    {Interval: 900, FirstTime: t0.Add(15 * time.Minute), Segments: []madmin.RPCStats{s(5), s(9)}},
+		}}}}
+		check(t, m, "rpc/last_day", "lockRPC", "Total Requests")
+	})
+
+	t.Run("disk", func(t *testing.T) {
+		s := func(count uint64) madmin.DiskAction { return madmin.DiskAction{Count: count} }
+		m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{LastDaySegmented: map[string]madmin.SegmentedDiskActions{
+			"WalkDir":  {Interval: 900, FirstTime: t0, Segments: []madmin.DiskAction{s(1), s(2)}},
+			"ReadFile": {Interval: 900, FirstTime: t0.Add(15 * time.Minute), Segments: []madmin.DiskAction{s(5), s(9)}},
+		}}}}
+		check(t, m, "drive/ops_last_day", "ReadFile", "Operations")
+	})
+
+	t.Run("kms", func(t *testing.T) {
+		s := func(count uint64) madmin.KMSAction { return madmin.KMSAction{Count: count} }
+		m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{KMS: &madmin.KMSRtMetrics{LastDay: map[string]madmin.SegmentedKMSActions{
+			"encrypt": {Interval: 900, FirstTime: t0, Segments: []madmin.KMSAction{s(1), s(2)}},
+			"decrypt": {Interval: 900, FirstTime: t0.Add(15 * time.Minute), Segments: []madmin.KMSAction{s(5), s(9)}},
+		}}}}
+		check(t, m, "kms/last_day", "decrypt", "Calls")
+	})
 }
 
 func TestDiskSetLeafData(t *testing.T) {

--- a/mnav/rpc.go
+++ b/mnav/rpc.go
@@ -182,6 +182,52 @@ func (node *RPCLastMinuteNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children available for last minute RPC stats")
 }
 
+// rpcView adapts RPC last-day data to the generic _by_time navigation.
+func rpcView(ops map[string]madmin.SegmentedRPCMetrics) segView[madmin.RPCStats, *madmin.RPCStats] {
+	return segView[madmin.RPCStats, *madmin.RPCStats]{
+		ops:         ops,
+		metricType:  madmin.MetricsRPC,
+		metricFlags: madmin.MetricsDayStats,
+		empty:       func(s *madmin.RPCStats) bool { return s.Requests == 0 },
+		segDesc:     rpcSegmentDesc,
+		opDesc:      rpcOpDesc,
+		opLeaf: func(op string, s madmin.RPCStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &RPCHandlerSegmentNode{handler: op, stats: s, segmentTime: segTime, parent: parent, path: path}
+		},
+		sumLeaf: func(s madmin.RPCStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
+			return &RPCTimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
+		},
+	}
+}
+
+func rpcSegmentDesc(total madmin.RPCStats, interval int, segTime, end time.Time) string {
+	day := ""
+	if !sameLocalDay(segTime, time.Now()) {
+		day = "Yesterday "
+	}
+	var rps float64
+	if interval > 0 {
+		rps = float64(total.Requests) / float64(interval)
+	}
+	desc := fmt.Sprintf("%s%s -> %s, %.1f req/s", day, segTime.Local().Format("15:04"), end.Local().Format("15:04"), rps)
+	if total.Requests > 0 && total.RequestTimeSecs > 0 {
+		desc += fmt.Sprintf(", %.1fms avg", (total.RequestTimeSecs/float64(total.Requests))*1000)
+	}
+	return desc
+}
+
+func rpcOpDesc(_ string, s madmin.RPCStats, interval int) string {
+	var rps float64
+	if interval > 0 {
+		rps = float64(s.Requests) / float64(interval)
+	}
+	desc := fmt.Sprintf("%.1f req/s", rps)
+	if s.Requests > 0 && s.RequestTimeSecs > 0 {
+		desc += fmt.Sprintf(", %.1fms avg", (s.RequestTimeSecs/float64(s.Requests))*1000)
+	}
+	return desc
+}
+
 // RPCLastDayNode shows last day RPC statistics segmented
 type RPCLastDayNode struct {
 	rpc    *madmin.RPCMetrics
@@ -200,13 +246,16 @@ func (node *RPCLastDayNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 
-	children := make([]MetricChild, 0, len(node.rpc.LastDay)+1)
+	children := make([]MetricChild, 0, len(node.rpc.LastDay)+2)
 
-	// Add "All" entry first
-	children = append(children, MetricChild{
-		Name:        "All",
-		Description: "Aggregated statistics for all RPC handlers",
-	})
+	// Time-first entry, then the aggregated per-handler "All".
+	children = append(children,
+		MetricChild{Name: byTimeName, Description: "Browse by time segment (all handlers)"},
+		MetricChild{
+			Name:        "All",
+			Description: "Aggregated statistics for all RPC handlers",
+		},
+	)
 
 	// Add individual handlers, sorted alphabetically
 	handlerNames := make([]string, 0, len(node.rpc.LastDay))
@@ -263,6 +312,10 @@ func (node *RPCLastDayNode) GetParent() MetricNode              { return node.pa
 func (node *RPCLastDayNode) GetPath() string                    { return node.path }
 
 func (node *RPCLastDayNode) GetChild(name string) (MetricNode, error) {
+	if name == byTimeName {
+		return newByTimeNode(rpcView(node.rpc.LastDay), node, node.path+"/"+byTimeName), nil
+	}
+
 	// Handle "All" entry
 	if name == "All" {
 		return &RPCLastDayAllNode{


### PR DESCRIPTION
For many the main access point is last_day -> Operation -> time_selection -> stats.

That means there is no way to investigate a certain time period and you have to navigate back 2 levels to see other operations for that time segment.

This adds last_day -> _by_time -> time segment -> operations (with summary) -> stats to multiple types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Browse by time segment" navigation for last-day API, RPC, disk, and KMS metrics.
  * Displays non-empty time segments newest-first, with per-operation details and aggregated `_ALL` summaries.
  * Added time-segment context to metric details, including rates, counts, latency, and errors where available.
  * Improved empty-state messaging with "No activity."
* **Tests**
  * Added coverage for time-based navigation, timestamp-aligned metrics, and cross-operation aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->