### PR TITLE
feat: add MemPerf() for memory bandwidth validation

### DIFF
--- a/perf-mem.go
+++ b/perf-mem.go
@@ -88,6 +88,11 @@ type MemPerfNodeResult struct {
 // the topology could not be read. Values below roughly 0.65 are worth
 // investigating before trusting any other benchmark from the node.
 func (r MemPerfNodeResult) Efficiency() float64 {
+	// A theoretical figure with no source behind it is not a measurement;
+	// reporting a ratio from it would dress up a guess as data.
+	if r.TopologySource == "" || r.TopologySource == MemPerfTopologyUnavailable {
+		return 0
+	}
 	if r.TheoreticalBps == 0 {
 		return 0
 	}
@@ -127,6 +132,16 @@ type MemPerfOpts struct {
 // anything else running on those nodes; treat it as a deployment validation
 // step rather than something to run against a live workload.
 func (adm *AdminClient) MemPerf(ctx context.Context, opts MemPerfOpts) (result MemPerfResult, err error) {
+	// Zero means "server default"; a negative is a caller mistake. Treating it
+	// as the default would quietly turn a typo into a saturating run across
+	// every core.
+	if opts.Duration < 0 {
+		return result, ErrInvalidArgument("duration cannot be negative")
+	}
+	if opts.Threads < 0 {
+		return result, ErrInvalidArgument("threads cannot be negative")
+	}
+
 	queryVals := make(url.Values)
 	if opts.Duration > 0 {
 		queryVals.Set("duration", opts.Duration.String())

--- a/perf-mem.go
+++ b/perf-mem.go
@@ -1,0 +1,156 @@
+//
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// MemPerfTopologySource records where a node's memory topology came from, so a
+// consumer can tell a real theoretical figure from an absent one rather than
+// silently trusting a zero.
+type MemPerfTopologySource string
+
+const (
+	// MemPerfTopologyDMI - read from SMBIOS type 17 memory device entries.
+	MemPerfTopologyDMI MemPerfTopologySource = "dmi"
+
+	// MemPerfTopologyEDAC - derived from the kernel EDAC memory controller tree,
+	// which reports sizes and channel layout but not clocks.
+	MemPerfTopologyEDAC MemPerfTopologySource = "edac"
+
+	// MemPerfTopologyUnavailable - neither source was readable; only the
+	// measured bandwidth is meaningful.
+	MemPerfTopologyUnavailable MemPerfTopologySource = "unavailable"
+)
+
+// MemPerfDIMM describes one populated memory device as the firmware reports it.
+type MemPerfDIMM struct {
+	Locator       string `json:"locator,omitempty"`
+	SizeBytes     uint64 `json:"sizeBytes,omitempty"`
+	MaxSpeedMTs   uint32 `json:"maxSpeedMTs,omitempty"`
+	ConfiguredMTs uint32 `json:"configuredMTs,omitempty"`
+}
+
+// MemPerfNodeResult holds one server's memory bandwidth measurement alongside
+// the topology it should be judged against.
+//
+// BandwidthBps is what the hardware actually delivered under a saturating load;
+// TheoreticalBps is what the populated DIMMs allow. The ratio between them is
+// the number worth acting on: a node far below its own theoretical figure is
+// usually mispopulated or downclocked, which no amount of software tuning will
+// recover.
+type MemPerfNodeResult struct {
+	Endpoint string `json:"endpoint"`
+
+	// Measured under a saturating multi-threaded load.
+	BandwidthBps uint64        `json:"bandwidthBps"`
+	PerNUMABps   []uint64      `json:"perNumaBps,omitempty"`
+	Threads      int           `json:"threads,omitempty"`
+	BufferBytes  uint64        `json:"bufferBytes,omitempty"`
+	Duration     time.Duration `json:"duration,omitempty"`
+
+	// Best-effort topology. Absent fields mean unreadable, not zero.
+	TheoreticalBps uint64                `json:"theoreticalBps,omitempty"`
+	TopologySource MemPerfTopologySource `json:"topologySource,omitempty"`
+	Channels       int                   `json:"channels,omitempty"`
+	ConfiguredMTs  uint32                `json:"configuredMTs,omitempty"`
+	MaxSpeedMTs    uint32                `json:"maxSpeedMTs,omitempty"`
+	NUMANodes      int                   `json:"numaNodes,omitempty"`
+	DIMMs          []MemPerfDIMM         `json:"dimms,omitempty"`
+
+	Error string `json:"error,omitempty"`
+}
+
+// Efficiency returns measured bandwidth as a fraction of theoretical, or 0 when
+// the topology could not be read. Values below roughly 0.65 are worth
+// investigating before trusting any other benchmark from the node.
+func (r MemPerfNodeResult) Efficiency() float64 {
+	if r.TheoreticalBps == 0 {
+		return 0
+	}
+	return float64(r.BandwidthBps) / float64(r.TheoreticalBps)
+}
+
+// Downclocked reports whether the DIMMs are running below their rated speed.
+// Theoretical bandwidth is computed from the configured clock, so a downclocked
+// node can show good efficiency while still leaving bandwidth on the table.
+func (r MemPerfNodeResult) Downclocked() bool {
+	return r.MaxSpeedMTs > 0 && r.ConfiguredMTs > 0 && r.ConfiguredMTs < r.MaxSpeedMTs
+}
+
+// MemPerfResult - aggregate results from all servers.
+type MemPerfResult struct {
+	NodeResults []MemPerfNodeResult `json:"nodeResults"`
+}
+
+// MemPerfOpts provide configurable options for the memory bandwidth test.
+type MemPerfOpts struct {
+	// Duration of the saturating load. Zero picks the server default.
+	Duration time.Duration
+
+	// Threads issuing traffic. Zero uses every available core, which is what
+	// saturation requires on a many-core host.
+	Threads int
+
+	// BufferSize is the per-thread working set. It must exceed the last-level
+	// cache or the test measures cache, not memory. Zero picks the server
+	// default.
+	BufferSize uint64
+}
+
+// MemPerf runs a memory bandwidth test on every MinIO server.
+//
+// The test deliberately saturates memory for its duration and will slow
+// anything else running on those nodes; treat it as a deployment validation
+// step rather than something to run against a live workload.
+func (adm *AdminClient) MemPerf(ctx context.Context, opts MemPerfOpts) (result MemPerfResult, err error) {
+	queryVals := make(url.Values)
+	if opts.Duration > 0 {
+		queryVals.Set("duration", opts.Duration.String())
+	}
+	if opts.Threads > 0 {
+		queryVals.Set("threads", strconv.Itoa(opts.Threads))
+	}
+	if opts.BufferSize > 0 {
+		queryVals.Set("buffersize", strconv.FormatUint(opts.BufferSize, 10))
+	}
+
+	resp, err := adm.executeMethod(ctx,
+		http.MethodPost, requestData{
+			relPath:     adminAPIPrefix + "/speedtest/mem",
+			queryValues: queryVals,
+		})
+	if err != nil {
+		return result, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return result, httpRespToErrorResponse(resp)
+	}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	return result, err
+}

--- a/perf-mem_test.go
+++ b/perf-mem_test.go
@@ -21,6 +21,7 @@ package madmin
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -139,8 +140,15 @@ func TestMemPerfNegativeOpts(t *testing.T) {
 			}))
 			defer server.Close()
 
-			if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), tc.opts); err == nil {
+			_, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), tc.opts)
+			if err == nil {
 				t.Fatal("expected an error for a negative option")
+			}
+			// Assert the reason rather than merely that something failed: a
+			// dial error would otherwise satisfy this test.
+			var errResp ErrorResponse
+			if !errors.As(err, &errResp) || errResp.Code != "InvalidArgument" {
+				t.Errorf("expected an InvalidArgument ErrorResponse, got %#v", err)
 			}
 			if called {
 				t.Error("no request should be issued when validation fails")

--- a/perf-mem_test.go
+++ b/perf-mem_test.go
@@ -1,0 +1,312 @@
+//
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newMemPerfTestClient(t *testing.T, serverURL string) *AdminClient {
+	t.Helper()
+	client, err := New(mustParseHost(t, serverURL), "ak", "sk", false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return client
+}
+
+// TestMemPerfRequest verifies the client issues POST against the speedtest/mem
+// admin path.
+func TestMemPerfRequest(t *testing.T) {
+	var capturedMethod, capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), MemPerfOpts{}); err != nil {
+		t.Fatalf("MemPerf: %v", err)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", capturedMethod)
+	}
+	if !strings.HasPrefix(capturedPath, "/minio/admin/") {
+		t.Errorf("path missing /minio/admin/ prefix: %s", capturedPath)
+	}
+	if !strings.HasSuffix(capturedPath, "/speedtest/mem") {
+		t.Errorf("path missing /speedtest/mem suffix: %s", capturedPath)
+	}
+}
+
+// TestMemPerfQueryValues covers option serialization, and that zero options are
+// omitted entirely so the server applies its own defaults.
+func TestMemPerfQueryValues(t *testing.T) {
+	tests := []struct {
+		name string
+		opts MemPerfOpts
+		want map[string]string
+		omit []string
+	}{
+		{
+			name: "all options set",
+			opts: MemPerfOpts{Duration: 12 * time.Second, Threads: 64, BufferSize: 1 << 26},
+			want: map[string]string{"duration": "12s", "threads": "64", "buffersize": "67108864"},
+		},
+		{
+			name: "zero options omitted",
+			opts: MemPerfOpts{},
+			omit: []string{"duration", "threads", "buffersize"},
+		},
+		{
+			name: "partial options",
+			opts: MemPerfOpts{Threads: 8},
+			want: map[string]string{"threads": "8"},
+			omit: []string{"duration", "buffersize"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var q url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				q = r.URL.Query()
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), tc.opts); err != nil {
+				t.Fatalf("MemPerf: %v", err)
+			}
+			for k, want := range tc.want {
+				if got := q.Get(k); got != want {
+					t.Errorf("%s = %q, want %q", k, got, want)
+				}
+			}
+			for _, k := range tc.omit {
+				if _, ok := q[k]; ok {
+					t.Errorf("%s should be omitted when zero, got %q", k, q.Get(k))
+				}
+			}
+		})
+	}
+}
+
+// TestMemPerfNegativeOpts checks that a negative option is rejected before any
+// request is issued, so a caller mistake cannot start a saturating run.
+func TestMemPerfNegativeOpts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts MemPerfOpts
+	}{
+		{"negative duration", MemPerfOpts{Duration: -time.Second}},
+		{"negative threads", MemPerfOpts{Threads: -1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), tc.opts); err == nil {
+				t.Fatal("expected an error for a negative option")
+			}
+			if called {
+				t.Error("no request should be issued when validation fails")
+			}
+		})
+	}
+}
+
+// TestMemPerfDecode covers decoding of a populated multi-node response.
+func TestMemPerfDecode(t *testing.T) {
+	body := `{"nodeResults":[
+      {"endpoint":"node-1:9000","bandwidthBps":335000000000,"perNumaBps":[168000000000,167000000000],
+       "threads":256,"bufferBytes":67108864,"duration":5000000000,
+       "theoreticalBps":460800000000,"topologySource":"dmi","channels":12,
+       "configuredMTs":4800,"maxSpeedMTs":5600,"numaNodes":2,
+       "dimms":[{"locator":"DIMM_A1","sizeBytes":68719476736,"maxSpeedMTs":5600,"configuredMTs":4800}]},
+      {"endpoint":"node-2:9000","bandwidthBps":120000000000,"topologySource":"edac","channels":8},
+      {"endpoint":"node-3:9000","error":"perf unavailable"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	res, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), MemPerfOpts{})
+	if err != nil {
+		t.Fatalf("MemPerf: %v", err)
+	}
+	if len(res.NodeResults) != 3 {
+		t.Fatalf("expected 3 node results, got %d", len(res.NodeResults))
+	}
+
+	n := res.NodeResults[0]
+	if n.BandwidthBps != 335000000000 {
+		t.Errorf("bandwidth = %d", n.BandwidthBps)
+	}
+	if n.TopologySource != MemPerfTopologyDMI {
+		t.Errorf("topologySource = %q", n.TopologySource)
+	}
+	if n.Channels != 12 || n.NUMANodes != 2 {
+		t.Errorf("channels = %d, numaNodes = %d", n.Channels, n.NUMANodes)
+	}
+	if n.Duration != 5*time.Second {
+		t.Errorf("duration = %v, want 5s", n.Duration)
+	}
+	if len(n.PerNUMABps) != 2 {
+		t.Errorf("perNumaBps len = %d", len(n.PerNUMABps))
+	}
+	if len(n.DIMMs) != 1 || n.DIMMs[0].Locator != "DIMM_A1" {
+		t.Errorf("dimms = %+v", n.DIMMs)
+	}
+	if !n.Downclocked() {
+		t.Error("4800 configured against 5600 rated should report downclocked")
+	}
+
+	if res.NodeResults[2].Error != "perf unavailable" {
+		t.Errorf("per-node error not decoded: %q", res.NodeResults[2].Error)
+	}
+}
+
+// TestMemPerfHTTPError checks a non-200 response surfaces as an error.
+func TestMemPerfHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), MemPerfOpts{}); err == nil {
+		t.Fatal("expected an error for a 500 response")
+	}
+}
+
+// TestMemPerfMalformedJSON checks a truncated body surfaces as an error rather
+// than an empty result.
+func TestMemPerfMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"nodeResults":[{"endpoint":`))
+	}))
+	defer server.Close()
+
+	if _, err := newMemPerfTestClient(t, server.URL).MemPerf(context.Background(), MemPerfOpts{}); err == nil {
+		t.Fatal("expected an error for malformed JSON")
+	}
+}
+
+// TestMemPerfContextCancelled checks a cancelled context aborts the call.
+func TestMemPerfContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := newMemPerfTestClient(t, server.URL).MemPerf(ctx, MemPerfOpts{}); err == nil {
+		t.Fatal("expected an error for a cancelled context")
+	}
+}
+
+// TestMemPerfEfficiency pins the contract that a ratio is only reported when a
+// topology source actually backs the theoretical figure.
+func TestMemPerfEfficiency(t *testing.T) {
+	tests := []struct {
+		name string
+		res  MemPerfNodeResult
+		want float64
+	}{
+		{
+			name: "dmi topology",
+			res:  MemPerfNodeResult{BandwidthBps: 200, TheoreticalBps: 400, TopologySource: MemPerfTopologyDMI},
+			want: 0.5,
+		},
+		{
+			name: "edac topology without a theoretical figure",
+			res:  MemPerfNodeResult{BandwidthBps: 200, TopologySource: MemPerfTopologyEDAC},
+			want: 0,
+		},
+		{
+			name: "unavailable topology never reports a ratio",
+			res:  MemPerfNodeResult{BandwidthBps: 200, TheoreticalBps: 400, TopologySource: MemPerfTopologyUnavailable},
+			want: 0,
+		},
+		{
+			name: "unset topology never reports a ratio",
+			res:  MemPerfNodeResult{BandwidthBps: 200, TheoreticalBps: 400},
+			want: 0,
+		},
+		{
+			name: "zero theoretical",
+			res:  MemPerfNodeResult{BandwidthBps: 200, TopologySource: MemPerfTopologyDMI},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.res.Efficiency(); got != tc.want {
+				t.Errorf("Efficiency() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMemPerfDownclocked covers the rated-versus-configured comparison, which
+// stays meaningful even on a node showing good efficiency.
+func TestMemPerfDownclocked(t *testing.T) {
+	tests := []struct {
+		name string
+		res  MemPerfNodeResult
+		want bool
+	}{
+		{"configured below rated", MemPerfNodeResult{ConfiguredMTs: 4800, MaxSpeedMTs: 5600}, true},
+		{"running at rated", MemPerfNodeResult{ConfiguredMTs: 5600, MaxSpeedMTs: 5600}, false},
+		{"rated unknown", MemPerfNodeResult{ConfiguredMTs: 4800}, false},
+		{"configured unknown", MemPerfNodeResult{MaxSpeedMTs: 5600}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.res.Downclocked(); got != tc.want {
+				t.Errorf("Downclocked() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `MemPerf()` plus its result types, calling a new `/speedtest/mem` admin endpoint. Server side follows in a separate PR.

Memory bandwidth is what caps large-object throughput on many-core storage nodes, and it is the one resource no utilization counter shows — DMA from a drive or NIC never touches a core, so CPU, disk and network can all read idle while DRAM is saturated.

The result carries the measurement next to the topology it should be judged against, so `Efficiency()` distinguishes a genuinely saturated node from a mispopulated or downclocked one. Theoretical bandwidth is derived from the *configured* clock rather than the rated one — 5600 MT/s parts pinned at 4800 are common, and using the rated speed would make a healthy node look broken.

Topology capture is best effort and records its own provenance (`dmi` / `edac` / `unavailable`), so an unreadable source is never mistaken for a measured zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memory-bandwidth performance test through the administration interface.
  * Supports configurable test duration, thread count, and buffer size.
  * Reports performance results, memory topology, DIMM details, efficiency, and downclocking status.
  * Provides clear handling for unavailable topology information, invalid settings, cancelled requests, and service errors.
* **Tests**
  * Added coverage for request options, response handling, error scenarios, efficiency calculations, and downclock detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->