### PR TITLE
Fix ServerHealthInfo swallowing body

### DIFF
--- a/health.go
+++ b/health.go
@@ -1612,5 +1612,15 @@ func (adm *AdminClient) ServerHealthInfo(ctx context.Context, types []HealthData
 		return nil, "", errors.New("Upgrade Minio Client to support health info version " + version.Version)
 	}
 
+	// decoder reads ahead, so it can hold bytes belonging to the frames after
+	// the version one. Callers decode those from resp.Body with a decoder of
+	// their own, so the buffered remainder has to go back in front of the
+	// stream; otherwise the next frame silently loses its prefix.
+	body := resp.Body
+	resp.Body = &closeWrapper{
+		Reader: io.MultiReader(decoder.Buffered(), body),
+		Closer: body,
+	}
+
 	return resp, version.Version, nil
 }

--- a/health_test.go
+++ b/health_test.go
@@ -22,8 +22,11 @@ package madmin
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"testing"
+	"time"
 )
 
 // TestCPUFreqStatsJSONMarshal tests that only Name and Governor are included in JSON output when set
@@ -274,5 +277,53 @@ func TestCPUMultithreadingDetection(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// TestServerHealthInfoPreservesBufferedFrames verifies the version probe does
+// not swallow the frames behind it. The probe's decoder reads ahead, so when
+// the server emits several frames into one flush the bytes after the version
+// frame land in that decoder's buffer. Callers decode the rest of the stream
+// from resp.Body with a decoder of their own, and would otherwise pick up a
+// frame whose prefix is already gone.
+func TestServerHealthInfoPreservesBufferedFrames(t *testing.T) {
+	frame := func(ts time.Time) []byte {
+		b, err := json.Marshal(HealthInfo{Version: HealthInfoVersion, TimeStamp: ts})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		return b
+	}
+	first, second := time.Unix(500, 0).UTC(), time.Unix(1000, 0).UTC()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Both frames in a single write, so they reach the client in one read.
+		_, _ = w.Write(append(frame(first), frame(second)...))
+	}))
+	defer server.Close()
+
+	client, err := New(mustParseHost(t, server.URL), "ak", "sk", false)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, version, err := client.ServerHealthInfo(context.Background(),
+		[]HealthDataType{HealthDataTypeMinioInfo}, time.Second, "")
+	if err != nil {
+		t.Fatalf("ServerHealthInfo: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if version != HealthInfoVersion {
+		t.Errorf("version = %q, want %q", version, HealthInfoVersion)
+	}
+
+	var got HealthInfo
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decoding the frame after the version probe: %v", err)
+	}
+	if !got.TimeStamp.Equal(second) {
+		t.Errorf("TimeStamp = %v, want the frame after the probe (%v)", got.TimeStamp, second)
 	}
 }


### PR DESCRIPTION
The decoder relies on flush timings to not overread (and corrupt) the response. It basically relies on the rest of the body not being available and a short read returning.

This means that slow callers may end up reading more than the initial version response. Append any body the decoder may have read before returning the remaining body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed health checks so subsequent response frames are no longer lost when reading version information.
  - Preserved the complete response stream for reliable processing of health data.

- **Tests**
  - Added regression coverage to verify that buffered health frames remain available after version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->