### PR TITLE
Improve locks/targets/iam historic data

### DIFF
--- a/metrics-iam.go
+++ b/metrics-iam.go
@@ -23,7 +23,14 @@ import "time"
 
 //go:generate go tool msgp -unexported -d clearomitted -d "tag json" -d "timezone utc" -d "maps binkeys" -file $GOFILE
 
-// IAMMetrics is the identity inventory and the latency of the store behind it.
+// IAMMetrics is the identity inventory, the cost of authorizing against it, and
+// the latency of the store behind it.
+//
+// Three time bases, none of them cumulative since process start:
+//
+//   - Cache is instantaneous, a reading of the inventory as it stands.
+//   - Auth and Store are the sliding last minute.
+//   - LastHour and LastDay are segmented windows, present only when asked for.
 type IAMMetrics struct {
 	CollectedAt time.Time `json:"collected"`
 
@@ -33,13 +40,27 @@ type IAMMetrics struct {
 	// takes the most recently sampled copy and never sums.
 	Cache *IAMCacheStats `json:"cache,omitempty"`
 
-	// Store is IAM persistence latency by operation: "save", "load", "delete",
-	// "list". Node-local and summing.
+	// Auth is what authorizing requests cost over the last minute. This is the
+	// request path.
+	Auth *IAMAuthStats `json:"auth,omitempty"`
+
+	// Store is IAM persistence latency over the last minute by operation: "save",
+	// "load", "delete", "list". Node-local and summing.
 	//
 	// This is the refresh and admin path, not the request path -- requests read the
 	// in-memory cache -- so a rise here delays IAM changes propagating rather than
-	// slowing traffic.
+	// slowing traffic. It is also low-frequency, so an idle minute reports nothing
+	// and the windows below are where it is normally read.
 	Store map[string]TimedAction `json:"store,omitempty"`
+
+	// LastHour is 1-minute segments over the last hour, set only when
+	// MetricsHourStats is requested. Non-nil with no segments means the window was
+	// requested and nothing has completed in it yet.
+	LastHour *SegmentedIAMMetrics `json:"lastHour,omitempty"`
+
+	// LastDay is 15-minute segments over the last day, set only when
+	// MetricsDayStats is requested.
+	LastDay *SegmentedIAMMetrics `json:"lastDay,omitempty"`
 }
 
 // Merge other into m.
@@ -53,6 +74,29 @@ func (m *IAMMetrics) Merge(other *IAMMetrics) {
 	}
 	mergeMap(&m.Store, other.Store)
 
+	if other.Auth != nil {
+		if m.Auth == nil {
+			m.Auth = &IAMAuthStats{}
+		}
+		m.Auth.Merge(other.Auth)
+	}
+
+	// A requested-but-empty window is non-nil with no segments, so presence is
+	// tested rather than length: dropping it here would read downstream as "not
+	// requested".
+	if other.LastHour != nil {
+		if m.LastHour == nil {
+			m.LastHour = &SegmentedIAMMetrics{}
+		}
+		m.LastHour.Add(other.LastHour)
+	}
+	if other.LastDay != nil {
+		if m.LastDay == nil {
+			m.LastDay = &SegmentedIAMMetrics{}
+		}
+		m.LastDay.Add(other.LastDay)
+	}
+
 	// Latest-wins on the sample time, never summed.
 	if other.Cache == nil {
 		return
@@ -61,6 +105,174 @@ func (m *IAMMetrics) Merge(other *IAMMetrics) {
 		c := *other.Cache
 		m.Cache = &c
 	}
+}
+
+// Resolution paths an authorization can take, in the order IAMSys.IsAllowed
+// tests them. They are the keys of IAMAuthStats.ByPath and the split the
+// segments carry, because their costs differ by orders of magnitude: a plugin
+// call crosses the network, an owner check does nothing at all.
+const (
+	// IAMPathPlugin is an external authorization plugin. When one is configured it
+	// answers every request, so this path is all-or-nothing per deployment.
+	IAMPathPlugin = "plugin"
+
+	// IAMPathOwner is the root or account owner, allowed without evaluating anything.
+	IAMPathOwner = "owner"
+
+	// IAMPathSTS is a temporary credential, resolved through its session policy and
+	// then its parent's.
+	IAMPathSTS = "sts"
+
+	// IAMPathSvcAcct is a service account, resolved through its parent.
+	IAMPathSvcAcct = "svcacct"
+
+	// IAMPathUser is a regular user, resolved from the policy mappings.
+	IAMPathUser = "user"
+)
+
+// IAMAuthStats is what authorizing requests cost over the last minute, split by
+// how the identity had to be resolved.
+//
+// Everything here is node-local and summing.
+type IAMAuthStats struct {
+	// ByPath is keyed by the IAMPath constants. A path nobody took is absent rather
+	// than zero, so a deployment with no plugin configured never reports one.
+	ByPath map[string]TimedAction `json:"by_path,omitempty"`
+
+	// Denied is authorizations that resolved and refused. A rise here is a client
+	// or policy change, not a server fault.
+	Denied uint64 `json:"denied,omitempty"`
+
+	// Errors is authorizations that could not be resolved at all, which are refused
+	// without a policy decision having been reached.
+	Errors uint64 `json:"errors,omitempty"`
+
+	// CacheMiss is regular-user authorizations that had to build their merged policy
+	// rather than reuse a cached one. Against the IAMPathUser count it gives the
+	// hit rate; sustained misses mean the cache is being invalidated faster than it
+	// is filled.
+	CacheMiss uint64 `json:"cache_miss,omitempty"`
+}
+
+// Merge other into s.
+func (s *IAMAuthStats) Merge(other *IAMAuthStats) {
+	if other == nil {
+		return
+	}
+	mergeMap(&s.ByPath, other.ByPath)
+	s.Denied += other.Denied
+	s.Errors += other.Errors
+	s.CacheMiss += other.CacheMiss
+}
+
+// SegmentedIAMMetrics is a time-segmented view of IAM activity.
+type SegmentedIAMMetrics = Segmented[IAMSegment, *IAMSegment]
+
+// IAMSegment is IAM activity over one time segment.
+//
+// Both axes it carries are plain sums, so segments merge across nodes and
+// rescale to a coarser interval by addition. The one exception is MaxNanos,
+// merged worst-wins.
+//
+// The inventory is deliberately absent: it is a gauge, and summing a gauge's
+// samples over a segment means nothing.
+//
+// The paths are fixed fields rather than a map keyed by the IAMPath constants,
+// because a map would be repeated in all 156 segments a node carries.
+type IAMSegment struct {
+	// Authorization counts and their summed latency, per resolution path. The mean
+	// for a path is its Nanos over its Count, and its share of traffic is its Count
+	// over the total.
+	PluginCount  uint64 `json:"plugin_count,omitempty"`
+	PluginNanos  uint64 `json:"plugin_ns,omitempty"`
+	OwnerCount   uint64 `json:"owner_count,omitempty"`
+	OwnerNanos   uint64 `json:"owner_ns,omitempty"`
+	STSCount     uint64 `json:"sts_count,omitempty"`
+	STSNanos     uint64 `json:"sts_ns,omitempty"`
+	SvcAcctCount uint64 `json:"svcacct_count,omitempty"`
+	SvcAcctNanos uint64 `json:"svcacct_ns,omitempty"`
+	UserCount    uint64 `json:"user_count,omitempty"`
+	UserNanos    uint64 `json:"user_ns,omitempty"`
+
+	// MaxNanos is the slowest single authorization in the segment, whatever path it
+	// took. One figure rather than one per path: a configured plugin answers every
+	// request, so at most one path is ever in contention for it.
+	MaxNanos uint64 `json:"max_ns,omitempty"`
+
+	Denied    uint64 `json:"denied,omitempty"`
+	Errors    uint64 `json:"errors,omitempty"`
+	CacheMiss uint64 `json:"cache_miss,omitempty"`
+
+	// Persistence counts and their summed latency. This is the refresh and admin
+	// path, and it is infrequent enough that the segments are the only place it can
+	// be seen at all.
+	SaveCount   uint64 `json:"save_count,omitempty"`
+	SaveNanos   uint64 `json:"save_ns,omitempty"`
+	LoadCount   uint64 `json:"load_count,omitempty"`
+	LoadNanos   uint64 `json:"load_ns,omitempty"`
+	DeleteCount uint64 `json:"delete_count,omitempty"`
+	DeleteNanos uint64 `json:"delete_ns,omitempty"`
+	ListCount   uint64 `json:"list_count,omitempty"`
+	ListNanos   uint64 `json:"list_ns,omitempty"`
+
+	// StoreErrors is failed persistence operations, all four kinds together: a
+	// failing IAM store is one condition however it surfaced.
+	StoreErrors uint64 `json:"store_errors,omitempty"`
+
+	// N is contributing nodes.
+	N int `json:"n"`
+}
+
+// Add other into s.
+func (s *IAMSegment) Add(other *IAMSegment) {
+	if other == nil {
+		return
+	}
+	s.PluginCount += other.PluginCount
+	s.PluginNanos += other.PluginNanos
+	s.OwnerCount += other.OwnerCount
+	s.OwnerNanos += other.OwnerNanos
+	s.STSCount += other.STSCount
+	s.STSNanos += other.STSNanos
+	s.SvcAcctCount += other.SvcAcctCount
+	s.SvcAcctNanos += other.SvcAcctNanos
+	s.UserCount += other.UserCount
+	s.UserNanos += other.UserNanos
+	s.MaxNanos = max(s.MaxNanos, other.MaxNanos)
+	s.Denied += other.Denied
+	s.Errors += other.Errors
+	s.CacheMiss += other.CacheMiss
+	s.SaveCount += other.SaveCount
+	s.SaveNanos += other.SaveNanos
+	s.LoadCount += other.LoadCount
+	s.LoadNanos += other.LoadNanos
+	s.DeleteCount += other.DeleteCount
+	s.DeleteNanos += other.DeleteNanos
+	s.ListCount += other.ListCount
+	s.ListNanos += other.ListNanos
+	s.StoreErrors += other.StoreErrors
+	s.N += other.N
+}
+
+// AuthCount is every authorization recorded in the segment, all paths together.
+func (s IAMSegment) AuthCount() uint64 {
+	return s.PluginCount + s.OwnerCount + s.STSCount + s.SvcAcctCount + s.UserCount
+}
+
+// AuthNanos is the summed authorization latency in the segment, all paths
+// together.
+func (s IAMSegment) AuthNanos() uint64 {
+	return s.PluginNanos + s.OwnerNanos + s.STSNanos + s.SvcAcctNanos + s.UserNanos
+}
+
+// StoreCount is every persistence operation recorded in the segment.
+func (s IAMSegment) StoreCount() uint64 {
+	return s.SaveCount + s.LoadCount + s.DeleteCount + s.ListCount
+}
+
+// StoreNanos is the summed persistence latency in the segment.
+func (s IAMSegment) StoreNanos() uint64 {
+	return s.SaveNanos + s.LoadNanos + s.DeleteNanos + s.ListNanos
 }
 
 // IAMCacheStats is the identity inventory held in memory on every node.

--- a/metrics-iam_gen.go
+++ b/metrics-iam_gen.go
@@ -7,6 +7,366 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *IAMAuthStats) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "by_path":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ByPath")
+				return
+			}
+			if z.ByPath == nil {
+				z.ByPath = make(map[string]TimedAction, zb0002)
+			} else if len(z.ByPath) > 0 {
+				clear(z.ByPath)
+			}
+			for zb0002 > 0 {
+				zb0002--
+				var za0001 string
+				za0001, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath")
+					return
+				}
+				var za0002 TimedAction
+				err = za0002.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath", za0001)
+					return
+				}
+				z.ByPath[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		case "denied":
+			z.Denied, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "errors":
+			z.Errors, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "cache_miss":
+			z.CacheMiss, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+			zb0001Mask |= 0x8
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ByPath = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Denied = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Errors = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.CacheMiss = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IAMAuthStats) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.ByPath == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Denied == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Errors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.CacheMiss == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "by_path"
+			err = en.Append(0xa7, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x74, 0x68)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.ByPath)))
+			if err != nil {
+				err = msgp.WrapError(err, "ByPath")
+				return
+			}
+			for za0001, za0002 := range z.ByPath {
+				err = en.WriteString(za0001)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath")
+					return
+				}
+				err = za0002.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "denied"
+			err = en.Append(0xa6, 0x64, 0x65, 0x6e, 0x69, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Denied)
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "errors"
+			err = en.Append(0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Errors)
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "cache_miss"
+			err = en.Append(0xaa, 0x63, 0x61, 0x63, 0x68, 0x65, 0x5f, 0x6d, 0x69, 0x73, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.CacheMiss)
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IAMAuthStats) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	if z.ByPath == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Denied == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.Errors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.CacheMiss == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "by_path"
+			o = append(o, 0xa7, 0x62, 0x79, 0x5f, 0x70, 0x61, 0x74, 0x68)
+			o = msgp.AppendMapHeader(o, uint32(len(z.ByPath)))
+			for za0001, za0002 := range z.ByPath {
+				o = msgp.AppendString(o, za0001)
+				o, err = za0002.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "denied"
+			o = append(o, 0xa6, 0x64, 0x65, 0x6e, 0x69, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.Denied)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "errors"
+			o = append(o, 0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			o = msgp.AppendUint64(o, z.Errors)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "cache_miss"
+			o = append(o, 0xaa, 0x63, 0x61, 0x63, 0x68, 0x65, 0x5f, 0x6d, 0x69, 0x73, 0x73)
+			o = msgp.AppendUint64(o, z.CacheMiss)
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IAMAuthStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 4 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "by_path":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ByPath")
+				return
+			}
+			if z.ByPath == nil {
+				z.ByPath = make(map[string]TimedAction, zb0002)
+			} else if len(z.ByPath) > 0 {
+				clear(z.ByPath)
+			}
+			for zb0002 > 0 {
+				var za0002 TimedAction
+				zb0002--
+				var za0001 string
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath")
+					return
+				}
+				bts, err = za0002.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ByPath", za0001)
+					return
+				}
+				z.ByPath[za0001] = za0002
+			}
+			zb0001Mask |= 0x1
+		case "denied":
+			z.Denied, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "errors":
+			z.Errors, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "cache_miss":
+			z.CacheMiss, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+			zb0001Mask |= 0x8
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xf {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ByPath = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Denied = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.Errors = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.CacheMiss = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *IAMAuthStats) Msgsize() (s int) {
+	s = 1 + 8 + msgp.MapHeaderSize
+	if z.ByPath != nil {
+		for za0001, za0002 := range z.ByPath {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
+		}
+	}
+	s += 7 + msgp.Uint64Size + 7 + msgp.Uint64Size + 11 + msgp.Uint64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *IAMCacheStats) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -510,7 +870,7 @@ func (z *IAMMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 2 bits */
+	var zb0001Mask uint8 /* 5 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -551,6 +911,25 @@ func (z *IAMMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x1
+		case "auth":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Auth")
+					return
+				}
+				z.Auth = nil
+			} else {
+				if z.Auth == nil {
+					z.Auth = new(IAMAuthStats)
+				}
+				err = z.Auth.DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "Auth")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
 		case "store":
 			var zb0002 uint32
 			zb0002, err = dc.ReadMapHeader()
@@ -579,7 +958,45 @@ func (z *IAMMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Store[za0001] = za0002
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x4
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedIAMMetrics)
+				}
+				err = (*Segmented[IAMSegment, *IAMSegment])(z.LastHour).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedIAMMetrics)
+				}
+				err = (*Segmented[IAMSegment, *IAMSegment])(z.LastDay).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x10
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -589,12 +1006,21 @@ func (z *IAMMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3 {
+	if zb0001Mask != 0x1f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Cache = nil
 		}
 		if (zb0001Mask & 0x2) == 0 {
+			z.Auth = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
 			z.Store = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.LastDay = nil
 		}
 	}
 	return
@@ -603,16 +1029,28 @@ func (z *IAMMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *IAMMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	if z.Cache == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Store == nil {
+	if z.Auth == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if z.Store == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -662,6 +1100,25 @@ func (z *IAMMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "auth"
+			err = en.Append(0xa4, 0x61, 0x75, 0x74, 0x68)
+			if err != nil {
+				return
+			}
+			if z.Auth == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z.Auth.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Auth")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
 			// write "store"
 			err = en.Append(0xa5, 0x73, 0x74, 0x6f, 0x72, 0x65)
 			if err != nil {
@@ -685,6 +1142,44 @@ func (z *IAMMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[IAMSegment, *IAMSegment])(z.LastHour).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[IAMSegment, *IAMSegment])(z.LastDay).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -693,16 +1188,28 @@ func (z *IAMMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *IAMMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(4)
-	var zb0001Mask uint8 /* 4 bits */
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	if z.Cache == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.Store == nil {
+	if z.Auth == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
+	}
+	if z.Store == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -729,6 +1236,19 @@ func (z *IAMMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "auth"
+			o = append(o, 0xa4, 0x61, 0x75, 0x74, 0x68)
+			if z.Auth == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = z.Auth.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Auth")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
 			// string "store"
 			o = append(o, 0xa5, 0x73, 0x74, 0x6f, 0x72, 0x65)
 			o = msgp.AppendMapHeader(o, uint32(len(z.Store)))
@@ -737,6 +1257,32 @@ func (z *IAMMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				o, err = za0002.MarshalMsg(o)
 				if err != nil {
 					err = msgp.WrapError(err, "Store", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[IAMSegment, *IAMSegment])(z.LastHour).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[IAMSegment, *IAMSegment])(z.LastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
 					return
 				}
 			}
@@ -755,7 +1301,7 @@ func (z *IAMMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 2 bits */
+	var zb0001Mask uint8 /* 5 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -795,6 +1341,24 @@ func (z *IAMMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x1
+		case "auth":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Auth = nil
+			} else {
+				if z.Auth == nil {
+					z.Auth = new(IAMAuthStats)
+				}
+				bts, err = z.Auth.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Auth")
+					return
+				}
+			}
+			zb0001Mask |= 0x2
 		case "store":
 			var zb0002 uint32
 			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -823,7 +1387,43 @@ func (z *IAMMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Store[za0001] = za0002
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x4
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedIAMMetrics)
+				}
+				bts, err = (*Segmented[IAMSegment, *IAMSegment])(z.LastHour).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedIAMMetrics)
+				}
+				bts, err = (*Segmented[IAMSegment, *IAMSegment])(z.LastDay).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x10
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -833,12 +1433,21 @@ func (z *IAMMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3 {
+	if zb0001Mask != 0x1f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Cache = nil
 		}
 		if (zb0001Mask & 0x2) == 0 {
+			z.Auth = nil
+		}
+		if (zb0001Mask & 0x4) == 0 {
 			z.Store = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LastHour = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.LastDay = nil
 		}
 	}
 	o = bts
@@ -853,6 +1462,12 @@ func (z *IAMMetrics) Msgsize() (s int) {
 	} else {
 		s += z.Cache.Msgsize()
 	}
+	s += 5
+	if z.Auth == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.Auth.Msgsize()
+	}
 	s += 6 + msgp.MapHeaderSize
 	if z.Store != nil {
 		for za0001, za0002 := range z.Store {
@@ -860,5 +1475,1186 @@ func (z *IAMMetrics) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0001) + za0002.Msgsize()
 		}
 	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[IAMSegment, *IAMSegment])(z.LastHour).Msgsize()
+	}
+	s += 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[IAMSegment, *IAMSegment])(z.LastDay).Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *IAMSegment) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint32 /* 23 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "plugin_count":
+			z.PluginCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "PluginCount")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "plugin_ns":
+			z.PluginNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "PluginNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "owner_count":
+			z.OwnerCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerCount")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "owner_ns":
+			z.OwnerNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerNanos")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "sts_count":
+			z.STSCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "STSCount")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "sts_ns":
+			z.STSNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "STSNanos")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "svcacct_count":
+			z.SvcAcctCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctCount")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "svcacct_ns":
+			z.SvcAcctNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctNanos")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "user_count":
+			z.UserCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "UserCount")
+				return
+			}
+			zb0001Mask |= 0x100
+		case "user_ns":
+			z.UserNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "UserNanos")
+				return
+			}
+			zb0001Mask |= 0x200
+		case "max_ns":
+			z.MaxNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+			zb0001Mask |= 0x400
+		case "denied":
+			z.Denied, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+			zb0001Mask |= 0x800
+		case "errors":
+			z.Errors, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+			zb0001Mask |= 0x1000
+		case "cache_miss":
+			z.CacheMiss, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+			zb0001Mask |= 0x2000
+		case "save_count":
+			z.SaveCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "SaveCount")
+				return
+			}
+			zb0001Mask |= 0x4000
+		case "save_ns":
+			z.SaveNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "SaveNanos")
+				return
+			}
+			zb0001Mask |= 0x8000
+		case "load_count":
+			z.LoadCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "LoadCount")
+				return
+			}
+			zb0001Mask |= 0x10000
+		case "load_ns":
+			z.LoadNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "LoadNanos")
+				return
+			}
+			zb0001Mask |= 0x20000
+		case "delete_count":
+			z.DeleteCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteCount")
+				return
+			}
+			zb0001Mask |= 0x40000
+		case "delete_ns":
+			z.DeleteNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteNanos")
+				return
+			}
+			zb0001Mask |= 0x80000
+		case "list_count":
+			z.ListCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ListCount")
+				return
+			}
+			zb0001Mask |= 0x100000
+		case "list_ns":
+			z.ListNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ListNanos")
+				return
+			}
+			zb0001Mask |= 0x200000
+		case "store_errors":
+			z.StoreErrors, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "StoreErrors")
+				return
+			}
+			zb0001Mask |= 0x400000
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7fffff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.PluginCount = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.PluginNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.OwnerCount = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.OwnerNanos = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.STSCount = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.STSNanos = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.SvcAcctCount = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.SvcAcctNanos = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.UserCount = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.UserNanos = 0
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.MaxNanos = 0
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.Denied = 0
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.Errors = 0
+		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.CacheMiss = 0
+		}
+		if (zb0001Mask & 0x4000) == 0 {
+			z.SaveCount = 0
+		}
+		if (zb0001Mask & 0x8000) == 0 {
+			z.SaveNanos = 0
+		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.LoadCount = 0
+		}
+		if (zb0001Mask & 0x20000) == 0 {
+			z.LoadNanos = 0
+		}
+		if (zb0001Mask & 0x40000) == 0 {
+			z.DeleteCount = 0
+		}
+		if (zb0001Mask & 0x80000) == 0 {
+			z.DeleteNanos = 0
+		}
+		if (zb0001Mask & 0x100000) == 0 {
+			z.ListCount = 0
+		}
+		if (zb0001Mask & 0x200000) == 0 {
+			z.ListNanos = 0
+		}
+		if (zb0001Mask & 0x400000) == 0 {
+			z.StoreErrors = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *IAMSegment) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(24)
+	var zb0001Mask uint32 /* 24 bits */
+	_ = zb0001Mask
+	if z.PluginCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.PluginNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.OwnerCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.OwnerNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.STSCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.STSNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.SvcAcctCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.SvcAcctNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.UserCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.UserNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.MaxNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.Denied == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.Errors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1000
+	}
+	if z.CacheMiss == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2000
+	}
+	if z.SaveCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4000
+	}
+	if z.SaveNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8000
+	}
+	if z.LoadCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10000
+	}
+	if z.LoadNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20000
+	}
+	if z.DeleteCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40000
+	}
+	if z.DeleteNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80000
+	}
+	if z.ListCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100000
+	}
+	if z.ListNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200000
+	}
+	if z.StoreErrors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400000
+	}
+	// variable map header, size zb0001Len
+	err = en.WriteMapHeader(zb0001Len)
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "plugin_count"
+			err = en.Append(0xac, 0x70, 0x6c, 0x75, 0x67, 0x69, 0x6e, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.PluginCount)
+			if err != nil {
+				err = msgp.WrapError(err, "PluginCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "plugin_ns"
+			err = en.Append(0xa9, 0x70, 0x6c, 0x75, 0x67, 0x69, 0x6e, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.PluginNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "PluginNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "owner_count"
+			err = en.Append(0xab, 0x6f, 0x77, 0x6e, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.OwnerCount)
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "owner_ns"
+			err = en.Append(0xa8, 0x6f, 0x77, 0x6e, 0x65, 0x72, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.OwnerNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "sts_count"
+			err = en.Append(0xa9, 0x73, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.STSCount)
+			if err != nil {
+				err = msgp.WrapError(err, "STSCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "sts_ns"
+			err = en.Append(0xa6, 0x73, 0x74, 0x73, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.STSNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "STSNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "svcacct_count"
+			err = en.Append(0xad, 0x73, 0x76, 0x63, 0x61, 0x63, 0x63, 0x74, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.SvcAcctCount)
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "svcacct_ns"
+			err = en.Append(0xaa, 0x73, 0x76, 0x63, 0x61, 0x63, 0x63, 0x74, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.SvcAcctNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "user_count"
+			err = en.Append(0xaa, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.UserCount)
+			if err != nil {
+				err = msgp.WrapError(err, "UserCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "user_ns"
+			err = en.Append(0xa7, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.UserNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "UserNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// write "max_ns"
+			err = en.Append(0xa6, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.MaxNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
+			// write "denied"
+			err = en.Append(0xa6, 0x64, 0x65, 0x6e, 0x69, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Denied)
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+		}
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
+			// write "errors"
+			err = en.Append(0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Errors)
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// write "cache_miss"
+			err = en.Append(0xaa, 0x63, 0x61, 0x63, 0x68, 0x65, 0x5f, 0x6d, 0x69, 0x73, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.CacheMiss)
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// write "save_count"
+			err = en.Append(0xaa, 0x73, 0x61, 0x76, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.SaveCount)
+			if err != nil {
+				err = msgp.WrapError(err, "SaveCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+			// write "save_ns"
+			err = en.Append(0xa7, 0x73, 0x61, 0x76, 0x65, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.SaveNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "SaveNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// write "load_count"
+			err = en.Append(0xaa, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.LoadCount)
+			if err != nil {
+				err = msgp.WrapError(err, "LoadCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20000) == 0 { // if not omitted
+			// write "load_ns"
+			err = en.Append(0xa7, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.LoadNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "LoadNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40000) == 0 { // if not omitted
+			// write "delete_count"
+			err = en.Append(0xac, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DeleteCount)
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80000) == 0 { // if not omitted
+			// write "delete_ns"
+			err = en.Append(0xa9, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DeleteNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100000) == 0 { // if not omitted
+			// write "list_count"
+			err = en.Append(0xaa, 0x6c, 0x69, 0x73, 0x74, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.ListCount)
+			if err != nil {
+				err = msgp.WrapError(err, "ListCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200000) == 0 { // if not omitted
+			// write "list_ns"
+			err = en.Append(0xa7, 0x6c, 0x69, 0x73, 0x74, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.ListNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "ListNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x400000) == 0 { // if not omitted
+			// write "store_errors"
+			err = en.Append(0xac, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.StoreErrors)
+			if err != nil {
+				err = msgp.WrapError(err, "StoreErrors")
+				return
+			}
+		}
+		// write "n"
+		err = en.Append(0xa1, 0x6e)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.N)
+		if err != nil {
+			err = msgp.WrapError(err, "N")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *IAMSegment) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(24)
+	var zb0001Mask uint32 /* 24 bits */
+	_ = zb0001Mask
+	if z.PluginCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.PluginNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.OwnerCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.OwnerNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.STSCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.STSNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.SvcAcctCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.SvcAcctNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.UserCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.UserNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.MaxNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.Denied == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.Errors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1000
+	}
+	if z.CacheMiss == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2000
+	}
+	if z.SaveCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4000
+	}
+	if z.SaveNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8000
+	}
+	if z.LoadCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10000
+	}
+	if z.LoadNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20000
+	}
+	if z.DeleteCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40000
+	}
+	if z.DeleteNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80000
+	}
+	if z.ListCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100000
+	}
+	if z.ListNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200000
+	}
+	if z.StoreErrors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400000
+	}
+	// variable map header, size zb0001Len
+	o = msgp.AppendMapHeader(o, zb0001Len)
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "plugin_count"
+			o = append(o, 0xac, 0x70, 0x6c, 0x75, 0x67, 0x69, 0x6e, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.PluginCount)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "plugin_ns"
+			o = append(o, 0xa9, 0x70, 0x6c, 0x75, 0x67, 0x69, 0x6e, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.PluginNanos)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "owner_count"
+			o = append(o, 0xab, 0x6f, 0x77, 0x6e, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.OwnerCount)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "owner_ns"
+			o = append(o, 0xa8, 0x6f, 0x77, 0x6e, 0x65, 0x72, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.OwnerNanos)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "sts_count"
+			o = append(o, 0xa9, 0x73, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.STSCount)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "sts_ns"
+			o = append(o, 0xa6, 0x73, 0x74, 0x73, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.STSNanos)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "svcacct_count"
+			o = append(o, 0xad, 0x73, 0x76, 0x63, 0x61, 0x63, 0x63, 0x74, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.SvcAcctCount)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "svcacct_ns"
+			o = append(o, 0xaa, 0x73, 0x76, 0x63, 0x61, 0x63, 0x63, 0x74, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.SvcAcctNanos)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "user_count"
+			o = append(o, 0xaa, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.UserCount)
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "user_ns"
+			o = append(o, 0xa7, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.UserNanos)
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// string "max_ns"
+			o = append(o, 0xa6, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.MaxNanos)
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
+			// string "denied"
+			o = append(o, 0xa6, 0x64, 0x65, 0x6e, 0x69, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.Denied)
+		}
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
+			// string "errors"
+			o = append(o, 0xa6, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			o = msgp.AppendUint64(o, z.Errors)
+		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// string "cache_miss"
+			o = append(o, 0xaa, 0x63, 0x61, 0x63, 0x68, 0x65, 0x5f, 0x6d, 0x69, 0x73, 0x73)
+			o = msgp.AppendUint64(o, z.CacheMiss)
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// string "save_count"
+			o = append(o, 0xaa, 0x73, 0x61, 0x76, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.SaveCount)
+		}
+		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+			// string "save_ns"
+			o = append(o, 0xa7, 0x73, 0x61, 0x76, 0x65, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.SaveNanos)
+		}
+		if (zb0001Mask & 0x10000) == 0 { // if not omitted
+			// string "load_count"
+			o = append(o, 0xaa, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.LoadCount)
+		}
+		if (zb0001Mask & 0x20000) == 0 { // if not omitted
+			// string "load_ns"
+			o = append(o, 0xa7, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.LoadNanos)
+		}
+		if (zb0001Mask & 0x40000) == 0 { // if not omitted
+			// string "delete_count"
+			o = append(o, 0xac, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.DeleteCount)
+		}
+		if (zb0001Mask & 0x80000) == 0 { // if not omitted
+			// string "delete_ns"
+			o = append(o, 0xa9, 0x64, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.DeleteNanos)
+		}
+		if (zb0001Mask & 0x100000) == 0 { // if not omitted
+			// string "list_count"
+			o = append(o, 0xaa, 0x6c, 0x69, 0x73, 0x74, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.ListCount)
+		}
+		if (zb0001Mask & 0x200000) == 0 { // if not omitted
+			// string "list_ns"
+			o = append(o, 0xa7, 0x6c, 0x69, 0x73, 0x74, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.ListNanos)
+		}
+		if (zb0001Mask & 0x400000) == 0 { // if not omitted
+			// string "store_errors"
+			o = append(o, 0xac, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			o = msgp.AppendUint64(o, z.StoreErrors)
+		}
+		// string "n"
+		o = append(o, 0xa1, 0x6e)
+		o = msgp.AppendInt(o, z.N)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *IAMSegment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint32 /* 23 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "plugin_count":
+			z.PluginCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PluginCount")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "plugin_ns":
+			z.PluginNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PluginNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "owner_count":
+			z.OwnerCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerCount")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "owner_ns":
+			z.OwnerNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "OwnerNanos")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "sts_count":
+			z.STSCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "STSCount")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "sts_ns":
+			z.STSNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "STSNanos")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "svcacct_count":
+			z.SvcAcctCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctCount")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "svcacct_ns":
+			z.SvcAcctNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SvcAcctNanos")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "user_count":
+			z.UserCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UserCount")
+				return
+			}
+			zb0001Mask |= 0x100
+		case "user_ns":
+			z.UserNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UserNanos")
+				return
+			}
+			zb0001Mask |= 0x200
+		case "max_ns":
+			z.MaxNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+			zb0001Mask |= 0x400
+		case "denied":
+			z.Denied, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Denied")
+				return
+			}
+			zb0001Mask |= 0x800
+		case "errors":
+			z.Errors, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Errors")
+				return
+			}
+			zb0001Mask |= 0x1000
+		case "cache_miss":
+			z.CacheMiss, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CacheMiss")
+				return
+			}
+			zb0001Mask |= 0x2000
+		case "save_count":
+			z.SaveCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SaveCount")
+				return
+			}
+			zb0001Mask |= 0x4000
+		case "save_ns":
+			z.SaveNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SaveNanos")
+				return
+			}
+			zb0001Mask |= 0x8000
+		case "load_count":
+			z.LoadCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LoadCount")
+				return
+			}
+			zb0001Mask |= 0x10000
+		case "load_ns":
+			z.LoadNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LoadNanos")
+				return
+			}
+			zb0001Mask |= 0x20000
+		case "delete_count":
+			z.DeleteCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteCount")
+				return
+			}
+			zb0001Mask |= 0x40000
+		case "delete_ns":
+			z.DeleteNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DeleteNanos")
+				return
+			}
+			zb0001Mask |= 0x80000
+		case "list_count":
+			z.ListCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ListCount")
+				return
+			}
+			zb0001Mask |= 0x100000
+		case "list_ns":
+			z.ListNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ListNanos")
+				return
+			}
+			zb0001Mask |= 0x200000
+		case "store_errors":
+			z.StoreErrors, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "StoreErrors")
+				return
+			}
+			zb0001Mask |= 0x400000
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7fffff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.PluginCount = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.PluginNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.OwnerCount = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.OwnerNanos = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.STSCount = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.STSNanos = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.SvcAcctCount = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.SvcAcctNanos = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.UserCount = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.UserNanos = 0
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.MaxNanos = 0
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.Denied = 0
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.Errors = 0
+		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.CacheMiss = 0
+		}
+		if (zb0001Mask & 0x4000) == 0 {
+			z.SaveCount = 0
+		}
+		if (zb0001Mask & 0x8000) == 0 {
+			z.SaveNanos = 0
+		}
+		if (zb0001Mask & 0x10000) == 0 {
+			z.LoadCount = 0
+		}
+		if (zb0001Mask & 0x20000) == 0 {
+			z.LoadNanos = 0
+		}
+		if (zb0001Mask & 0x40000) == 0 {
+			z.DeleteCount = 0
+		}
+		if (zb0001Mask & 0x80000) == 0 {
+			z.DeleteNanos = 0
+		}
+		if (zb0001Mask & 0x100000) == 0 {
+			z.ListCount = 0
+		}
+		if (zb0001Mask & 0x200000) == 0 {
+			z.ListNanos = 0
+		}
+		if (zb0001Mask & 0x400000) == 0 {
+			z.StoreErrors = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *IAMSegment) Msgsize() (s int) {
+	s = 3 + 13 + msgp.Uint64Size + 10 + msgp.Uint64Size + 12 + msgp.Uint64Size + 9 + msgp.Uint64Size + 10 + msgp.Uint64Size + 7 + msgp.Uint64Size + 14 + msgp.Uint64Size + 11 + msgp.Uint64Size + 11 + msgp.Uint64Size + 8 + msgp.Uint64Size + 7 + msgp.Uint64Size + 7 + msgp.Uint64Size + 7 + msgp.Uint64Size + 11 + msgp.Uint64Size + 11 + msgp.Uint64Size + 8 + msgp.Uint64Size + 11 + msgp.Uint64Size + 8 + msgp.Uint64Size + 13 + msgp.Uint64Size + 10 + msgp.Uint64Size + 11 + msgp.Uint64Size + 8 + msgp.Uint64Size + 13 + msgp.Uint64Size + 2 + msgp.IntSize
 	return
 }

--- a/metrics-iam_gen_test.go
+++ b/metrics-iam_gen_test.go
@@ -9,6 +9,119 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+func TestMarshalUnmarshalIAMAuthStats(t *testing.T) {
+	v := IAMAuthStats{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIAMAuthStats(b *testing.B) {
+	v := IAMAuthStats{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIAMAuthStats(b *testing.B) {
+	v := IAMAuthStats{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIAMAuthStats(b *testing.B) {
+	v := IAMAuthStats{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIAMAuthStats(t *testing.T) {
+	v := IAMAuthStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeIAMAuthStats Msgsize() is inaccurate")
+	}
+
+	vn := IAMAuthStats{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIAMAuthStats(b *testing.B) {
+	v := IAMAuthStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIAMAuthStats(b *testing.B) {
+	v := IAMAuthStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalIAMCacheStats(t *testing.T) {
 	v := IAMCacheStats{}
 	bts, err := v.MarshalMsg(nil)
@@ -220,6 +333,119 @@ func BenchmarkEncodeIAMMetrics(b *testing.B) {
 
 func BenchmarkDecodeIAMMetrics(b *testing.B) {
 	v := IAMMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalIAMSegment(t *testing.T) {
+	v := IAMSegment{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgIAMSegment(b *testing.B) {
+	v := IAMSegment{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgIAMSegment(b *testing.B) {
+	v := IAMSegment{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalIAMSegment(b *testing.B) {
+	v := IAMSegment{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeIAMSegment(t *testing.T) {
+	v := IAMSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeIAMSegment Msgsize() is inaccurate")
+	}
+
+	vn := IAMSegment{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeIAMSegment(b *testing.B) {
+	v := IAMSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeIAMSegment(b *testing.B) {
+	v := IAMSegment{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/metrics-iam_test.go
+++ b/metrics-iam_test.go
@@ -1,0 +1,251 @@
+//
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+package madmin
+
+import (
+	"testing"
+	"time"
+)
+
+// The path names are the map keys on the wire and the field split in every
+// segment, so renaming one silently reattributes a series.
+func TestIAMPathNamesStable(t *testing.T) {
+	for _, tc := range []struct{ got, want string }{
+		{IAMPathPlugin, "plugin"},
+		{IAMPathOwner, "owner"},
+		{IAMPathSTS, "sts"},
+		{IAMPathSvcAcct, "svcacct"},
+		{IAMPathUser, "user"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("path name = %q, want %q", tc.got, tc.want)
+		}
+	}
+}
+
+// Every counter in a segment sums across nodes. The one exception is the
+// maximum, which takes the worst node: summing peaks would invent a latency no
+// request ever saw.
+func TestIAMSegmentAdd(t *testing.T) {
+	a := &IAMSegment{
+		UserCount: 10, UserNanos: 1000,
+		STSCount: 2, STSNanos: 800,
+		MaxNanos: 500,
+		Denied:   1, Errors: 2, CacheMiss: 3,
+		LoadCount: 1, LoadNanos: 90, StoreErrors: 1,
+		N: 1,
+	}
+	b := &IAMSegment{
+		UserCount: 5, UserNanos: 250,
+		PluginCount: 4, PluginNanos: 4000,
+		MaxNanos:  1500,
+		Denied:    2,
+		SaveCount: 3, SaveNanos: 300,
+		N: 1,
+	}
+
+	got := *a
+	got.Add(b)
+
+	if got.UserCount != 15 || got.UserNanos != 1250 {
+		t.Errorf("user = %d/%d, want 15/1250", got.UserCount, got.UserNanos)
+	}
+	if got.MaxNanos != 1500 {
+		t.Errorf("MaxNanos = %d, want 1500: the worst node's peak, not the sum", got.MaxNanos)
+	}
+	if got.Denied != 3 || got.Errors != 2 || got.CacheMiss != 3 {
+		t.Errorf("counters = %d/%d/%d, want 3/2/3", got.Denied, got.Errors, got.CacheMiss)
+	}
+	// A path only one node took survives rather than being lost.
+	if got.PluginCount != 4 || got.STSCount != 2 {
+		t.Errorf("a path only one node reported was lost: %+v", got)
+	}
+	if got.SaveCount != 3 || got.LoadCount != 1 || got.StoreErrors != 1 {
+		t.Errorf("store counters = %+v, want save 3 load 1 errors 1", got)
+	}
+	if got.N != 2 {
+		t.Errorf("N = %d, want 2", got.N)
+	}
+	// The argument is another node's report and must not be touched.
+	if b.UserCount != 5 || b.MaxNanos != 1500 {
+		t.Errorf("argument mutated: %+v", b)
+	}
+
+	got.Add(nil)
+	if got.UserCount != 15 {
+		t.Error("Add(nil) changed the receiver")
+	}
+}
+
+// The derived totals are what a renderer uses instead of adding ten fields by
+// hand, so they must cover every path.
+func TestIAMSegmentTotals(t *testing.T) {
+	s := IAMSegment{
+		PluginCount: 1, PluginNanos: 10,
+		OwnerCount: 2, OwnerNanos: 20,
+		STSCount: 3, STSNanos: 30,
+		SvcAcctCount: 4, SvcAcctNanos: 40,
+		UserCount: 5, UserNanos: 50,
+		SaveCount: 6, SaveNanos: 60,
+		LoadCount: 7, LoadNanos: 70,
+		DeleteCount: 8, DeleteNanos: 80,
+		ListCount: 9, ListNanos: 90,
+	}
+	if got := s.AuthCount(); got != 15 {
+		t.Errorf("AuthCount() = %d, want 15", got)
+	}
+	if got := s.AuthNanos(); got != 150 {
+		t.Errorf("AuthNanos() = %d, want 150", got)
+	}
+	if got := s.StoreCount(); got != 30 {
+		t.Errorf("StoreCount() = %d, want 30", got)
+	}
+	if got := s.StoreNanos(); got != 300 {
+		t.Errorf("StoreNanos() = %d, want 300", got)
+	}
+}
+
+func TestIAMAuthStatsMerge(t *testing.T) {
+	a := &IAMAuthStats{
+		ByPath: map[string]TimedAction{
+			IAMPathUser: {Count: 2, AccTime: 100, MinTime: 40, MaxTime: 60},
+		},
+		Denied: 1, CacheMiss: 4,
+	}
+	b := &IAMAuthStats{
+		ByPath: map[string]TimedAction{
+			IAMPathUser:   {Count: 1, AccTime: 900, MinTime: 900, MaxTime: 900},
+			IAMPathPlugin: {Count: 5, AccTime: 50_000, MinTime: 8000, MaxTime: 20_000},
+		},
+		Denied: 2, Errors: 3,
+	}
+
+	var got IAMAuthStats
+	got.Merge(a)
+	got.Merge(b)
+
+	user := got.ByPath[IAMPathUser]
+	if user.Count != 3 || user.MinTime != 40 || user.MaxTime != 900 {
+		t.Errorf("user = %+v, want count 3 with the extremes preserved", user)
+	}
+	if got.ByPath[IAMPathPlugin].Count != 5 {
+		t.Errorf("a path only one node took was lost: %+v", got.ByPath)
+	}
+	if got.Denied != 3 || got.Errors != 3 || got.CacheMiss != 4 {
+		t.Errorf("counters = %d/%d/%d, want 3/3/4", got.Denied, got.Errors, got.CacheMiss)
+	}
+	// Merge is handed another node's report, so its maps must survive.
+	if a.ByPath[IAMPathUser].Count != 2 {
+		t.Errorf("argument mutated: %+v", a.ByPath)
+	}
+
+	got.Merge(nil)
+	if got.Denied != 3 {
+		t.Error("Merge(nil) changed the receiver")
+	}
+}
+
+func TestIAMMetricsMergeWindows(t *testing.T) {
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+	a := &IAMMetrics{
+		Nodes:    1,
+		LastHour: iamWindow(t0, IAMSegment{N: 1, UserCount: 10, UserNanos: 500, MaxNanos: 90}),
+		LastDay:  iamWindow(t0, IAMSegment{N: 1, LoadCount: 1, LoadNanos: 40}),
+	}
+	b := &IAMMetrics{
+		Nodes:    1,
+		LastHour: iamWindow(t0, IAMSegment{N: 1, UserCount: 4, UserNanos: 200, MaxNanos: 700}),
+		LastDay:  iamWindow(t0, IAMSegment{N: 1, LoadCount: 2, LoadNanos: 80}),
+	}
+
+	var got IAMMetrics
+	got.Merge(a)
+	got.Merge(b)
+
+	if tot := got.LastHour.Total(); tot.UserCount != 14 || tot.UserNanos != 700 {
+		t.Errorf("hour total = %+v, want 14 authorizations over 700ns", tot)
+	}
+	if tot := got.LastHour.Total(); tot.MaxNanos != 700 {
+		t.Errorf("hour MaxNanos = %d, want 700", tot.MaxNanos)
+	}
+	if tot := got.LastDay.Total(); tot.LoadCount != 3 || tot.LoadNanos != 120 {
+		t.Errorf("day total = %+v, want 3 loads over 120ns", tot)
+	}
+	if a.LastHour.Total().UserCount != 10 {
+		t.Errorf("argument mutated: %+v", a.LastHour)
+	}
+}
+
+// A window a node was asked for but has nothing in yet is non-nil with no
+// segments. The merge must keep it: dropping it makes the result indistinguishable
+// from a window nobody requested, which is a different answer.
+func TestIAMMetricsMergeKeepsEmptyRequestedWindow(t *testing.T) {
+	requestedButEmpty := &IAMMetrics{
+		Nodes:    1,
+		LastHour: &SegmentedIAMMetrics{Interval: 60},
+	}
+	var got IAMMetrics
+	got.Merge(requestedButEmpty)
+
+	if got.LastHour == nil {
+		t.Fatal("a requested-but-empty window was dropped, so it now reads as not requested")
+	}
+	if len(got.LastHour.Segments) != 0 {
+		t.Errorf("segments = %d, want 0", len(got.LastHour.Segments))
+	}
+
+	// And a node that did have data must still merge into it.
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	got.Merge(&IAMMetrics{
+		Nodes:    1,
+		LastHour: iamWindow(t0, IAMSegment{N: 1, OwnerCount: 3}),
+	})
+	if tot := got.LastHour.Total(); tot.OwnerCount != 3 {
+		t.Errorf("hour total = %+v, want the later node's 3 authorizations", tot)
+	}
+}
+
+func TestIAMMetricsMergeAuthAndNil(t *testing.T) {
+	full := &IAMMetrics{
+		Nodes: 1,
+		Auth: &IAMAuthStats{
+			ByPath: map[string]TimedAction{IAMPathOwner: {Count: 7, AccTime: 70}},
+			Denied: 1,
+		},
+	}
+	var got IAMMetrics
+	got.Merge(full)
+	got.Merge(&IAMMetrics{})
+	got.Merge(nil)
+
+	if got.Auth == nil || got.Auth.ByPath[IAMPathOwner].Count != 7 || got.Auth.Denied != 1 {
+		t.Errorf("a node reporting nothing blanked a real report: %+v", got.Auth)
+	}
+}
+
+// iamWindow is one node's IAM report: a single segment on the minute grid.
+func iamWindow(first time.Time, seg IAMSegment) *SegmentedIAMMetrics {
+	return &SegmentedIAMMetrics{
+		Interval:  60,
+		FirstTime: first,
+		Segments:  []IAMSegment{seg},
+	}
+}

--- a/metrics-locks.go
+++ b/metrics-locks.go
@@ -24,33 +24,79 @@ import "time"
 //go:generate go tool msgp -unexported -d clearomitted -d "tag json" -d "timezone utc" -d "maps binkeys" -file $GOFILE
 
 // LockMetrics is the state of this cluster's distributed locking.
+//
+// Three time bases live here, and which one a field uses is stated on the field.
+// No value is cumulative since process start: a lifetime counter needs two
+// collections before it says anything, and resets invisibly on restart.
+//
+//   - Instantaneous, read live at collection: Resources, Waiting.
+//   - Sliding last minute, from in-memory accumulators, never persisted:
+//     Acquire, Held, Release, AcquireFailed, TimedOut, Conflicts, Canceled,
+//     ServerLatency.
+//   - Segmented windows, persisted across restarts: LastHour, LastDay. These are
+//     also the only place the rarer events appear -- rejections, lease expiries
+//     and quorum losses -- because they are far too infrequent to show up in a
+//     one-minute view.
 type LockMetrics struct {
 	CollectedAt time.Time `json:"collected"`
 
 	Nodes int `json:"nodes"`
 
-	// Resources counts distinct resources with a lock held, not locks -- one resource
-	// can carry many readers -- so it is not comparable with Purge's reader and
-	// writer counts.
+	// Resources counts distinct resources with a lock held right now, not locks --
+	// one resource can carry many readers -- so it is not comparable with Purge's
+	// reader and writer counts.
 	Resources int64 `json:"resources,omitempty"`
 
-	// Waiting is goroutines blocked on acquisition; Rejected is acquisitions refused
-	// at the wait limit. Rising Rejected means contention has become a throughput
-	// problem.
-	Waiting  int64  `json:"waiting,omitempty"`
-	Rejected uint64 `json:"rejected,omitempty"`
+	// Waiting is goroutines blocked on acquisition right now.
+	Waiting int64 `json:"waiting,omitempty"`
 
-	// ExpiredTotal is a monotonic count of locks reclaimed on lease expiry, meaning a
-	// holder died or was partitioned away.
-	ExpiredTotal uint64 `json:"expired_total,omitempty"`
+	// Acquire is how long callers on this node waited before being granted a lock,
+	// over the last minute -- the question a lock subsystem exists to answer. It
+	// spans the whole acquisition, so it includes every retry and distributed
+	// round-trip. Attempts that never got the lock are in AcquireFailed instead, so
+	// AccTime/Count is the mean wait of a caller that did get it.
+	Acquire LockOpStats `json:"acquire,omitzero"`
 
-	// QuorumLost counts locks force-released after a refresh missed quorum: this node
-	// giving up on a lock it holds, as opposed to reclaiming one a peer abandoned.
-	QuorumLost uint64 `json:"quorum_lost,omitempty"`
+	// AcquireFailed is the attempts that never got the lock, over the last minute.
+	// Count is how many and AccTime is the waiting they did before giving up, which
+	// is work the cluster paid for and threw away. Why they failed is split across
+	// TimedOut, Conflicts and Canceled.
+	AcquireFailed LockOpStats `json:"acquire_failed,omitzero"`
+
+	// TimedOut, Conflicts and Canceled break AcquireFailed down by cause, over the
+	// same last minute: gave up waiting, refused at once because the caller would
+	// not block, and ended because the caller's own context did. Only Conflicts is
+	// routine under load. They sum to AcquireFailed's total count.
+	TimedOut  uint64 `json:"timed_out,omitempty"`
+	Conflicts uint64 `json:"conflicts,omitempty"`
+	Canceled  uint64 `json:"canceled,omitempty"`
+
+	// Held is how long a granted lock stayed held before its holder released it,
+	// over the last minute. This is the input side of contention: a lock held long
+	// makes every waiter wait. Counted once per lock on the node that took it, so
+	// unlike Resources it does not scale with the number of servers a lock is
+	// replicated to.
+	Held LockOpStats `json:"held,omitzero"`
+
+	// Release is how long releasing took, measured from the moment the hold ended,
+	// so Held and Release do not overlap and together span the lock's life. Near
+	// zero for plain distributed locks, which release fire-and-forget; real for the
+	// bulk and coalesced paths, which wait for their release RPCs.
+	Release LockOpStats `json:"release,omitzero"`
+
+	// ServerLatency is what this node's own lock servers cost to talk to, as opposed
+	// to what its callers waited.
+	ServerLatency LockServerLatency `json:"server_latency,omitzero"`
 
 	// Purge is sampled by the periodic cleanup pass rather than read live, so it has
 	// its own timestamp and Readers+Writers does not reconcile with Resources.
 	Purge *LockPurgeStats `json:"purge,omitempty"`
+
+	// LastDay is 96 x 15-minute segments, requested with the DayStats flag.
+	LastDay *SegmentedLockMetrics `json:"lastDay,omitempty"`
+
+	// LastHour is 60 x 1-minute segments, requested with the HourStats flag.
+	LastHour *SegmentedLockMetrics `json:"lastHour,omitempty"`
 }
 
 // Merge other into l.
@@ -64,14 +110,31 @@ func (l *LockMetrics) Merge(other *LockMetrics) {
 	}
 	l.Resources += other.Resources
 	l.Waiting += other.Waiting
-	l.Rejected += other.Rejected
-	l.ExpiredTotal += other.ExpiredTotal
-	l.QuorumLost += other.QuorumLost
+	l.TimedOut += other.TimedOut
+	l.Conflicts += other.Conflicts
+	l.Canceled += other.Canceled
+	l.Acquire.Merge(other.Acquire)
+	l.AcquireFailed.Merge(other.AcquireFailed)
+	l.Held.Merge(other.Held)
+	l.Release.Merge(other.Release)
+	l.ServerLatency.Merge(other.ServerLatency)
 	if other.Purge != nil {
 		if l.Purge == nil {
 			l.Purge = new(LockPurgeStats)
 		}
 		l.Purge.Merge(other.Purge)
+	}
+	if other.LastDay != nil {
+		if l.LastDay == nil {
+			l.LastDay = new(SegmentedLockMetrics)
+		}
+		l.LastDay.Add(other.LastDay)
+	}
+	if other.LastHour != nil {
+		if l.LastHour == nil {
+			l.LastHour = new(SegmentedLockMetrics)
+		}
+		l.LastHour.Add(other.LastHour)
 	}
 }
 
@@ -108,4 +171,117 @@ func (p *LockPurgeStats) Merge(other *LockPurgeStats) {
 	if !other.OldestHeldAt.IsZero() && (p.OldestHeldAt.IsZero() || other.OldestHeldAt.Before(p.OldestHeldAt)) {
 		p.OldestHeldAt = other.OldestHeldAt
 	}
+}
+
+// LockOpStats is one lock timing split by lock kind. Readers share a resource
+// while writers exclude each other, so they queue for different reasons and a
+// combined figure hides which of the two is slow.
+type LockOpStats struct {
+	Read  TimedAction `json:"read,omitempty"`
+	Write TimedAction `json:"write,omitempty"`
+}
+
+// IsZero reports whether nothing has been recorded, for omitzero.
+func (s LockOpStats) IsZero() bool { return s.Read.Count == 0 && s.Write.Count == 0 }
+
+// Count is the combined number of operations recorded.
+func (s LockOpStats) Count() uint64 { return s.Read.Count + s.Write.Count }
+
+// Merge other into s.
+func (s *LockOpStats) Merge(other LockOpStats) {
+	s.Read.Merge(other.Read)
+	s.Write.Merge(other.Write)
+}
+
+// LockServerLatency is how long this node's own lock servers took to service lock
+// RPCs over the last minute, across every operation type. It is the locker's own
+// cost; what a caller waited for a lock is LockMetrics.Acquire.
+//
+// An average and a maximum rather than a TimedAction: the underlying accumulator
+// keeps one sample per one-second slot and discards the rest, so a sample count
+// would be fabricated.
+type LockServerLatency struct {
+	// N is contributing lock servers, so AvgSumNanos divided by N is the mean.
+	N int `json:"n,omitempty"`
+
+	AvgSumNanos uint64 `json:"avg_sum_nanos,omitempty"`
+	MaxNanos    uint64 `json:"max_nanos,omitempty"`
+}
+
+// IsZero reports whether nothing has been recorded, for omitzero.
+func (l LockServerLatency) IsZero() bool { return l.N == 0 }
+
+// Merge other into l. Averages sum against N; the maximum takes the worst server,
+// so one slow lock server stays visible.
+func (l *LockServerLatency) Merge(other LockServerLatency) {
+	if other.N == 0 {
+		return
+	}
+	l.N += other.N
+	l.AvgSumNanos += other.AvgSumNanos
+	l.MaxNanos = max(l.MaxNanos, other.MaxNanos)
+}
+
+// SegmentedLockMetrics is a time-segmented view of locking activity.
+type SegmentedLockMetrics = Segmented[LockSegment, *LockSegment]
+
+// LockSegment is locking activity over one time segment.
+//
+// Every field is a plain sum over the segment, so segments merge across nodes and
+// rescale to a coarser interval by addition. Reads and writes are combined: the
+// split belongs to the live view, where it is one object rather than 156.
+//
+// Instantaneous gauges are absent -- resource and waiter counts are samples, and
+// summing samples over a segment means nothing.
+type LockSegment struct {
+	// AcquireCount is locks granted in the segment and AcquireNanos their summed
+	// wait, so the mean wait is AcquireNanos/AcquireCount and the grant rate is
+	// AcquireCount over the interval.
+	AcquireCount uint64 `json:"acquire_count,omitempty"`
+	AcquireNanos uint64 `json:"acquire_ns,omitempty"`
+
+	// AcquireFailed is attempts that never got the lock, all causes, and
+	// AcquireFailedNanos the waiting they wasted.
+	AcquireFailed      uint64 `json:"acquire_failed,omitempty"`
+	AcquireFailedNanos uint64 `json:"acquire_failed_ns,omitempty"`
+
+	HeldCount uint64 `json:"held_count,omitempty"`
+	HeldNanos uint64 `json:"held_ns,omitempty"`
+
+	ReleaseCount uint64 `json:"release_count,omitempty"`
+	ReleaseNanos uint64 `json:"release_ns,omitempty"`
+
+	// Rejected is acquisitions refused at a lock server's wait limit, Expired is
+	// locks reclaimed on lease expiry -- a holder died or was partitioned away --
+	// and QuorumLost is locks this node gave up after a refresh missed quorum. All
+	// three are rare enough that a segmented history is the only place they show.
+	//
+	// The first two are counted once per shard, not once per server in it, so they
+	// are on the same scale as the live Purge block and as AcquireFailed rather than
+	// multiplied by the shard's drive count.
+	Rejected   uint64 `json:"rejected,omitempty"`
+	Expired    uint64 `json:"expired,omitempty"`
+	QuorumLost uint64 `json:"quorum_lost,omitempty"`
+
+	// N is contributing nodes.
+	N int `json:"n"`
+}
+
+// Add other into s.
+func (s *LockSegment) Add(other *LockSegment) {
+	if other == nil {
+		return
+	}
+	s.AcquireCount += other.AcquireCount
+	s.AcquireNanos += other.AcquireNanos
+	s.AcquireFailed += other.AcquireFailed
+	s.AcquireFailedNanos += other.AcquireFailedNanos
+	s.HeldCount += other.HeldCount
+	s.HeldNanos += other.HeldNanos
+	s.ReleaseCount += other.ReleaseCount
+	s.ReleaseNanos += other.ReleaseNanos
+	s.Rejected += other.Rejected
+	s.Expired += other.Expired
+	s.QuorumLost += other.QuorumLost
+	s.N += other.N
 }

--- a/metrics-locks_gen.go
+++ b/metrics-locks_gen.go
@@ -18,7 +18,7 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 6 bits */
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -54,27 +54,282 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x2
-		case "rejected":
-			z.Rejected, err = dc.ReadUint64()
+		case "acquire":
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
-				err = msgp.WrapError(err, "Rejected")
+				err = msgp.WrapError(err, "Acquire")
 				return
+			}
+			var zb0002Mask uint8 /* 2 bits */
+			_ = zb0002Mask
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					err = z.Acquire.Read.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire", "Read")
+						return
+					}
+					zb0002Mask |= 0x1
+				case "write":
+					err = z.Acquire.Write.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire", "Write")
+						return
+					}
+					zb0002Mask |= 0x2
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0002Mask != 0x3 {
+				if (zb0002Mask & 0x1) == 0 {
+					z.Acquire.Read = TimedAction{}
+				}
+				if (zb0002Mask & 0x2) == 0 {
+					z.Acquire.Write = TimedAction{}
+				}
 			}
 			zb0001Mask |= 0x4
-		case "expired_total":
-			z.ExpiredTotal, err = dc.ReadUint64()
+		case "acquire_failed":
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
-				err = msgp.WrapError(err, "ExpiredTotal")
+				err = msgp.WrapError(err, "AcquireFailed")
 				return
 			}
+			var zb0003Mask uint8 /* 2 bits */
+			_ = zb0003Mask
+			for zb0003 > 0 {
+				zb0003--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					err = z.AcquireFailed.Read.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed", "Read")
+						return
+					}
+					zb0003Mask |= 0x1
+				case "write":
+					err = z.AcquireFailed.Write.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed", "Write")
+						return
+					}
+					zb0003Mask |= 0x2
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0003Mask != 0x3 {
+				if (zb0003Mask & 0x1) == 0 {
+					z.AcquireFailed.Read = TimedAction{}
+				}
+				if (zb0003Mask & 0x2) == 0 {
+					z.AcquireFailed.Write = TimedAction{}
+				}
+			}
 			zb0001Mask |= 0x8
-		case "quorum_lost":
-			z.QuorumLost, err = dc.ReadUint64()
+		case "timed_out":
+			z.TimedOut, err = dc.ReadUint64()
 			if err != nil {
-				err = msgp.WrapError(err, "QuorumLost")
+				err = msgp.WrapError(err, "TimedOut")
 				return
 			}
 			zb0001Mask |= 0x10
+		case "conflicts":
+			z.Conflicts, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Conflicts")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "canceled":
+			z.Canceled, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Canceled")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "held":
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Held")
+				return
+			}
+			var zb0004Mask uint8 /* 2 bits */
+			_ = zb0004Mask
+			for zb0004 > 0 {
+				zb0004--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Held")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					err = z.Held.Read.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Held", "Read")
+						return
+					}
+					zb0004Mask |= 0x1
+				case "write":
+					err = z.Held.Write.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Held", "Write")
+						return
+					}
+					zb0004Mask |= 0x2
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Held")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0004Mask != 0x3 {
+				if (zb0004Mask & 0x1) == 0 {
+					z.Held.Read = TimedAction{}
+				}
+				if (zb0004Mask & 0x2) == 0 {
+					z.Held.Write = TimedAction{}
+				}
+			}
+			zb0001Mask |= 0x80
+		case "release":
+			var zb0005 uint32
+			zb0005, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Release")
+				return
+			}
+			var zb0005Mask uint8 /* 2 bits */
+			_ = zb0005Mask
+			for zb0005 > 0 {
+				zb0005--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Release")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					err = z.Release.Read.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Release", "Read")
+						return
+					}
+					zb0005Mask |= 0x1
+				case "write":
+					err = z.Release.Write.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Release", "Write")
+						return
+					}
+					zb0005Mask |= 0x2
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Release")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0005Mask != 0x3 {
+				if (zb0005Mask & 0x1) == 0 {
+					z.Release.Read = TimedAction{}
+				}
+				if (zb0005Mask & 0x2) == 0 {
+					z.Release.Write = TimedAction{}
+				}
+			}
+			zb0001Mask |= 0x100
+		case "server_latency":
+			var zb0006 uint32
+			zb0006, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "ServerLatency")
+				return
+			}
+			var zb0006Mask uint8 /* 3 bits */
+			_ = zb0006Mask
+			for zb0006 > 0 {
+				zb0006--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "ServerLatency")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "n":
+					z.ServerLatency.N, err = dc.ReadInt()
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "N")
+						return
+					}
+					zb0006Mask |= 0x1
+				case "avg_sum_nanos":
+					z.ServerLatency.AvgSumNanos, err = dc.ReadUint64()
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "AvgSumNanos")
+						return
+					}
+					zb0006Mask |= 0x2
+				case "max_nanos":
+					z.ServerLatency.MaxNanos, err = dc.ReadUint64()
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "MaxNanos")
+						return
+					}
+					zb0006Mask |= 0x4
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0006Mask != 0x7 {
+				if (zb0006Mask & 0x1) == 0 {
+					z.ServerLatency.N = 0
+				}
+				if (zb0006Mask & 0x2) == 0 {
+					z.ServerLatency.AvgSumNanos = 0
+				}
+				if (zb0006Mask & 0x4) == 0 {
+					z.ServerLatency.MaxNanos = 0
+				}
+			}
+			zb0001Mask |= 0x200
 		case "purge":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -93,7 +348,45 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x400
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedLockMetrics)
+				}
+				err = (*Segmented[LockSegment, *LockSegment])(z.LastDay).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x800
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedLockMetrics)
+				}
+				err = (*Segmented[LockSegment, *LockSegment])(z.LastHour).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x1000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -103,7 +396,7 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3f {
+	if zb0001Mask != 0x1fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Resources = 0
 		}
@@ -111,16 +404,37 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.Waiting = 0
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.Rejected = 0
+			z.Acquire = (LockOpStats{})
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.ExpiredTotal = 0
+			z.AcquireFailed = (LockOpStats{})
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.QuorumLost = 0
+			z.TimedOut = 0
 		}
 		if (zb0001Mask & 0x20) == 0 {
+			z.Conflicts = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.Canceled = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.Held = (LockOpStats{})
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.Release = (LockOpStats{})
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.ServerLatency = (LockServerLatency{})
+		}
+		if (zb0001Mask & 0x400) == 0 {
 			z.Purge = nil
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.LastHour = nil
 		}
 	}
 	return
@@ -129,8 +443,8 @@ func (z *LockMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *LockMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(8)
-	var zb0001Mask uint8 /* 8 bits */
+	zb0001Len := uint32(15)
+	var zb0001Mask uint16 /* 15 bits */
 	_ = zb0001Mask
 	if z.Resources == 0 {
 		zb0001Len--
@@ -140,21 +454,49 @@ func (z *LockMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.Rejected == 0 {
+	if z.Acquire.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.ExpiredTotal == 0 {
+	if z.AcquireFailed.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.QuorumLost == 0 {
+	if z.TimedOut == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.Purge == nil {
+	if z.Conflicts == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
+	}
+	if z.Canceled == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.Held.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.Release.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.ServerLatency.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.Purge == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1000
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4000
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -209,42 +551,270 @@ func (z *LockMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// write "rejected"
-			err = en.Append(0xa8, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65, 0x64)
+			// write "acquire"
+			err = en.Append(0xa7, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65)
 			if err != nil {
 				return
 			}
-			err = en.WriteUint64(z.Rejected)
+			// check for omitted fields
+			zb0002Len := uint32(2)
+			var zb0002Mask uint8 /* 2 bits */
+			_ = zb0002Mask
+			// variable map header, size zb0002Len
+			err = en.Append(0x80 | uint8(zb0002Len))
 			if err != nil {
-				err = msgp.WrapError(err, "Rejected")
 				return
+			}
+
+			// skip if no fields are to be emitted
+			if zb0002Len != 0 {
+				// write "read"
+				err = en.Append(0xa4, 0x72, 0x65, 0x61, 0x64)
+				if err != nil {
+					return
+				}
+				err = z.Acquire.Read.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire", "Read")
+					return
+				}
+				// write "write"
+				err = en.Append(0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				if err != nil {
+					return
+				}
+				err = z.Acquire.Write.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire", "Write")
+					return
+				}
 			}
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// write "expired_total"
-			err = en.Append(0xad, 0x65, 0x78, 0x70, 0x69, 0x72, 0x65, 0x64, 0x5f, 0x74, 0x6f, 0x74, 0x61, 0x6c)
+			// write "acquire_failed"
+			err = en.Append(0xae, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
 			if err != nil {
 				return
 			}
-			err = en.WriteUint64(z.ExpiredTotal)
+			// check for omitted fields
+			zb0003Len := uint32(2)
+			var zb0003Mask uint8 /* 2 bits */
+			_ = zb0003Mask
+			// variable map header, size zb0003Len
+			err = en.Append(0x80 | uint8(zb0003Len))
 			if err != nil {
-				err = msgp.WrapError(err, "ExpiredTotal")
 				return
+			}
+
+			// skip if no fields are to be emitted
+			if zb0003Len != 0 {
+				// write "read"
+				err = en.Append(0xa4, 0x72, 0x65, 0x61, 0x64)
+				if err != nil {
+					return
+				}
+				err = z.AcquireFailed.Read.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed", "Read")
+					return
+				}
+				// write "write"
+				err = en.Append(0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				if err != nil {
+					return
+				}
+				err = z.AcquireFailed.Write.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed", "Write")
+					return
+				}
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// write "quorum_lost"
-			err = en.Append(0xab, 0x71, 0x75, 0x6f, 0x72, 0x75, 0x6d, 0x5f, 0x6c, 0x6f, 0x73, 0x74)
+			// write "timed_out"
+			err = en.Append(0xa9, 0x74, 0x69, 0x6d, 0x65, 0x64, 0x5f, 0x6f, 0x75, 0x74)
 			if err != nil {
 				return
 			}
-			err = en.WriteUint64(z.QuorumLost)
+			err = en.WriteUint64(z.TimedOut)
 			if err != nil {
-				err = msgp.WrapError(err, "QuorumLost")
+				err = msgp.WrapError(err, "TimedOut")
 				return
 			}
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "conflicts"
+			err = en.Append(0xa9, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Conflicts)
+			if err != nil {
+				err = msgp.WrapError(err, "Conflicts")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "canceled"
+			err = en.Append(0xa8, 0x63, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Canceled)
+			if err != nil {
+				err = msgp.WrapError(err, "Canceled")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "held"
+			err = en.Append(0xa4, 0x68, 0x65, 0x6c, 0x64)
+			if err != nil {
+				return
+			}
+			// check for omitted fields
+			zb0004Len := uint32(2)
+			var zb0004Mask uint8 /* 2 bits */
+			_ = zb0004Mask
+			// variable map header, size zb0004Len
+			err = en.Append(0x80 | uint8(zb0004Len))
+			if err != nil {
+				return
+			}
+
+			// skip if no fields are to be emitted
+			if zb0004Len != 0 {
+				// write "read"
+				err = en.Append(0xa4, 0x72, 0x65, 0x61, 0x64)
+				if err != nil {
+					return
+				}
+				err = z.Held.Read.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Held", "Read")
+					return
+				}
+				// write "write"
+				err = en.Append(0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				if err != nil {
+					return
+				}
+				err = z.Held.Write.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Held", "Write")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// write "release"
+			err = en.Append(0xa7, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65)
+			if err != nil {
+				return
+			}
+			// check for omitted fields
+			zb0005Len := uint32(2)
+			var zb0005Mask uint8 /* 2 bits */
+			_ = zb0005Mask
+			// variable map header, size zb0005Len
+			err = en.Append(0x80 | uint8(zb0005Len))
+			if err != nil {
+				return
+			}
+
+			// skip if no fields are to be emitted
+			if zb0005Len != 0 {
+				// write "read"
+				err = en.Append(0xa4, 0x72, 0x65, 0x61, 0x64)
+				if err != nil {
+					return
+				}
+				err = z.Release.Read.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Release", "Read")
+					return
+				}
+				// write "write"
+				err = en.Append(0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				if err != nil {
+					return
+				}
+				err = z.Release.Write.EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "Release", "Write")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
+			// write "server_latency"
+			err = en.Append(0xae, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x6c, 0x61, 0x74, 0x65, 0x6e, 0x63, 0x79)
+			if err != nil {
+				return
+			}
+			// check for omitted fields
+			zb0006Len := uint32(3)
+			var zb0006Mask uint8 /* 3 bits */
+			_ = zb0006Mask
+			if z.ServerLatency.N == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x1
+			}
+			if z.ServerLatency.AvgSumNanos == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x2
+			}
+			if z.ServerLatency.MaxNanos == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x4
+			}
+			// variable map header, size zb0006Len
+			err = en.Append(0x80 | uint8(zb0006Len))
+			if err != nil {
+				return
+			}
+
+			// skip if no fields are to be emitted
+			if zb0006Len != 0 {
+				if (zb0006Mask & 0x1) == 0 { // if not omitted
+					// write "n"
+					err = en.Append(0xa1, 0x6e)
+					if err != nil {
+						return
+					}
+					err = en.WriteInt(z.ServerLatency.N)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "N")
+						return
+					}
+				}
+				if (zb0006Mask & 0x2) == 0 { // if not omitted
+					// write "avg_sum_nanos"
+					err = en.Append(0xad, 0x61, 0x76, 0x67, 0x5f, 0x73, 0x75, 0x6d, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+					if err != nil {
+						return
+					}
+					err = en.WriteUint64(z.ServerLatency.AvgSumNanos)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "AvgSumNanos")
+						return
+					}
+				}
+				if (zb0006Mask & 0x4) == 0 { // if not omitted
+					// write "max_nanos"
+					err = en.Append(0xa9, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+					if err != nil {
+						return
+					}
+					err = en.WriteUint64(z.ServerLatency.MaxNanos)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "MaxNanos")
+						return
+					}
+				}
+			}
+		}
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// write "purge"
 			err = en.Append(0xa5, 0x70, 0x75, 0x72, 0x67, 0x65)
 			if err != nil {
@@ -263,6 +833,44 @@ func (z *LockMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[LockSegment, *LockSegment])(z.LastDay).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[LockSegment, *LockSegment])(z.LastHour).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -271,8 +879,8 @@ func (z *LockMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *LockMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(8)
-	var zb0001Mask uint8 /* 8 bits */
+	zb0001Len := uint32(15)
+	var zb0001Mask uint16 /* 15 bits */
 	_ = zb0001Mask
 	if z.Resources == 0 {
 		zb0001Len--
@@ -282,21 +890,49 @@ func (z *LockMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.Rejected == 0 {
+	if z.Acquire.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.ExpiredTotal == 0 {
+	if z.AcquireFailed.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.QuorumLost == 0 {
+	if z.TimedOut == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.Purge == nil {
+	if z.Conflicts == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
+	}
+	if z.Canceled == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.Held.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.Release.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	if z.ServerLatency.IsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x800
+	}
+	if z.Purge == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1000
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x2000
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -320,21 +956,174 @@ func (z *LockMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendInt64(o, z.Waiting)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
-			// string "rejected"
-			o = append(o, 0xa8, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65, 0x64)
-			o = msgp.AppendUint64(o, z.Rejected)
+			// string "acquire"
+			o = append(o, 0xa7, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65)
+			// check for omitted fields
+			zb0002Len := uint32(2)
+			var zb0002Mask uint8 /* 2 bits */
+			_ = zb0002Mask
+			// variable map header, size zb0002Len
+			o = append(o, 0x80|uint8(zb0002Len))
+
+			// skip if no fields are to be emitted
+			if zb0002Len != 0 {
+				// string "read"
+				o = append(o, 0xa4, 0x72, 0x65, 0x61, 0x64)
+				o, err = z.Acquire.Read.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire", "Read")
+					return
+				}
+				// string "write"
+				o = append(o, 0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				o, err = z.Acquire.Write.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire", "Write")
+					return
+				}
+			}
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not omitted
-			// string "expired_total"
-			o = append(o, 0xad, 0x65, 0x78, 0x70, 0x69, 0x72, 0x65, 0x64, 0x5f, 0x74, 0x6f, 0x74, 0x61, 0x6c)
-			o = msgp.AppendUint64(o, z.ExpiredTotal)
+			// string "acquire_failed"
+			o = append(o, 0xae, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			// check for omitted fields
+			zb0003Len := uint32(2)
+			var zb0003Mask uint8 /* 2 bits */
+			_ = zb0003Mask
+			// variable map header, size zb0003Len
+			o = append(o, 0x80|uint8(zb0003Len))
+
+			// skip if no fields are to be emitted
+			if zb0003Len != 0 {
+				// string "read"
+				o = append(o, 0xa4, 0x72, 0x65, 0x61, 0x64)
+				o, err = z.AcquireFailed.Read.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed", "Read")
+					return
+				}
+				// string "write"
+				o = append(o, 0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				o, err = z.AcquireFailed.Write.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed", "Write")
+					return
+				}
+			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// string "quorum_lost"
-			o = append(o, 0xab, 0x71, 0x75, 0x6f, 0x72, 0x75, 0x6d, 0x5f, 0x6c, 0x6f, 0x73, 0x74)
-			o = msgp.AppendUint64(o, z.QuorumLost)
+			// string "timed_out"
+			o = append(o, 0xa9, 0x74, 0x69, 0x6d, 0x65, 0x64, 0x5f, 0x6f, 0x75, 0x74)
+			o = msgp.AppendUint64(o, z.TimedOut)
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "conflicts"
+			o = append(o, 0xa9, 0x63, 0x6f, 0x6e, 0x66, 0x6c, 0x69, 0x63, 0x74, 0x73)
+			o = msgp.AppendUint64(o, z.Conflicts)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "canceled"
+			o = append(o, 0xa8, 0x63, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.Canceled)
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "held"
+			o = append(o, 0xa4, 0x68, 0x65, 0x6c, 0x64)
+			// check for omitted fields
+			zb0004Len := uint32(2)
+			var zb0004Mask uint8 /* 2 bits */
+			_ = zb0004Mask
+			// variable map header, size zb0004Len
+			o = append(o, 0x80|uint8(zb0004Len))
+
+			// skip if no fields are to be emitted
+			if zb0004Len != 0 {
+				// string "read"
+				o = append(o, 0xa4, 0x72, 0x65, 0x61, 0x64)
+				o, err = z.Held.Read.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Held", "Read")
+					return
+				}
+				// string "write"
+				o = append(o, 0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				o, err = z.Held.Write.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Held", "Write")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// string "release"
+			o = append(o, 0xa7, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65)
+			// check for omitted fields
+			zb0005Len := uint32(2)
+			var zb0005Mask uint8 /* 2 bits */
+			_ = zb0005Mask
+			// variable map header, size zb0005Len
+			o = append(o, 0x80|uint8(zb0005Len))
+
+			// skip if no fields are to be emitted
+			if zb0005Len != 0 {
+				// string "read"
+				o = append(o, 0xa4, 0x72, 0x65, 0x61, 0x64)
+				o, err = z.Release.Read.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Release", "Read")
+					return
+				}
+				// string "write"
+				o = append(o, 0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+				o, err = z.Release.Write.MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "Release", "Write")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not omitted
+			// string "server_latency"
+			o = append(o, 0xae, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x6c, 0x61, 0x74, 0x65, 0x6e, 0x63, 0x79)
+			// check for omitted fields
+			zb0006Len := uint32(3)
+			var zb0006Mask uint8 /* 3 bits */
+			_ = zb0006Mask
+			if z.ServerLatency.N == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x1
+			}
+			if z.ServerLatency.AvgSumNanos == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x2
+			}
+			if z.ServerLatency.MaxNanos == 0 {
+				zb0006Len--
+				zb0006Mask |= 0x4
+			}
+			// variable map header, size zb0006Len
+			o = append(o, 0x80|uint8(zb0006Len))
+
+			// skip if no fields are to be emitted
+			if zb0006Len != 0 {
+				if (zb0006Mask & 0x1) == 0 { // if not omitted
+					// string "n"
+					o = append(o, 0xa1, 0x6e)
+					o = msgp.AppendInt(o, z.ServerLatency.N)
+				}
+				if (zb0006Mask & 0x2) == 0 { // if not omitted
+					// string "avg_sum_nanos"
+					o = append(o, 0xad, 0x61, 0x76, 0x67, 0x5f, 0x73, 0x75, 0x6d, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+					o = msgp.AppendUint64(o, z.ServerLatency.AvgSumNanos)
+				}
+				if (zb0006Mask & 0x4) == 0 { // if not omitted
+					// string "max_nanos"
+					o = append(o, 0xa9, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+					o = msgp.AppendUint64(o, z.ServerLatency.MaxNanos)
+				}
+			}
+		}
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// string "purge"
 			o = append(o, 0xa5, 0x70, 0x75, 0x72, 0x67, 0x65)
 			if z.Purge == nil {
@@ -343,6 +1132,32 @@ func (z *LockMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				o, err = z.Purge.MarshalMsg(o)
 				if err != nil {
 					err = msgp.WrapError(err, "Purge")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[LockSegment, *LockSegment])(z.LastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[LockSegment, *LockSegment])(z.LastHour).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
 					return
 				}
 			}
@@ -361,7 +1176,7 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 6 bits */
+	var zb0001Mask uint16 /* 13 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -397,27 +1212,282 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x2
-		case "rejected":
-			z.Rejected, bts, err = msgp.ReadUint64Bytes(bts)
+		case "acquire":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Rejected")
+				err = msgp.WrapError(err, "Acquire")
 				return
+			}
+			var zb0002Mask uint8 /* 2 bits */
+			_ = zb0002Mask
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Acquire")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					bts, err = z.Acquire.Read.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire", "Read")
+						return
+					}
+					zb0002Mask |= 0x1
+				case "write":
+					bts, err = z.Acquire.Write.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire", "Write")
+						return
+					}
+					zb0002Mask |= 0x2
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Acquire")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0002Mask != 0x3 {
+				if (zb0002Mask & 0x1) == 0 {
+					z.Acquire.Read = TimedAction{}
+				}
+				if (zb0002Mask & 0x2) == 0 {
+					z.Acquire.Write = TimedAction{}
+				}
 			}
 			zb0001Mask |= 0x4
-		case "expired_total":
-			z.ExpiredTotal, bts, err = msgp.ReadUint64Bytes(bts)
+		case "acquire_failed":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "ExpiredTotal")
+				err = msgp.WrapError(err, "AcquireFailed")
 				return
 			}
+			var zb0003Mask uint8 /* 2 bits */
+			_ = zb0003Mask
+			for zb0003 > 0 {
+				zb0003--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "AcquireFailed")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					bts, err = z.AcquireFailed.Read.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed", "Read")
+						return
+					}
+					zb0003Mask |= 0x1
+				case "write":
+					bts, err = z.AcquireFailed.Write.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed", "Write")
+						return
+					}
+					zb0003Mask |= 0x2
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "AcquireFailed")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0003Mask != 0x3 {
+				if (zb0003Mask & 0x1) == 0 {
+					z.AcquireFailed.Read = TimedAction{}
+				}
+				if (zb0003Mask & 0x2) == 0 {
+					z.AcquireFailed.Write = TimedAction{}
+				}
+			}
 			zb0001Mask |= 0x8
-		case "quorum_lost":
-			z.QuorumLost, bts, err = msgp.ReadUint64Bytes(bts)
+		case "timed_out":
+			z.TimedOut, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "QuorumLost")
+				err = msgp.WrapError(err, "TimedOut")
 				return
 			}
 			zb0001Mask |= 0x10
+		case "conflicts":
+			z.Conflicts, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Conflicts")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "canceled":
+			z.Canceled, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Canceled")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "held":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Held")
+				return
+			}
+			var zb0004Mask uint8 /* 2 bits */
+			_ = zb0004Mask
+			for zb0004 > 0 {
+				zb0004--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Held")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					bts, err = z.Held.Read.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Held", "Read")
+						return
+					}
+					zb0004Mask |= 0x1
+				case "write":
+					bts, err = z.Held.Write.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Held", "Write")
+						return
+					}
+					zb0004Mask |= 0x2
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Held")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0004Mask != 0x3 {
+				if (zb0004Mask & 0x1) == 0 {
+					z.Held.Read = TimedAction{}
+				}
+				if (zb0004Mask & 0x2) == 0 {
+					z.Held.Write = TimedAction{}
+				}
+			}
+			zb0001Mask |= 0x80
+		case "release":
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Release")
+				return
+			}
+			var zb0005Mask uint8 /* 2 bits */
+			_ = zb0005Mask
+			for zb0005 > 0 {
+				zb0005--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Release")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "read":
+					bts, err = z.Release.Read.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Release", "Read")
+						return
+					}
+					zb0005Mask |= 0x1
+				case "write":
+					bts, err = z.Release.Write.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Release", "Write")
+						return
+					}
+					zb0005Mask |= 0x2
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Release")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0005Mask != 0x3 {
+				if (zb0005Mask & 0x1) == 0 {
+					z.Release.Read = TimedAction{}
+				}
+				if (zb0005Mask & 0x2) == 0 {
+					z.Release.Write = TimedAction{}
+				}
+			}
+			zb0001Mask |= 0x100
+		case "server_latency":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ServerLatency")
+				return
+			}
+			var zb0006Mask uint8 /* 3 bits */
+			_ = zb0006Mask
+			for zb0006 > 0 {
+				zb0006--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ServerLatency")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "n":
+					z.ServerLatency.N, bts, err = msgp.ReadIntBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "N")
+						return
+					}
+					zb0006Mask |= 0x1
+				case "avg_sum_nanos":
+					z.ServerLatency.AvgSumNanos, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "AvgSumNanos")
+						return
+					}
+					zb0006Mask |= 0x2
+				case "max_nanos":
+					z.ServerLatency.MaxNanos, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency", "MaxNanos")
+						return
+					}
+					zb0006Mask |= 0x4
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ServerLatency")
+						return
+					}
+				}
+			}
+			// Clear omitted fields.
+			if zb0006Mask != 0x7 {
+				if (zb0006Mask & 0x1) == 0 {
+					z.ServerLatency.N = 0
+				}
+				if (zb0006Mask & 0x2) == 0 {
+					z.ServerLatency.AvgSumNanos = 0
+				}
+				if (zb0006Mask & 0x4) == 0 {
+					z.ServerLatency.MaxNanos = 0
+				}
+			}
+			zb0001Mask |= 0x200
 		case "purge":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -435,7 +1505,43 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x400
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedLockMetrics)
+				}
+				bts, err = (*Segmented[LockSegment, *LockSegment])(z.LastDay).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x800
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedLockMetrics)
+				}
+				bts, err = (*Segmented[LockSegment, *LockSegment])(z.LastHour).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x1000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -445,7 +1551,7 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3f {
+	if zb0001Mask != 0x1fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Resources = 0
 		}
@@ -453,16 +1559,37 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.Waiting = 0
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.Rejected = 0
+			z.Acquire = (LockOpStats{})
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.ExpiredTotal = 0
+			z.AcquireFailed = (LockOpStats{})
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.QuorumLost = 0
+			z.TimedOut = 0
 		}
 		if (zb0001Mask & 0x20) == 0 {
+			z.Conflicts = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.Canceled = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.Held = (LockOpStats{})
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.Release = (LockOpStats{})
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.ServerLatency = (LockServerLatency{})
+		}
+		if (zb0001Mask & 0x400) == 0 {
 			z.Purge = nil
+		}
+		if (zb0001Mask & 0x800) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.LastHour = nil
 		}
 	}
 	o = bts
@@ -471,12 +1598,207 @@ func (z *LockMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *LockMetrics) Msgsize() (s int) {
-	s = 1 + 10 + msgp.TimeSize + 6 + msgp.IntSize + 10 + msgp.Int64Size + 8 + msgp.Int64Size + 9 + msgp.Uint64Size + 14 + msgp.Uint64Size + 12 + msgp.Uint64Size + 6
+	s = 1 + 10 + msgp.TimeSize + 6 + msgp.IntSize + 10 + msgp.Int64Size + 8 + msgp.Int64Size + 8 + 1 + 5 + z.Acquire.Read.Msgsize() + 6 + z.Acquire.Write.Msgsize() + 15 + 1 + 5 + z.AcquireFailed.Read.Msgsize() + 6 + z.AcquireFailed.Write.Msgsize() + 10 + msgp.Uint64Size + 10 + msgp.Uint64Size + 9 + msgp.Uint64Size + 5 + 1 + 5 + z.Held.Read.Msgsize() + 6 + z.Held.Write.Msgsize() + 8 + 1 + 5 + z.Release.Read.Msgsize() + 6 + z.Release.Write.Msgsize() + 15 + 1 + 2 + msgp.IntSize + 14 + msgp.Uint64Size + 10 + msgp.Uint64Size + 6
 	if z.Purge == nil {
 		s += msgp.NilSize
 	} else {
 		s += z.Purge.Msgsize()
 	}
+	s += 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[LockSegment, *LockSegment])(z.LastDay).Msgsize()
+	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[LockSegment, *LockSegment])(z.LastHour).Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *LockOpStats) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 2 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "read":
+			err = z.Read.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Read")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "write":
+			err = z.Write.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Write")
+				return
+			}
+			zb0001Mask |= 0x2
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Read = TimedAction{}
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Write = TimedAction{}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *LockOpStats) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(2)
+	var zb0001Mask uint8 /* 2 bits */
+	_ = zb0001Mask
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// write "read"
+		err = en.Append(0xa4, 0x72, 0x65, 0x61, 0x64)
+		if err != nil {
+			return
+		}
+		err = z.Read.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Read")
+			return
+		}
+		// write "write"
+		err = en.Append(0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+		if err != nil {
+			return
+		}
+		err = z.Write.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Write")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *LockOpStats) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(2)
+	var zb0001Mask uint8 /* 2 bits */
+	_ = zb0001Mask
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		// string "read"
+		o = append(o, 0xa4, 0x72, 0x65, 0x61, 0x64)
+		o, err = z.Read.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Read")
+			return
+		}
+		// string "write"
+		o = append(o, 0xa5, 0x77, 0x72, 0x69, 0x74, 0x65)
+		o, err = z.Write.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Write")
+			return
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *LockOpStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 2 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "read":
+			bts, err = z.Read.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Read")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "write":
+			bts, err = z.Write.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Write")
+				return
+			}
+			zb0001Mask |= 0x2
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x3 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Read = TimedAction{}
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Write = TimedAction{}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *LockOpStats) Msgsize() (s int) {
+	s = 1 + 5 + z.Read.Msgsize() + 6 + z.Write.Msgsize()
 	return
 }
 
@@ -811,5 +2133,878 @@ func (z *LockPurgeStats) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *LockPurgeStats) Msgsize() (s int) {
 	s = 1 + 11 + msgp.TimeSize + 8 + msgp.Int64Size + 8 + msgp.Int64Size + 8 + msgp.Int64Size + 15 + msgp.TimeSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *LockSegment) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "acquire_count":
+			z.AcquireCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireCount")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "acquire_ns":
+			z.AcquireNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "acquire_failed":
+			z.AcquireFailed, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailed")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "acquire_failed_ns":
+			z.AcquireFailedNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailedNanos")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "held_count":
+			z.HeldCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "HeldCount")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "held_ns":
+			z.HeldNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "HeldNanos")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "release_count":
+			z.ReleaseCount, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseCount")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "release_ns":
+			z.ReleaseNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseNanos")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "rejected":
+			z.Rejected, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Rejected")
+				return
+			}
+			zb0001Mask |= 0x100
+		case "expired":
+			z.Expired, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Expired")
+				return
+			}
+			zb0001Mask |= 0x200
+		case "quorum_lost":
+			z.QuorumLost, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "QuorumLost")
+				return
+			}
+			zb0001Mask |= 0x400
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7ff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.AcquireCount = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AcquireNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.AcquireFailed = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.AcquireFailedNanos = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.HeldCount = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.HeldNanos = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.ReleaseCount = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.ReleaseNanos = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.Rejected = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.Expired = 0
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.QuorumLost = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *LockSegment) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(12)
+	var zb0001Mask uint16 /* 12 bits */
+	_ = zb0001Mask
+	if z.AcquireCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AcquireNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.AcquireFailed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.AcquireFailedNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.HeldCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.HeldNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.ReleaseCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.ReleaseNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.Rejected == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.Expired == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.QuorumLost == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "acquire_count"
+			err = en.Append(0xad, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.AcquireCount)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "acquire_ns"
+			err = en.Append(0xaa, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.AcquireNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "acquire_failed"
+			err = en.Append(0xae, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.AcquireFailed)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailed")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "acquire_failed_ns"
+			err = en.Append(0xb1, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.AcquireFailedNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailedNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "held_count"
+			err = en.Append(0xaa, 0x68, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.HeldCount)
+			if err != nil {
+				err = msgp.WrapError(err, "HeldCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "held_ns"
+			err = en.Append(0xa7, 0x68, 0x65, 0x6c, 0x64, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.HeldNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "HeldNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "release_count"
+			err = en.Append(0xad, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.ReleaseCount)
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseCount")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "release_ns"
+			err = en.Append(0xaa, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x5f, 0x6e, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.ReleaseNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "rejected"
+			err = en.Append(0xa8, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Rejected)
+			if err != nil {
+				err = msgp.WrapError(err, "Rejected")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// write "expired"
+			err = en.Append(0xa7, 0x65, 0x78, 0x70, 0x69, 0x72, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Expired)
+			if err != nil {
+				err = msgp.WrapError(err, "Expired")
+				return
+			}
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// write "quorum_lost"
+			err = en.Append(0xab, 0x71, 0x75, 0x6f, 0x72, 0x75, 0x6d, 0x5f, 0x6c, 0x6f, 0x73, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.QuorumLost)
+			if err != nil {
+				err = msgp.WrapError(err, "QuorumLost")
+				return
+			}
+		}
+		// write "n"
+		err = en.Append(0xa1, 0x6e)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.N)
+		if err != nil {
+			err = msgp.WrapError(err, "N")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *LockSegment) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(12)
+	var zb0001Mask uint16 /* 12 bits */
+	_ = zb0001Mask
+	if z.AcquireCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AcquireNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.AcquireFailed == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.AcquireFailedNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.HeldCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.HeldNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.ReleaseCount == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.ReleaseNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.Rejected == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x100
+	}
+	if z.Expired == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x200
+	}
+	if z.QuorumLost == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x400
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "acquire_count"
+			o = append(o, 0xad, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.AcquireCount)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "acquire_ns"
+			o = append(o, 0xaa, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.AcquireNanos)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "acquire_failed"
+			o = append(o, 0xae, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.AcquireFailed)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "acquire_failed_ns"
+			o = append(o, 0xb1, 0x61, 0x63, 0x71, 0x75, 0x69, 0x72, 0x65, 0x5f, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.AcquireFailedNanos)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "held_count"
+			o = append(o, 0xaa, 0x68, 0x65, 0x6c, 0x64, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.HeldCount)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "held_ns"
+			o = append(o, 0xa7, 0x68, 0x65, 0x6c, 0x64, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.HeldNanos)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "release_count"
+			o = append(o, 0xad, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74)
+			o = msgp.AppendUint64(o, z.ReleaseCount)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "release_ns"
+			o = append(o, 0xaa, 0x72, 0x65, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x5f, 0x6e, 0x73)
+			o = msgp.AppendUint64(o, z.ReleaseNanos)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "rejected"
+			o = append(o, 0xa8, 0x72, 0x65, 0x6a, 0x65, 0x63, 0x74, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.Rejected)
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
+			// string "expired"
+			o = append(o, 0xa7, 0x65, 0x78, 0x70, 0x69, 0x72, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.Expired)
+		}
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
+			// string "quorum_lost"
+			o = append(o, 0xab, 0x71, 0x75, 0x6f, 0x72, 0x75, 0x6d, 0x5f, 0x6c, 0x6f, 0x73, 0x74)
+			o = msgp.AppendUint64(o, z.QuorumLost)
+		}
+		// string "n"
+		o = append(o, 0xa1, 0x6e)
+		o = msgp.AppendInt(o, z.N)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *LockSegment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint16 /* 11 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "acquire_count":
+			z.AcquireCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireCount")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "acquire_ns":
+			z.AcquireNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "acquire_failed":
+			z.AcquireFailed, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailed")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "acquire_failed_ns":
+			z.AcquireFailedNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AcquireFailedNanos")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "held_count":
+			z.HeldCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "HeldCount")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "held_ns":
+			z.HeldNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "HeldNanos")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "release_count":
+			z.ReleaseCount, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseCount")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "release_ns":
+			z.ReleaseNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ReleaseNanos")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "rejected":
+			z.Rejected, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Rejected")
+				return
+			}
+			zb0001Mask |= 0x100
+		case "expired":
+			z.Expired, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Expired")
+				return
+			}
+			zb0001Mask |= 0x200
+		case "quorum_lost":
+			z.QuorumLost, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "QuorumLost")
+				return
+			}
+			zb0001Mask |= 0x400
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7ff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.AcquireCount = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AcquireNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.AcquireFailed = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.AcquireFailedNanos = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.HeldCount = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.HeldNanos = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.ReleaseCount = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.ReleaseNanos = 0
+		}
+		if (zb0001Mask & 0x100) == 0 {
+			z.Rejected = 0
+		}
+		if (zb0001Mask & 0x200) == 0 {
+			z.Expired = 0
+		}
+		if (zb0001Mask & 0x400) == 0 {
+			z.QuorumLost = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *LockSegment) Msgsize() (s int) {
+	s = 1 + 14 + msgp.Uint64Size + 11 + msgp.Uint64Size + 15 + msgp.Uint64Size + 18 + msgp.Uint64Size + 11 + msgp.Uint64Size + 8 + msgp.Uint64Size + 14 + msgp.Uint64Size + 11 + msgp.Uint64Size + 9 + msgp.Uint64Size + 8 + msgp.Uint64Size + 12 + msgp.Uint64Size + 2 + msgp.IntSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *LockServerLatency) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "avg_sum_nanos":
+			z.AvgSumNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "AvgSumNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "max_nanos":
+			z.MaxNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+			zb0001Mask |= 0x4
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.N = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AvgSumNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MaxNanos = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z LockServerLatency) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	if z.N == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AvgSumNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MaxNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "n"
+			err = en.Append(0xa1, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt(z.N)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "avg_sum_nanos"
+			err = en.Append(0xad, 0x61, 0x76, 0x67, 0x5f, 0x73, 0x75, 0x6d, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.AvgSumNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "AvgSumNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "max_nanos"
+			err = en.Append(0xa9, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.MaxNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z LockServerLatency) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(3)
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	if z.N == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AvgSumNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MaxNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "n"
+			o = append(o, 0xa1, 0x6e)
+			o = msgp.AppendInt(o, z.N)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "avg_sum_nanos"
+			o = append(o, 0xad, 0x61, 0x76, 0x67, 0x5f, 0x73, 0x75, 0x6d, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			o = msgp.AppendUint64(o, z.AvgSumNanos)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "max_nanos"
+			o = append(o, 0xa9, 0x6d, 0x61, 0x78, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			o = msgp.AppendUint64(o, z.MaxNanos)
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *LockServerLatency) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 3 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "avg_sum_nanos":
+			z.AvgSumNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AvgSumNanos")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "max_nanos":
+			z.MaxNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MaxNanos")
+				return
+			}
+			zb0001Mask |= 0x4
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x7 {
+		if (zb0001Mask & 0x1) == 0 {
+			z.N = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AvgSumNanos = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MaxNanos = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z LockServerLatency) Msgsize() (s int) {
+	s = 1 + 2 + msgp.IntSize + 14 + msgp.Uint64Size + 10 + msgp.Uint64Size
 	return
 }

--- a/metrics-locks_gen_test.go
+++ b/metrics-locks_gen_test.go
@@ -122,6 +122,119 @@ func BenchmarkDecodeLockMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalLockOpStats(t *testing.T) {
+	v := LockOpStats{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgLockOpStats(b *testing.B) {
+	v := LockOpStats{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgLockOpStats(b *testing.B) {
+	v := LockOpStats{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalLockOpStats(b *testing.B) {
+	v := LockOpStats{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeLockOpStats(t *testing.T) {
+	v := LockOpStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeLockOpStats Msgsize() is inaccurate")
+	}
+
+	vn := LockOpStats{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeLockOpStats(b *testing.B) {
+	v := LockOpStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeLockOpStats(b *testing.B) {
+	v := LockOpStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalLockPurgeStats(t *testing.T) {
 	v := LockPurgeStats{}
 	bts, err := v.MarshalMsg(nil)
@@ -220,6 +333,232 @@ func BenchmarkEncodeLockPurgeStats(b *testing.B) {
 
 func BenchmarkDecodeLockPurgeStats(b *testing.B) {
 	v := LockPurgeStats{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalLockSegment(t *testing.T) {
+	v := LockSegment{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgLockSegment(b *testing.B) {
+	v := LockSegment{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgLockSegment(b *testing.B) {
+	v := LockSegment{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalLockSegment(b *testing.B) {
+	v := LockSegment{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeLockSegment(t *testing.T) {
+	v := LockSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeLockSegment Msgsize() is inaccurate")
+	}
+
+	vn := LockSegment{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeLockSegment(b *testing.B) {
+	v := LockSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeLockSegment(b *testing.B) {
+	v := LockSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalLockServerLatency(t *testing.T) {
+	v := LockServerLatency{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgLockServerLatency(b *testing.B) {
+	v := LockServerLatency{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgLockServerLatency(b *testing.B) {
+	v := LockServerLatency{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalLockServerLatency(b *testing.B) {
+	v := LockServerLatency{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeLockServerLatency(t *testing.T) {
+	v := LockServerLatency{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeLockServerLatency Msgsize() is inaccurate")
+	}
+
+	vn := LockServerLatency{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeLockServerLatency(b *testing.B) {
+	v := LockServerLatency{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeLockServerLatency(b *testing.B) {
+	v := LockServerLatency{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/metrics-targets.go
+++ b/metrics-targets.go
@@ -36,6 +36,10 @@ import "time"
 // atomic loads either way, so selectivity is legitimately a client-side concern,
 // and three bits would triple the collect, merge, navigation and test surface
 // for one concept.
+//
+// Nothing here is cumulative since process start. The per-target time bases are
+// stated on TargetMetrics; log volume arrives as the two persisted segmented
+// windows below.
 type DeliveryTargetMetrics struct {
 	CollectedAt time.Time `json:"collected"`
 	Nodes       int       `json:"nodes"`
@@ -55,14 +59,18 @@ type DeliveryTargetMetrics struct {
 	// Spill is the on-disk overflow store shared by the audit and log queues.
 	Spill *TargetSpillStats `json:"spill,omitempty"`
 
-	// LogVolume maps a log severity ("error", "warning", "fatal", "info",
-	// "event") to the number of lines emitted since process start.
+	// Log lines emitted, by severity, over a segmented window.
 	//
-	// It is on the section rather than on a target because a line is counted
+	// They are on the section rather than on a target because a line is counted
 	// once on emission regardless of how many targets it fans out to -- and
 	// because it is the only signal here that still works with no target
 	// configured at all.
-	LogVolume map[string]uint64 `json:"log_volume,omitempty"`
+	//
+	// LogVolumeLastDay is 96 x 15-minute segments, requested with the DayStats
+	// flag; LogVolumeLastHour is 60 x 1-minute segments, requested with the
+	// HourStats flag.
+	LogVolumeLastDay  *SegmentedLogVolume `json:"logVolumeLastDay,omitempty"`
+	LogVolumeLastHour *SegmentedLogVolume `json:"logVolumeLastHour,omitempty"`
 }
 
 // TargetSpillStats is the disk overflow store for a delivery queue.
@@ -73,10 +81,27 @@ type TargetSpillStats struct {
 
 // TargetMetrics is one delivery target's state in this scope.
 //
+// Four time bases live here, and which one a field uses is stated on the field.
+// No value is cumulative since process start: a lifetime counter needs two
+// collections before it says anything, and resets invisibly on restart.
+//
+//   - Identity and configuration, echoed identically by every node: Subsystem,
+//     Name, Type, Endpoint.
+//   - Instantaneous, read live at collection: N, NodesOnline, NodesChecking,
+//     QueueLength, QueueCapacity, Inflight, Workers.
+//   - Sliding last minute, from in-memory accumulators, never persisted:
+//     LastMinute.
+//   - Segmented windows, persisted across restarts: LastHour, LastDay. Delivered
+//     events, requests, failures and dropped events live only there, because a
+//     one-minute view never catches events that arrive in bursts hours apart.
+//
+// LastError sits outside all four: it is the single most recent failure in
+// scope, kept with its own timestamp.
+//
 // Every numeric field sums across hosts except LastMinute, which merges as a
-// TimedAction, and Drops, which sums by key. A per-node outlier -- one node
-// whose queue is full while five are idle -- shows up as a ByHost entry, and
-// QueueLength against QueueCapacity is a correct saturation figure at either
+// TimedAction, and the windows, which merge segment-wise. A per-node outlier --
+// one node whose queue is full while five are idle -- shows up as a ByHost entry,
+// and QueueLength against QueueCapacity is a correct saturation figure at either
 // scope because both sum.
 type TargetMetrics struct {
 	// N is the number of nodes reporting this target. Nodes are expected to
@@ -94,20 +119,6 @@ type TargetMetrics struct {
 	NodesOnline   int `json:"nodes_online,omitempty"`
 	NodesChecking int `json:"nodes_checking,omitempty"`
 
-	// Cumulative flow since process start; resets on restart.
-	TotalEvents    uint64 `json:"total_events,omitempty"`
-	TotalRequests  uint64 `json:"total_requests,omitempty"`
-	FailedRequests uint64 `json:"failed_requests,omitempty"`
-	WriterErrors   uint64 `json:"writer_errors,omitempty"`
-
-	// Drops maps the reason an event was discarded to a count: "queue_full",
-	// "retries_exhausted", "shutdown", or "other".
-	//
-	// The sum over this map is the total dropped-event count, so there is no
-	// separate total field. "other" exists so that sum stays exact even when the
-	// server cannot classify a drop.
-	Drops map[string]uint64 `json:"drops,omitempty"`
-
 	// Backpressure gauges.
 	QueueLength   int64 `json:"queue_length,omitempty"`
 	QueueCapacity int64 `json:"queue_capacity,omitempty"`
@@ -117,10 +128,10 @@ type TargetMetrics struct {
 	// LastMinute is delivery over the last ~60s.
 	//
 	// Count is *requests*, not events: a batching target covers up to its batch
-	// size per request, so TotalEvents/Count is the batch factor rather than a
-	// rate. The mean latency is AccTime/Count and the delivery rate is
-	// Count/60 -- neither is sent. Bytes is populated only by the writer path
-	// that knows the encoded payload size.
+	// size per request, so the batch factor is a window's Events/Requests rather
+	// than anything derivable here. The mean latency is AccTime/Count and the
+	// delivery rate is Count/60 -- neither is sent. Bytes is populated only by the
+	// writer path that knows the encoded payload size.
 	LastMinute TimedAction `json:"last_minute"`
 
 	// LastError is the most recent delivery failure anywhere in scope, kept with
@@ -128,6 +139,12 @@ type TargetMetrics struct {
 	// timestamps break on the lexicographically smaller message.
 	LastError     string    `json:"last_error,omitempty"`
 	LastErrorTime time.Time `json:"last_error_time,omitzero"`
+
+	// LastDay is 96 x 15-minute segments, requested with the DayStats flag.
+	LastDay *SegmentedTargetMetrics `json:"lastDay,omitempty"`
+
+	// LastHour is 60 x 1-minute segments, requested with the HourStats flag.
+	LastHour *SegmentedTargetMetrics `json:"lastHour,omitempty"`
 }
 
 // Add other into t.
@@ -141,17 +158,27 @@ func (t *TargetMetrics) Add(other *TargetMetrics) {
 	t.N += other.N
 	t.NodesOnline += other.NodesOnline
 	t.NodesChecking += other.NodesChecking
-	t.TotalEvents += other.TotalEvents
-	t.TotalRequests += other.TotalRequests
-	t.FailedRequests += other.FailedRequests
-	t.WriterErrors += other.WriterErrors
-	addMap(&t.Drops, other.Drops)
 	t.QueueLength += other.QueueLength
 	t.QueueCapacity += other.QueueCapacity
 	t.Inflight += other.Inflight
 	t.Workers += other.Workers
 	t.LastMinute.Merge(other.LastMinute)
 	takeLater(&t.LastErrorTime, &t.LastError, other.LastErrorTime, other.LastError)
+	// Presence survives the merge: a window that was requested and came back with
+	// no completed segment is kept non-nil, so a reader can tell it apart from one
+	// that was never asked for.
+	if o := other.LastDay; o != nil {
+		if t.LastDay == nil {
+			t.LastDay = new(SegmentedTargetMetrics)
+		}
+		t.LastDay.Add(o)
+	}
+	if o := other.LastHour; o != nil {
+		if t.LastHour == nil {
+			t.LastHour = new(SegmentedTargetMetrics)
+		}
+		t.LastHour.Add(o)
+	}
 }
 
 // Merge other into d.
@@ -173,5 +200,112 @@ func (d *DeliveryTargetMetrics) Merge(other *DeliveryTargetMetrics) {
 		d.Spill.Bytes += other.Spill.Bytes
 		d.Spill.Files += other.Spill.Files
 	}
-	addMap(&d.LogVolume, other.LogVolume)
+	// Presence survives the merge; see TargetMetrics.Add.
+	if o := other.LogVolumeLastDay; o != nil {
+		if d.LogVolumeLastDay == nil {
+			d.LogVolumeLastDay = new(SegmentedLogVolume)
+		}
+		d.LogVolumeLastDay.Add(o)
+	}
+	if o := other.LogVolumeLastHour; o != nil {
+		if d.LogVolumeLastHour == nil {
+			d.LogVolumeLastHour = new(SegmentedLogVolume)
+		}
+		d.LogVolumeLastHour.Add(o)
+	}
+}
+
+// SegmentedTargetMetrics is a time-segmented view of one target's delivery flow.
+type SegmentedTargetMetrics = Segmented[TargetSegment, *TargetSegment]
+
+// TargetSegment is one delivery target's flow over one time segment.
+//
+// Every field is a plain sum over the segment, so segments merge across nodes and
+// rescale to a coarser interval by addition. Reading a window rolls it forward, so
+// a field whose additive identity is not zero would be corrupted by the read.
+//
+// Queue depth, in-flight and worker counts are absent: they are instantaneous
+// gauges, and a sum of samples across a segment means nothing.
+type TargetSegment struct {
+	// Events is events accepted for delivery and Requests the attempts they were
+	// batched into, so Events/Requests is the batch factor. RequestNanos is the
+	// summed delivery latency, so RequestNanos/Requests is the mean.
+	Events       uint64 `json:"events,omitempty"`
+	Requests     uint64 `json:"requests,omitempty"`
+	RequestNanos uint64 `json:"request_nanos,omitempty"`
+
+	// WriterErrors is every delivery attempt that failed to write. Attempts are
+	// retried, so one event can contribute several.
+	//
+	// There is deliberately no separate failed-request count beside it: the two
+	// move together on every non-batching path, and a batching target increments
+	// only this one, so a second field would be the same value twice and would read
+	// as zero for Kafka.
+	WriterErrors uint64 `json:"writer_errors,omitempty"`
+
+	// The reasons an event was discarded, as fixed fields rather than a map so the
+	// segment stays a flat record of sums. They sum to the segment's dropped-event
+	// count, so there is no separate total; DroppedOther keeps that sum exact when
+	// the server cannot classify a drop.
+	DroppedQueueFull        uint64 `json:"dropped_queue_full,omitempty"`
+	DroppedRetriesExhausted uint64 `json:"dropped_retries_exhausted,omitempty"`
+	DroppedShutdown         uint64 `json:"dropped_shutdown,omitempty"`
+	DroppedOther            uint64 `json:"dropped_other,omitempty"`
+
+	// N is contributing nodes.
+	N int `json:"n"`
+}
+
+// Add other to s for the Segmenter interface.
+func (s *TargetSegment) Add(other *TargetSegment) {
+	if other == nil {
+		return
+	}
+	s.Events += other.Events
+	s.Requests += other.Requests
+	s.RequestNanos += other.RequestNanos
+	s.WriterErrors += other.WriterErrors
+	s.DroppedQueueFull += other.DroppedQueueFull
+	s.DroppedRetriesExhausted += other.DroppedRetriesExhausted
+	s.DroppedShutdown += other.DroppedShutdown
+	s.DroppedOther += other.DroppedOther
+	s.N += other.N
+}
+
+// SegmentedLogVolume is a time-segmented view of log lines emitted.
+type SegmentedLogVolume = Segmented[LogVolumeSegment, *LogVolumeSegment]
+
+// LogVolumeSegment is the log lines emitted over one time segment, by severity.
+//
+// Every field is a plain sum over the segment, so segments merge across nodes and
+// rescale to a coarser interval by addition. Reading a window rolls it forward, so
+// a field whose additive identity is not zero would be corrupted by the read.
+//
+// The severities are fixed fields rather than a map: they are a bounded enum, and
+// a map would be repeated in all 156 segments a node carries.
+//
+// These count lines *emitted*, so suppression happens before the count: a burst
+// reported through LogOnceIf contributes one line plus its periodic rollups.
+type LogVolumeSegment struct {
+	ErrorLines   uint64 `json:"error_lines,omitempty"`
+	WarningLines uint64 `json:"warning_lines,omitempty"`
+	FatalLines   uint64 `json:"fatal_lines,omitempty"`
+	InfoLines    uint64 `json:"info_lines,omitempty"`
+	EventLines   uint64 `json:"event_lines,omitempty"`
+
+	// N is contributing nodes.
+	N int `json:"n"`
+}
+
+// Add other to s for the Segmenter interface.
+func (s *LogVolumeSegment) Add(other *LogVolumeSegment) {
+	if other == nil {
+		return
+	}
+	s.ErrorLines += other.ErrorLines
+	s.WarningLines += other.WarningLines
+	s.FatalLines += other.FatalLines
+	s.InfoLines += other.InfoLines
+	s.EventLines += other.EventLines
+	s.N += other.N
 }

--- a/metrics-targets_gen.go
+++ b/metrics-targets_gen.go
@@ -18,7 +18,7 @@ func (z *DeliveryTargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -188,35 +188,44 @@ func (z *DeliveryTargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x8
-		case "log_volume":
-			var zb0006 uint32
-			zb0006, err = dc.ReadMapHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "LogVolume")
-				return
-			}
-			if z.LogVolume == nil {
-				z.LogVolume = make(map[string]uint64, zb0006)
-			} else if len(z.LogVolume) > 0 {
-				clear(z.LogVolume)
-			}
-			for zb0006 > 0 {
-				zb0006--
-				var za0007 string
-				za0007, err = dc.ReadString()
+		case "logVolumeLastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume")
+					err = msgp.WrapError(err, "LogVolumeLastDay")
 					return
 				}
-				var za0008 uint64
-				za0008, err = dc.ReadUint64()
+				z.LogVolumeLastDay = nil
+			} else {
+				if z.LogVolumeLastDay == nil {
+					z.LogVolumeLastDay = new(SegmentedLogVolume)
+				}
+				err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastDay).DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume", za0007)
+					err = msgp.WrapError(err, "LogVolumeLastDay")
 					return
 				}
-				z.LogVolume[za0007] = za0008
 			}
 			zb0001Mask |= 0x10
+		case "logVolumeLastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastHour")
+					return
+				}
+				z.LogVolumeLastHour = nil
+			} else {
+				if z.LogVolumeLastHour == nil {
+					z.LogVolumeLastHour = new(SegmentedLogVolume)
+				}
+				err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastHour).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x20
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -226,7 +235,7 @@ func (z *DeliveryTargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x3f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Notification = nil
 		}
@@ -240,7 +249,10 @@ func (z *DeliveryTargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.Spill = nil
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.LogVolume = nil
+			z.LogVolumeLastDay = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LogVolumeLastHour = nil
 		}
 	}
 	return
@@ -249,8 +261,8 @@ func (z *DeliveryTargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *DeliveryTargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(7)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.Notification == nil {
 		zb0001Len--
@@ -268,9 +280,13 @@ func (z *DeliveryTargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.LogVolume == nil {
+	if z.LogVolumeLastDay == nil {
 		zb0001Len--
 		zb0001Mask |= 0x40
+	}
+	if z.LogVolumeLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -432,25 +448,39 @@ func (z *DeliveryTargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// write "log_volume"
-			err = en.Append(0xaa, 0x6c, 0x6f, 0x67, 0x5f, 0x76, 0x6f, 0x6c, 0x75, 0x6d, 0x65)
+			// write "logVolumeLastDay"
+			err = en.Append(0xb0, 0x6c, 0x6f, 0x67, 0x56, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x4c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
 			if err != nil {
 				return
 			}
-			err = en.WriteMapHeader(uint32(len(z.LogVolume)))
-			if err != nil {
-				err = msgp.WrapError(err, "LogVolume")
-				return
-			}
-			for za0007, za0008 := range z.LogVolume {
-				err = en.WriteString(za0007)
+			if z.LogVolumeLastDay == nil {
+				err = en.WriteNil()
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume")
 					return
 				}
-				err = en.WriteUint64(za0008)
+			} else {
+				err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastDay).EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume", za0007)
+					err = msgp.WrapError(err, "LogVolumeLastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "logVolumeLastHour"
+			err = en.Append(0xb1, 0x6c, 0x6f, 0x67, 0x56, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x4c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LogVolumeLastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastHour).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastHour")
 					return
 				}
 			}
@@ -463,8 +493,8 @@ func (z *DeliveryTargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *DeliveryTargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(7)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.Notification == nil {
 		zb0001Len--
@@ -482,9 +512,13 @@ func (z *DeliveryTargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.LogVolume == nil {
+	if z.LogVolumeLastDay == nil {
 		zb0001Len--
 		zb0001Mask |= 0x40
+	}
+	if z.LogVolumeLastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -573,12 +607,29 @@ func (z *DeliveryTargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			}
 		}
 		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// string "log_volume"
-			o = append(o, 0xaa, 0x6c, 0x6f, 0x67, 0x5f, 0x76, 0x6f, 0x6c, 0x75, 0x6d, 0x65)
-			o = msgp.AppendMapHeader(o, uint32(len(z.LogVolume)))
-			for za0007, za0008 := range z.LogVolume {
-				o = msgp.AppendString(o, za0007)
-				o = msgp.AppendUint64(o, za0008)
+			// string "logVolumeLastDay"
+			o = append(o, 0xb0, 0x6c, 0x6f, 0x67, 0x56, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x4c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LogVolumeLastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "logVolumeLastHour"
+			o = append(o, 0xb1, 0x6c, 0x6f, 0x67, 0x56, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x4c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LogVolumeLastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastHour).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastHour")
+					return
+				}
 			}
 		}
 	}
@@ -595,7 +646,7 @@ func (z *DeliveryTargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -764,35 +815,42 @@ func (z *DeliveryTargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x8
-		case "log_volume":
-			var zb0006 uint32
-			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "LogVolume")
-				return
-			}
-			if z.LogVolume == nil {
-				z.LogVolume = make(map[string]uint64, zb0006)
-			} else if len(z.LogVolume) > 0 {
-				clear(z.LogVolume)
-			}
-			for zb0006 > 0 {
-				var za0008 uint64
-				zb0006--
-				var za0007 string
-				za0007, bts, err = msgp.ReadStringBytes(bts)
+		case "logVolumeLastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume")
 					return
 				}
-				za0008, bts, err = msgp.ReadUint64Bytes(bts)
+				z.LogVolumeLastDay = nil
+			} else {
+				if z.LogVolumeLastDay == nil {
+					z.LogVolumeLastDay = new(SegmentedLogVolume)
+				}
+				bts, err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastDay).UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "LogVolume", za0007)
+					err = msgp.WrapError(err, "LogVolumeLastDay")
 					return
 				}
-				z.LogVolume[za0007] = za0008
 			}
 			zb0001Mask |= 0x10
+		case "logVolumeLastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LogVolumeLastHour = nil
+			} else {
+				if z.LogVolumeLastHour == nil {
+					z.LogVolumeLastHour = new(SegmentedLogVolume)
+				}
+				bts, err = (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastHour).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LogVolumeLastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x20
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -802,7 +860,7 @@ func (z *DeliveryTargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x3f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Notification = nil
 		}
@@ -816,7 +874,10 @@ func (z *DeliveryTargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.Spill = nil
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.LogVolume = nil
+			z.LogVolumeLastDay = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LogVolumeLastHour = nil
 		}
 	}
 	o = bts
@@ -852,13 +913,377 @@ func (z *DeliveryTargetMetrics) Msgsize() (s int) {
 	} else {
 		s += 1 + 6 + msgp.Int64Size + 6 + msgp.Int64Size
 	}
-	s += 11 + msgp.MapHeaderSize
-	if z.LogVolume != nil {
-		for za0007, za0008 := range z.LogVolume {
-			_ = za0008
-			s += msgp.StringPrefixSize + len(za0007) + msgp.Uint64Size
+	s += 17
+	if z.LogVolumeLastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastDay).Msgsize()
+	}
+	s += 18
+	if z.LogVolumeLastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[LogVolumeSegment, *LogVolumeSegment])(z.LogVolumeLastHour).Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *LogVolumeSegment) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "error_lines":
+			z.ErrorLines, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "ErrorLines")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "warning_lines":
+			z.WarningLines, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "WarningLines")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "fatal_lines":
+			z.FatalLines, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "FatalLines")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "info_lines":
+			z.InfoLines, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "InfoLines")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "event_lines":
+			z.EventLines, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "EventLines")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
 		}
 	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ErrorLines = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.WarningLines = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.FatalLines = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.InfoLines = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.EventLines = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *LogVolumeSegment) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	if z.ErrorLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.WarningLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.FatalLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.InfoLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.EventLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "error_lines"
+			err = en.Append(0xab, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.ErrorLines)
+			if err != nil {
+				err = msgp.WrapError(err, "ErrorLines")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "warning_lines"
+			err = en.Append(0xad, 0x77, 0x61, 0x72, 0x6e, 0x69, 0x6e, 0x67, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.WarningLines)
+			if err != nil {
+				err = msgp.WrapError(err, "WarningLines")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "fatal_lines"
+			err = en.Append(0xab, 0x66, 0x61, 0x74, 0x61, 0x6c, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.FatalLines)
+			if err != nil {
+				err = msgp.WrapError(err, "FatalLines")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "info_lines"
+			err = en.Append(0xaa, 0x69, 0x6e, 0x66, 0x6f, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.InfoLines)
+			if err != nil {
+				err = msgp.WrapError(err, "InfoLines")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "event_lines"
+			err = en.Append(0xab, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.EventLines)
+			if err != nil {
+				err = msgp.WrapError(err, "EventLines")
+				return
+			}
+		}
+		// write "n"
+		err = en.Append(0xa1, 0x6e)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.N)
+		if err != nil {
+			err = msgp.WrapError(err, "N")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *LogVolumeSegment) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 6 bits */
+	_ = zb0001Mask
+	if z.ErrorLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.WarningLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.FatalLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.InfoLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.EventLines == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "error_lines"
+			o = append(o, 0xab, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.ErrorLines)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "warning_lines"
+			o = append(o, 0xad, 0x77, 0x61, 0x72, 0x6e, 0x69, 0x6e, 0x67, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.WarningLines)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "fatal_lines"
+			o = append(o, 0xab, 0x66, 0x61, 0x74, 0x61, 0x6c, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.FatalLines)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "info_lines"
+			o = append(o, 0xaa, 0x69, 0x6e, 0x66, 0x6f, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.InfoLines)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "event_lines"
+			o = append(o, 0xab, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x5f, 0x6c, 0x69, 0x6e, 0x65, 0x73)
+			o = msgp.AppendUint64(o, z.EventLines)
+		}
+		// string "n"
+		o = append(o, 0xa1, 0x6e)
+		o = msgp.AppendInt(o, z.N)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *LogVolumeSegment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "error_lines":
+			z.ErrorLines, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ErrorLines")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "warning_lines":
+			z.WarningLines, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "WarningLines")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "fatal_lines":
+			z.FatalLines, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "FatalLines")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "info_lines":
+			z.InfoLines, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "InfoLines")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "event_lines":
+			z.EventLines, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "EventLines")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.ErrorLines = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.WarningLines = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.FatalLines = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.InfoLines = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.EventLines = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *LogVolumeSegment) Msgsize() (s int) {
+	s = 1 + 12 + msgp.Uint64Size + 14 + msgp.Uint64Size + 12 + msgp.Uint64Size + 11 + msgp.Uint64Size + 12 + msgp.Uint64Size + 2 + msgp.IntSize
 	return
 }
 
@@ -872,7 +1297,7 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint32 /* 17 bits */
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -930,91 +1355,34 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x20
-		case "total_events":
-			z.TotalEvents, err = dc.ReadUint64()
-			if err != nil {
-				err = msgp.WrapError(err, "TotalEvents")
-				return
-			}
-			zb0001Mask |= 0x40
-		case "total_requests":
-			z.TotalRequests, err = dc.ReadUint64()
-			if err != nil {
-				err = msgp.WrapError(err, "TotalRequests")
-				return
-			}
-			zb0001Mask |= 0x80
-		case "failed_requests":
-			z.FailedRequests, err = dc.ReadUint64()
-			if err != nil {
-				err = msgp.WrapError(err, "FailedRequests")
-				return
-			}
-			zb0001Mask |= 0x100
-		case "writer_errors":
-			z.WriterErrors, err = dc.ReadUint64()
-			if err != nil {
-				err = msgp.WrapError(err, "WriterErrors")
-				return
-			}
-			zb0001Mask |= 0x200
-		case "drops":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
-			if err != nil {
-				err = msgp.WrapError(err, "Drops")
-				return
-			}
-			if z.Drops == nil {
-				z.Drops = make(map[string]uint64, zb0002)
-			} else if len(z.Drops) > 0 {
-				clear(z.Drops)
-			}
-			for zb0002 > 0 {
-				zb0002--
-				var za0001 string
-				za0001, err = dc.ReadString()
-				if err != nil {
-					err = msgp.WrapError(err, "Drops")
-					return
-				}
-				var za0002 uint64
-				za0002, err = dc.ReadUint64()
-				if err != nil {
-					err = msgp.WrapError(err, "Drops", za0001)
-					return
-				}
-				z.Drops[za0001] = za0002
-			}
-			zb0001Mask |= 0x400
 		case "queue_length":
 			z.QueueLength, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "QueueLength")
 				return
 			}
-			zb0001Mask |= 0x800
+			zb0001Mask |= 0x40
 		case "queue_capacity":
 			z.QueueCapacity, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "QueueCapacity")
 				return
 			}
-			zb0001Mask |= 0x1000
+			zb0001Mask |= 0x80
 		case "inflight":
 			z.Inflight, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Inflight")
 				return
 			}
-			zb0001Mask |= 0x2000
+			zb0001Mask |= 0x100
 		case "workers":
 			z.Workers, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Workers")
 				return
 			}
-			zb0001Mask |= 0x4000
+			zb0001Mask |= 0x200
 		case "last_minute":
 			err = z.LastMinute.DecodeMsg(dc)
 			if err != nil {
@@ -1027,14 +1395,52 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "LastError")
 				return
 			}
-			zb0001Mask |= 0x8000
+			zb0001Mask |= 0x400
 		case "last_error_time":
 			z.LastErrorTime, err = dc.ReadTimeUTC()
 			if err != nil {
 				err = msgp.WrapError(err, "LastErrorTime")
 				return
 			}
-			zb0001Mask |= 0x10000
+			zb0001Mask |= 0x800
+		case "lastDay":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedTargetMetrics)
+				}
+				err = (*Segmented[TargetSegment, *TargetSegment])(z.LastDay).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x1000
+		case "lastHour":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedTargetMetrics)
+				}
+				err = (*Segmented[TargetSegment, *TargetSegment])(z.LastHour).DecodeMsg(dc)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x2000
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -1044,7 +1450,7 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ffff {
+	if zb0001Mask != 0x3fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Subsystem = ""
 		}
@@ -1064,37 +1470,28 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.NodesChecking = 0
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.TotalEvents = 0
-		}
-		if (zb0001Mask & 0x80) == 0 {
-			z.TotalRequests = 0
-		}
-		if (zb0001Mask & 0x100) == 0 {
-			z.FailedRequests = 0
-		}
-		if (zb0001Mask & 0x200) == 0 {
-			z.WriterErrors = 0
-		}
-		if (zb0001Mask & 0x400) == 0 {
-			z.Drops = nil
-		}
-		if (zb0001Mask & 0x800) == 0 {
 			z.QueueLength = 0
 		}
-		if (zb0001Mask & 0x1000) == 0 {
+		if (zb0001Mask & 0x80) == 0 {
 			z.QueueCapacity = 0
 		}
-		if (zb0001Mask & 0x2000) == 0 {
+		if (zb0001Mask & 0x100) == 0 {
 			z.Inflight = 0
 		}
-		if (zb0001Mask & 0x4000) == 0 {
+		if (zb0001Mask & 0x200) == 0 {
 			z.Workers = 0
 		}
-		if (zb0001Mask & 0x8000) == 0 {
+		if (zb0001Mask & 0x400) == 0 {
 			z.LastError = ""
 		}
-		if (zb0001Mask & 0x10000) == 0 {
+		if (zb0001Mask & 0x800) == 0 {
 			z.LastErrorTime = (time.Time{})
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.LastHour = nil
 		}
 	}
 	return
@@ -1103,8 +1500,8 @@ func (z *TargetMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(19)
-	var zb0001Mask uint32 /* 19 bits */
+	zb0001Len := uint32(16)
+	var zb0001Mask uint16 /* 16 bits */
 	_ = zb0001Mask
 	if z.Subsystem == "" {
 		zb0001Len--
@@ -1130,49 +1527,37 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.TotalEvents == 0 {
+	if z.QueueLength == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.TotalRequests == 0 {
+	if z.QueueCapacity == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.FailedRequests == 0 {
+	if z.Inflight == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.WriterErrors == 0 {
+	if z.Workers == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x400
 	}
-	if z.Drops == nil {
-		zb0001Len--
-		zb0001Mask |= 0x800
-	}
-	if z.QueueLength == 0 {
+	if z.LastError == "" {
 		zb0001Len--
 		zb0001Mask |= 0x1000
 	}
-	if z.QueueCapacity == 0 {
+	if z.LastErrorTime.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2000
 	}
-	if z.Inflight == 0 {
+	if z.LastDay == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4000
 	}
-	if z.Workers == 0 {
+	if z.LastHour == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
-	}
-	if z.LastError == "" {
-		zb0001Len--
-		zb0001Mask |= 0x20000
-	}
-	if z.LastErrorTime.IsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x40000
 	}
 	// variable map header, size zb0001Len
 	err = en.WriteMapHeader(zb0001Len)
@@ -1265,78 +1650,6 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
-			// write "total_events"
-			err = en.Append(0xac, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteUint64(z.TotalEvents)
-			if err != nil {
-				err = msgp.WrapError(err, "TotalEvents")
-				return
-			}
-		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
-			// write "total_requests"
-			err = en.Append(0xae, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteUint64(z.TotalRequests)
-			if err != nil {
-				err = msgp.WrapError(err, "TotalRequests")
-				return
-			}
-		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
-			// write "failed_requests"
-			err = en.Append(0xaf, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x5f, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteUint64(z.FailedRequests)
-			if err != nil {
-				err = msgp.WrapError(err, "FailedRequests")
-				return
-			}
-		}
-		if (zb0001Mask & 0x400) == 0 { // if not omitted
-			// write "writer_errors"
-			err = en.Append(0xad, 0x77, 0x72, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteUint64(z.WriterErrors)
-			if err != nil {
-				err = msgp.WrapError(err, "WriterErrors")
-				return
-			}
-		}
-		if (zb0001Mask & 0x800) == 0 { // if not omitted
-			// write "drops"
-			err = en.Append(0xa5, 0x64, 0x72, 0x6f, 0x70, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteMapHeader(uint32(len(z.Drops)))
-			if err != nil {
-				err = msgp.WrapError(err, "Drops")
-				return
-			}
-			for za0001, za0002 := range z.Drops {
-				err = en.WriteString(za0001)
-				if err != nil {
-					err = msgp.WrapError(err, "Drops")
-					return
-				}
-				err = en.WriteUint64(za0002)
-				if err != nil {
-					err = msgp.WrapError(err, "Drops", za0001)
-					return
-				}
-			}
-		}
-		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// write "queue_length"
 			err = en.Append(0xac, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x6c, 0x65, 0x6e, 0x67, 0x74, 0x68)
 			if err != nil {
@@ -1348,7 +1661,7 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// write "queue_capacity"
 			err = en.Append(0xae, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x63, 0x61, 0x70, 0x61, 0x63, 0x69, 0x74, 0x79)
 			if err != nil {
@@ -1360,7 +1673,7 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// write "inflight"
 			err = en.Append(0xa8, 0x69, 0x6e, 0x66, 0x6c, 0x69, 0x67, 0x68, 0x74)
 			if err != nil {
@@ -1372,7 +1685,7 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// write "workers"
 			err = en.Append(0xa7, 0x77, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x73)
 			if err != nil {
@@ -1394,7 +1707,7 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "LastMinute")
 			return
 		}
-		if (zb0001Mask & 0x20000) == 0 { // if not omitted
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// write "last_error"
 			err = en.Append(0xaa, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
 			if err != nil {
@@ -1406,7 +1719,7 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x40000) == 0 { // if not omitted
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
 			// write "last_error_time"
 			err = en.Append(0xaf, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x74, 0x69, 0x6d, 0x65)
 			if err != nil {
@@ -1418,6 +1731,44 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// write "lastDay"
+			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if err != nil {
+				return
+			}
+			if z.LastDay == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[TargetSegment, *TargetSegment])(z.LastDay).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+			// write "lastHour"
+			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if err != nil {
+				return
+			}
+			if z.LastHour == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = (*Segmented[TargetSegment, *TargetSegment])(z.LastHour).EncodeMsg(en)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -1426,8 +1777,8 @@ func (z *TargetMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *TargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(19)
-	var zb0001Mask uint32 /* 19 bits */
+	zb0001Len := uint32(16)
+	var zb0001Mask uint16 /* 16 bits */
 	_ = zb0001Mask
 	if z.Subsystem == "" {
 		zb0001Len--
@@ -1453,49 +1804,37 @@ func (z *TargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if z.TotalEvents == 0 {
+	if z.QueueLength == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.TotalRequests == 0 {
+	if z.QueueCapacity == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if z.FailedRequests == 0 {
+	if z.Inflight == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if z.WriterErrors == 0 {
+	if z.Workers == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x400
 	}
-	if z.Drops == nil {
-		zb0001Len--
-		zb0001Mask |= 0x800
-	}
-	if z.QueueLength == 0 {
+	if z.LastError == "" {
 		zb0001Len--
 		zb0001Mask |= 0x1000
 	}
-	if z.QueueCapacity == 0 {
+	if z.LastErrorTime.IsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2000
 	}
-	if z.Inflight == 0 {
+	if z.LastDay == nil {
 		zb0001Len--
 		zb0001Mask |= 0x4000
 	}
-	if z.Workers == 0 {
+	if z.LastHour == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8000
-	}
-	if z.LastError == "" {
-		zb0001Len--
-		zb0001Mask |= 0x20000
-	}
-	if z.LastErrorTime.IsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x40000
 	}
 	// variable map header, size zb0001Len
 	o = msgp.AppendMapHeader(o, zb0001Len)
@@ -1536,50 +1875,21 @@ func (z *TargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendInt(o, z.NodesChecking)
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
-			// string "total_events"
-			o = append(o, 0xac, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73)
-			o = msgp.AppendUint64(o, z.TotalEvents)
-		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
-			// string "total_requests"
-			o = append(o, 0xae, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
-			o = msgp.AppendUint64(o, z.TotalRequests)
-		}
-		if (zb0001Mask & 0x200) == 0 { // if not omitted
-			// string "failed_requests"
-			o = append(o, 0xaf, 0x66, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x5f, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
-			o = msgp.AppendUint64(o, z.FailedRequests)
-		}
-		if (zb0001Mask & 0x400) == 0 { // if not omitted
-			// string "writer_errors"
-			o = append(o, 0xad, 0x77, 0x72, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
-			o = msgp.AppendUint64(o, z.WriterErrors)
-		}
-		if (zb0001Mask & 0x800) == 0 { // if not omitted
-			// string "drops"
-			o = append(o, 0xa5, 0x64, 0x72, 0x6f, 0x70, 0x73)
-			o = msgp.AppendMapHeader(o, uint32(len(z.Drops)))
-			for za0001, za0002 := range z.Drops {
-				o = msgp.AppendString(o, za0001)
-				o = msgp.AppendUint64(o, za0002)
-			}
-		}
-		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// string "queue_length"
 			o = append(o, 0xac, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x6c, 0x65, 0x6e, 0x67, 0x74, 0x68)
 			o = msgp.AppendInt64(o, z.QueueLength)
 		}
-		if (zb0001Mask & 0x2000) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// string "queue_capacity"
 			o = append(o, 0xae, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x63, 0x61, 0x70, 0x61, 0x63, 0x69, 0x74, 0x79)
 			o = msgp.AppendInt64(o, z.QueueCapacity)
 		}
-		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// string "inflight"
 			o = append(o, 0xa8, 0x69, 0x6e, 0x66, 0x6c, 0x69, 0x67, 0x68, 0x74)
 			o = msgp.AppendInt64(o, z.Inflight)
 		}
-		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+		if (zb0001Mask & 0x400) == 0 { // if not omitted
 			// string "workers"
 			o = append(o, 0xa7, 0x77, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x73)
 			o = msgp.AppendInt64(o, z.Workers)
@@ -1591,15 +1901,41 @@ func (z *TargetMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 			err = msgp.WrapError(err, "LastMinute")
 			return
 		}
-		if (zb0001Mask & 0x20000) == 0 { // if not omitted
+		if (zb0001Mask & 0x1000) == 0 { // if not omitted
 			// string "last_error"
 			o = append(o, 0xaa, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72)
 			o = msgp.AppendString(o, z.LastError)
 		}
-		if (zb0001Mask & 0x40000) == 0 { // if not omitted
+		if (zb0001Mask & 0x2000) == 0 { // if not omitted
 			// string "last_error_time"
 			o = append(o, 0xaf, 0x6c, 0x61, 0x73, 0x74, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x74, 0x69, 0x6d, 0x65)
 			o = msgp.AppendTime(o, z.LastErrorTime)
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not omitted
+			// string "lastDay"
+			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
+			if z.LastDay == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[TargetSegment, *TargetSegment])(z.LastDay).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8000) == 0 { // if not omitted
+			// string "lastHour"
+			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
+			if z.LastHour == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = (*Segmented[TargetSegment, *TargetSegment])(z.LastHour).MarshalMsg(o)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
 		}
 	}
 	return
@@ -1615,7 +1951,7 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint32 /* 17 bits */
+	var zb0001Mask uint16 /* 14 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -1673,91 +2009,34 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x20
-		case "total_events":
-			z.TotalEvents, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "TotalEvents")
-				return
-			}
-			zb0001Mask |= 0x40
-		case "total_requests":
-			z.TotalRequests, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "TotalRequests")
-				return
-			}
-			zb0001Mask |= 0x80
-		case "failed_requests":
-			z.FailedRequests, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "FailedRequests")
-				return
-			}
-			zb0001Mask |= 0x100
-		case "writer_errors":
-			z.WriterErrors, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "WriterErrors")
-				return
-			}
-			zb0001Mask |= 0x200
-		case "drops":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Drops")
-				return
-			}
-			if z.Drops == nil {
-				z.Drops = make(map[string]uint64, zb0002)
-			} else if len(z.Drops) > 0 {
-				clear(z.Drops)
-			}
-			for zb0002 > 0 {
-				var za0002 uint64
-				zb0002--
-				var za0001 string
-				za0001, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Drops")
-					return
-				}
-				za0002, bts, err = msgp.ReadUint64Bytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Drops", za0001)
-					return
-				}
-				z.Drops[za0001] = za0002
-			}
-			zb0001Mask |= 0x400
 		case "queue_length":
 			z.QueueLength, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "QueueLength")
 				return
 			}
-			zb0001Mask |= 0x800
+			zb0001Mask |= 0x40
 		case "queue_capacity":
 			z.QueueCapacity, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "QueueCapacity")
 				return
 			}
-			zb0001Mask |= 0x1000
+			zb0001Mask |= 0x80
 		case "inflight":
 			z.Inflight, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Inflight")
 				return
 			}
-			zb0001Mask |= 0x2000
+			zb0001Mask |= 0x100
 		case "workers":
 			z.Workers, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Workers")
 				return
 			}
-			zb0001Mask |= 0x4000
+			zb0001Mask |= 0x200
 		case "last_minute":
 			bts, err = z.LastMinute.UnmarshalMsg(bts)
 			if err != nil {
@@ -1770,14 +2049,50 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "LastError")
 				return
 			}
-			zb0001Mask |= 0x8000
+			zb0001Mask |= 0x400
 		case "last_error_time":
 			z.LastErrorTime, bts, err = msgp.ReadTimeUTCBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "LastErrorTime")
 				return
 			}
-			zb0001Mask |= 0x10000
+			zb0001Mask |= 0x800
+		case "lastDay":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastDay = nil
+			} else {
+				if z.LastDay == nil {
+					z.LastDay = new(SegmentedTargetMetrics)
+				}
+				bts, err = (*Segmented[TargetSegment, *TargetSegment])(z.LastDay).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastDay")
+					return
+				}
+			}
+			zb0001Mask |= 0x1000
+		case "lastHour":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LastHour = nil
+			} else {
+				if z.LastHour == nil {
+					z.LastHour = new(SegmentedTargetMetrics)
+				}
+				bts, err = (*Segmented[TargetSegment, *TargetSegment])(z.LastHour).UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LastHour")
+					return
+				}
+			}
+			zb0001Mask |= 0x2000
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1787,7 +2102,7 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ffff {
+	if zb0001Mask != 0x3fff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Subsystem = ""
 		}
@@ -1807,37 +2122,28 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.NodesChecking = 0
 		}
 		if (zb0001Mask & 0x40) == 0 {
-			z.TotalEvents = 0
-		}
-		if (zb0001Mask & 0x80) == 0 {
-			z.TotalRequests = 0
-		}
-		if (zb0001Mask & 0x100) == 0 {
-			z.FailedRequests = 0
-		}
-		if (zb0001Mask & 0x200) == 0 {
-			z.WriterErrors = 0
-		}
-		if (zb0001Mask & 0x400) == 0 {
-			z.Drops = nil
-		}
-		if (zb0001Mask & 0x800) == 0 {
 			z.QueueLength = 0
 		}
-		if (zb0001Mask & 0x1000) == 0 {
+		if (zb0001Mask & 0x80) == 0 {
 			z.QueueCapacity = 0
 		}
-		if (zb0001Mask & 0x2000) == 0 {
+		if (zb0001Mask & 0x100) == 0 {
 			z.Inflight = 0
 		}
-		if (zb0001Mask & 0x4000) == 0 {
+		if (zb0001Mask & 0x200) == 0 {
 			z.Workers = 0
 		}
-		if (zb0001Mask & 0x8000) == 0 {
+		if (zb0001Mask & 0x400) == 0 {
 			z.LastError = ""
 		}
-		if (zb0001Mask & 0x10000) == 0 {
+		if (zb0001Mask & 0x800) == 0 {
 			z.LastErrorTime = (time.Time{})
+		}
+		if (zb0001Mask & 0x1000) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x2000) == 0 {
+			z.LastHour = nil
 		}
 	}
 	o = bts
@@ -1846,14 +2152,512 @@ func (z *TargetMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *TargetMetrics) Msgsize() (s int) {
-	s = 3 + 2 + msgp.IntSize + 10 + msgp.StringPrefixSize + len(z.Subsystem) + 5 + msgp.StringPrefixSize + len(z.Name) + 5 + msgp.StringPrefixSize + len(z.Type) + 9 + msgp.StringPrefixSize + len(z.Endpoint) + 13 + msgp.IntSize + 15 + msgp.IntSize + 13 + msgp.Uint64Size + 15 + msgp.Uint64Size + 16 + msgp.Uint64Size + 14 + msgp.Uint64Size + 6 + msgp.MapHeaderSize
-	if z.Drops != nil {
-		for za0001, za0002 := range z.Drops {
-			_ = za0002
-			s += msgp.StringPrefixSize + len(za0001) + msgp.Uint64Size
+	s = 3 + 2 + msgp.IntSize + 10 + msgp.StringPrefixSize + len(z.Subsystem) + 5 + msgp.StringPrefixSize + len(z.Name) + 5 + msgp.StringPrefixSize + len(z.Type) + 9 + msgp.StringPrefixSize + len(z.Endpoint) + 13 + msgp.IntSize + 15 + msgp.IntSize + 13 + msgp.Int64Size + 15 + msgp.Int64Size + 9 + msgp.Int64Size + 8 + msgp.Int64Size + 12 + z.LastMinute.Msgsize() + 11 + msgp.StringPrefixSize + len(z.LastError) + 16 + msgp.TimeSize + 8
+	if z.LastDay == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[TargetSegment, *TargetSegment])(z.LastDay).Msgsize()
+	}
+	s += 9
+	if z.LastHour == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*Segmented[TargetSegment, *TargetSegment])(z.LastHour).Msgsize()
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *TargetSegment) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 8 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "events":
+			z.Events, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Events")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "requests":
+			z.Requests, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "Requests")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "request_nanos":
+			z.RequestNanos, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "RequestNanos")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "writer_errors":
+			z.WriterErrors, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "WriterErrors")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "dropped_queue_full":
+			z.DroppedQueueFull, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedQueueFull")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "dropped_retries_exhausted":
+			z.DroppedRetriesExhausted, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedRetriesExhausted")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "dropped_shutdown":
+			z.DroppedShutdown, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedShutdown")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "dropped_other":
+			z.DroppedOther, err = dc.ReadUint64()
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedOther")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "n":
+			z.N, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
 		}
 	}
-	s += 13 + msgp.Int64Size + 15 + msgp.Int64Size + 9 + msgp.Int64Size + 8 + msgp.Int64Size + 12 + z.LastMinute.Msgsize() + 11 + msgp.StringPrefixSize + len(z.LastError) + 16 + msgp.TimeSize
+	// Clear omitted fields.
+	if zb0001Mask != 0xff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Events = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Requests = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.RequestNanos = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.WriterErrors = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.DroppedQueueFull = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.DroppedRetriesExhausted = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.DroppedShutdown = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.DroppedOther = 0
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *TargetSegment) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
+	_ = zb0001Mask
+	if z.Events == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Requests == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.RequestNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.WriterErrors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.DroppedQueueFull == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.DroppedRetriesExhausted == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.DroppedShutdown == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.DroppedOther == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "events"
+			err = en.Append(0xa6, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Events)
+			if err != nil {
+				err = msgp.WrapError(err, "Events")
+				return
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "requests"
+			err = en.Append(0xa8, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.Requests)
+			if err != nil {
+				err = msgp.WrapError(err, "Requests")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "request_nanos"
+			err = en.Append(0xad, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.RequestNanos)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestNanos")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "writer_errors"
+			err = en.Append(0xad, 0x77, 0x72, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.WriterErrors)
+			if err != nil {
+				err = msgp.WrapError(err, "WriterErrors")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "dropped_queue_full"
+			err = en.Append(0xb2, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x66, 0x75, 0x6c, 0x6c)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DroppedQueueFull)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedQueueFull")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "dropped_retries_exhausted"
+			err = en.Append(0xb9, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x72, 0x65, 0x74, 0x72, 0x69, 0x65, 0x73, 0x5f, 0x65, 0x78, 0x68, 0x61, 0x75, 0x73, 0x74, 0x65, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DroppedRetriesExhausted)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedRetriesExhausted")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "dropped_shutdown"
+			err = en.Append(0xb0, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x73, 0x68, 0x75, 0x74, 0x64, 0x6f, 0x77, 0x6e)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DroppedShutdown)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedShutdown")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "dropped_other"
+			err = en.Append(0xad, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x6f, 0x74, 0x68, 0x65, 0x72)
+			if err != nil {
+				return
+			}
+			err = en.WriteUint64(z.DroppedOther)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedOther")
+				return
+			}
+		}
+		// write "n"
+		err = en.Append(0xa1, 0x6e)
+		if err != nil {
+			return
+		}
+		err = en.WriteInt(z.N)
+		if err != nil {
+			err = msgp.WrapError(err, "N")
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *TargetSegment) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
+	_ = zb0001Mask
+	if z.Events == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.Requests == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.RequestNanos == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.WriterErrors == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.DroppedQueueFull == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if z.DroppedRetriesExhausted == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.DroppedShutdown == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.DroppedOther == 0 {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "events"
+			o = append(o, 0xa6, 0x65, 0x76, 0x65, 0x6e, 0x74, 0x73)
+			o = msgp.AppendUint64(o, z.Events)
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "requests"
+			o = append(o, 0xa8, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x73)
+			o = msgp.AppendUint64(o, z.Requests)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "request_nanos"
+			o = append(o, 0xad, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x6e, 0x61, 0x6e, 0x6f, 0x73)
+			o = msgp.AppendUint64(o, z.RequestNanos)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "writer_errors"
+			o = append(o, 0xad, 0x77, 0x72, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x73)
+			o = msgp.AppendUint64(o, z.WriterErrors)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "dropped_queue_full"
+			o = append(o, 0xb2, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x71, 0x75, 0x65, 0x75, 0x65, 0x5f, 0x66, 0x75, 0x6c, 0x6c)
+			o = msgp.AppendUint64(o, z.DroppedQueueFull)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "dropped_retries_exhausted"
+			o = append(o, 0xb9, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x72, 0x65, 0x74, 0x72, 0x69, 0x65, 0x73, 0x5f, 0x65, 0x78, 0x68, 0x61, 0x75, 0x73, 0x74, 0x65, 0x64)
+			o = msgp.AppendUint64(o, z.DroppedRetriesExhausted)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "dropped_shutdown"
+			o = append(o, 0xb0, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x73, 0x68, 0x75, 0x74, 0x64, 0x6f, 0x77, 0x6e)
+			o = msgp.AppendUint64(o, z.DroppedShutdown)
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "dropped_other"
+			o = append(o, 0xad, 0x64, 0x72, 0x6f, 0x70, 0x70, 0x65, 0x64, 0x5f, 0x6f, 0x74, 0x68, 0x65, 0x72)
+			o = msgp.AppendUint64(o, z.DroppedOther)
+		}
+		// string "n"
+		o = append(o, 0xa1, 0x6e)
+		o = msgp.AppendInt(o, z.N)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *TargetSegment) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 8 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "events":
+			z.Events, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Events")
+				return
+			}
+			zb0001Mask |= 0x1
+		case "requests":
+			z.Requests, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Requests")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "request_nanos":
+			z.RequestNanos, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RequestNanos")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "writer_errors":
+			z.WriterErrors, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "WriterErrors")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "dropped_queue_full":
+			z.DroppedQueueFull, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedQueueFull")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "dropped_retries_exhausted":
+			z.DroppedRetriesExhausted, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedRetriesExhausted")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "dropped_shutdown":
+			z.DroppedShutdown, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedShutdown")
+				return
+			}
+			zb0001Mask |= 0x40
+		case "dropped_other":
+			z.DroppedOther, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DroppedOther")
+				return
+			}
+			zb0001Mask |= 0x80
+		case "n":
+			z.N, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "N")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0xff {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Events = 0
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.Requests = 0
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.RequestNanos = 0
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.WriterErrors = 0
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.DroppedQueueFull = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.DroppedRetriesExhausted = 0
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.DroppedShutdown = 0
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.DroppedOther = 0
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *TargetSegment) Msgsize() (s int) {
+	s = 1 + 7 + msgp.Uint64Size + 9 + msgp.Uint64Size + 14 + msgp.Uint64Size + 14 + msgp.Uint64Size + 19 + msgp.Uint64Size + 26 + msgp.Uint64Size + 17 + msgp.Uint64Size + 14 + msgp.Uint64Size + 2 + msgp.IntSize
 	return
 }
 

--- a/metrics-targets_gen_test.go
+++ b/metrics-targets_gen_test.go
@@ -122,6 +122,119 @@ func BenchmarkDecodeDeliveryTargetMetrics(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalLogVolumeSegment(t *testing.T) {
+	v := LogVolumeSegment{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgLogVolumeSegment(b *testing.B) {
+	v := LogVolumeSegment{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgLogVolumeSegment(b *testing.B) {
+	v := LogVolumeSegment{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalLogVolumeSegment(b *testing.B) {
+	v := LogVolumeSegment{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeLogVolumeSegment(t *testing.T) {
+	v := LogVolumeSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeLogVolumeSegment Msgsize() is inaccurate")
+	}
+
+	vn := LogVolumeSegment{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeLogVolumeSegment(b *testing.B) {
+	v := LogVolumeSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeLogVolumeSegment(b *testing.B) {
+	v := LogVolumeSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalTargetMetrics(t *testing.T) {
 	v := TargetMetrics{}
 	bts, err := v.MarshalMsg(nil)
@@ -220,6 +333,119 @@ func BenchmarkEncodeTargetMetrics(b *testing.B) {
 
 func BenchmarkDecodeTargetMetrics(b *testing.B) {
 	v := TargetMetrics{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalTargetSegment(t *testing.T) {
+	v := TargetSegment{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgTargetSegment(b *testing.B) {
+	v := TargetSegment{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgTargetSegment(b *testing.B) {
+	v := TargetSegment{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalTargetSegment(b *testing.B) {
+	v := TargetSegment{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeTargetSegment(t *testing.T) {
+	v := TargetSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeTargetSegment Msgsize() is inaccurate")
+	}
+
+	vn := TargetSegment{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeTargetSegment(b *testing.B) {
+	v := TargetSegment{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeTargetSegment(b *testing.B) {
+	v := TargetSegment{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/metrics-targets_test.go
+++ b/metrics-targets_test.go
@@ -20,7 +20,7 @@
 package madmin
 
 import (
-	"maps"
+	"slices"
 	"testing"
 	"time"
 )
@@ -39,29 +39,34 @@ func TestTargetMetricsAdd(t *testing.T) {
 
 	a := &TargetMetrics{
 		N: 1, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
-		NodesOnline: 1,
-		TotalEvents: 100, TotalRequests: 20, FailedRequests: 1, WriterErrors: 1,
-		Drops:         map[string]uint64{"queue_full": 2},
+		NodesOnline:   1,
 		QueueLength:   10,
 		QueueCapacity: 100_000,
 		LastMinute:    TimedAction{Count: 5, AccTime: 500, MinTime: 50, MaxTime: 200},
 		LastError:     "older", LastErrorTime: t0,
+		LastHour: targetWindow(t0, TargetSegment{
+			N: 1, Events: 100, Requests: 20, RequestNanos: 2000,
+			WriterErrors: 1, DroppedQueueFull: 2,
+		}),
 	}
 	b := &TargetMetrics{
 		N: 1, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
 		NodesOnline: 0, NodesChecking: 1,
-		TotalEvents: 50, TotalRequests: 10, FailedRequests: 4, WriterErrors: 2,
-		Drops:         map[string]uint64{"queue_full": 1, "retries_exhausted": 3},
 		QueueLength:   90_000,
 		QueueCapacity: 100_000,
 		LastMinute:    TimedAction{Count: 3, AccTime: 900, MinTime: 300, MaxTime: 400},
 		LastError:     "newer", LastErrorTime: t0.Add(time.Minute),
+		LastHour: targetWindow(t0, TargetSegment{
+			N: 1, Events: 50, Requests: 10, RequestNanos: 3000,
+			WriterErrors:     2,
+			DroppedQueueFull: 1, DroppedRetriesExhausted: 3,
+		}),
 	}
 
-	// Add mutates the receiver's maps in place by design, so a shallow copy of
+	// Add mutates the receiver's windows in place by design, so a shallow copy of
 	// the input would alias them. mergeMap never does that in production: it
-	// starts from the zero value and addMap allocates rather than aliasing a
-	// source -- see TestTargetMetricsAddDoesNotMutateArgument.
+	// starts from the zero value, and merging into an empty window copies the
+	// source's segments -- see TestTargetMetricsAddDoesNotMutateArgument.
 	got := cloneTargetMetrics(a)
 	got.Add(b)
 
@@ -69,11 +74,13 @@ func TestTargetMetricsAdd(t *testing.T) {
 	if got.N != 2 || got.NodesOnline != 1 || got.NodesChecking != 1 {
 		t.Errorf("readiness = %+v, want N=2 online=1 checking=1", got)
 	}
-	if got.TotalEvents != 150 || got.TotalRequests != 30 || got.WriterErrors != 3 {
-		t.Errorf("counters = %+v", got)
-	}
-	if !maps.Equal(got.Drops, map[string]uint64{"queue_full": 3, "retries_exhausted": 3}) {
-		t.Errorf("Drops = %v", got.Drops)
+	// Flow lives only in the windows, and every segment field is a plain sum.
+	if tot := got.LastHour.Total(); tot != (TargetSegment{
+		N: 2, Events: 150, Requests: 30, RequestNanos: 5000,
+		WriterErrors:     3,
+		DroppedQueueFull: 3, DroppedRetriesExhausted: 3,
+	}) {
+		t.Errorf("LastHour total = %+v", tot)
 	}
 	// Both sum, so saturation is correct at either scope.
 	if got.QueueLength != 90_010 || got.QueueCapacity != 200_000 {
@@ -91,61 +98,101 @@ func TestTargetMetricsAdd(t *testing.T) {
 	rev := cloneTargetMetrics(b)
 	rev.Add(a)
 	if rev.LastError != got.LastError || rev.LastMinute != got.LastMinute ||
-		rev.N != got.N || !maps.Equal(rev.Drops, got.Drops) {
+		rev.N != got.N || rev.LastHour.Total() != got.LastHour.Total() {
 		t.Errorf("order dependent:\n%+v\n%+v", rev, got)
+	}
+}
+
+// targetWindow is one node's report: a single segment on the minute grid.
+func targetWindow(first time.Time, seg TargetSegment) *SegmentedTargetMetrics {
+	return &SegmentedTargetMetrics{
+		Interval:  60,
+		FirstTime: first,
+		Segments:  []TargetSegment{seg},
+	}
+}
+
+// logVolumeWindow is one node's log-volume report: a single segment on the minute
+// grid.
+func logVolumeWindow(first time.Time, seg LogVolumeSegment) *SegmentedLogVolume {
+	return &SegmentedLogVolume{
+		Interval:  60,
+		FirstTime: first,
+		Segments:  []LogVolumeSegment{seg},
 	}
 }
 
 func cloneTargetMetrics(t *TargetMetrics) TargetMetrics {
 	out := *t
-	out.Drops = maps.Clone(t.Drops)
+	out.LastHour = cloneTargetWindow(t.LastHour)
+	out.LastDay = cloneTargetWindow(t.LastDay)
 	return out
+}
+
+func cloneTargetWindow(w *SegmentedTargetMetrics) *SegmentedTargetMetrics {
+	if w == nil {
+		return nil
+	}
+	out := *w
+	out.Segments = slices.Clone(w.Segments)
+	return &out
 }
 
 // Merge must never write through into the value it is given: the caller's copy is
 // another node's report, and mergeMap relies on Add being side-effect free on its
 // argument.
 func TestTargetMetricsAddDoesNotMutateArgument(t *testing.T) {
-	src := &TargetMetrics{N: 1, TotalEvents: 5, Drops: map[string]uint64{"queue_full": 2}}
-	want := maps.Clone(src.Drops)
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	src := &TargetMetrics{
+		N:        1,
+		LastHour: targetWindow(t0, TargetSegment{N: 1, Events: 5, DroppedQueueFull: 2}),
+	}
+	want := src.LastHour.Total()
 
 	dst := TargetMetrics{}
 	dst.Add(src)
 	dst.Add(src)
 
-	if !maps.Equal(src.Drops, want) {
-		t.Errorf("argument mutated: %v, want %v", src.Drops, want)
+	if got := src.LastHour.Total(); got != want {
+		t.Errorf("argument mutated: %+v, want %+v", got, want)
 	}
-	if dst.Drops["queue_full"] != 4 {
-		t.Errorf("dst = %v, want queue_full 4 after two merges", dst.Drops)
+	if got := dst.LastHour.Total(); got.Events != 10 || got.DroppedQueueFull != 4 {
+		t.Errorf("dst = %+v, want 10 events and 4 queue_full drops after two merges", got)
 	}
 }
 
 // The same guard one level up: merging a map of targets must not write into the
 // source maps.
 func TestDeliveryTargetMetricsMergeDoesNotMutateArgument(t *testing.T) {
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
 	src := &DeliveryTargetMetrics{
 		Nodes: 1,
 		Notification: map[string]TargetMetrics{
-			"notify_webhook:p": {N: 1, TotalEvents: 3, Drops: map[string]uint64{"shutdown": 1}},
+			"notify_webhook:p": {
+				N:        1,
+				LastHour: targetWindow(t0, TargetSegment{N: 1, Events: 3, DroppedShutdown: 1}),
+			},
 		},
-		LogVolume: map[string]uint64{"error": 2},
+		LogVolumeLastHour: logVolumeWindow(t0, LogVolumeSegment{N: 1, ErrorLines: 2}),
 	}
-	wantDrops := maps.Clone(src.Notification["notify_webhook:p"].Drops)
-	wantVolume := maps.Clone(src.LogVolume)
+	wantWindow := src.Notification["notify_webhook:p"].LastHour.Total()
+	wantVolume := src.LogVolumeLastHour.Total()
 
 	var dst DeliveryTargetMetrics
 	dst.Merge(src)
 	dst.Merge(src)
 
-	if !maps.Equal(src.Notification["notify_webhook:p"].Drops, wantDrops) {
-		t.Errorf("source target Drops mutated: %v", src.Notification["notify_webhook:p"].Drops)
+	if got := src.Notification["notify_webhook:p"].LastHour.Total(); got != wantWindow {
+		t.Errorf("source target window mutated: %+v, want %+v", got, wantWindow)
 	}
-	if !maps.Equal(src.LogVolume, wantVolume) {
-		t.Errorf("source LogVolume mutated: %v", src.LogVolume)
+	if got := src.LogVolumeLastHour.Total(); got != wantVolume {
+		t.Errorf("source log volume mutated: %+v, want %+v", got, wantVolume)
 	}
-	if got := dst.Notification["notify_webhook:p"]; got.TotalEvents != 6 || got.Drops["shutdown"] != 2 {
-		t.Errorf("dst = %+v, want events 6 and shutdown 2", got)
+	if got := dst.LogVolumeLastHour.Total(); got != (LogVolumeSegment{N: 2, ErrorLines: 4}) {
+		t.Errorf("dst log volume = %+v, want 4 error lines from 2 nodes", got)
+	}
+	if got := dst.Notification["notify_webhook:p"].LastHour.Total(); got.Events != 6 || got.DroppedShutdown != 2 {
+		t.Errorf("dst = %+v, want events 6 and 2 shutdown drops", got)
 	}
 }
 
@@ -164,19 +211,27 @@ func TestTargetMetricsAddKeepsIdentity(t *testing.T) {
 // The three classes stay in separate maps because a target name is only unique
 // within its config subsystem.
 func TestDeliveryTargetMetricsMerge(t *testing.T) {
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	target := func(events uint64) TargetMetrics {
+		return TargetMetrics{N: 1, LastHour: targetWindow(t0, TargetSegment{N: 1, Events: events})}
+	}
+
 	a := &DeliveryTargetMetrics{
 		Nodes:        1,
-		Notification: map[string]TargetMetrics{"notify_webhook:p": {N: 1, TotalEvents: 10}},
-		Audit:        map[string]TargetMetrics{"audit_kafka:1": {N: 1, TotalEvents: 5}},
+		Notification: map[string]TargetMetrics{"notify_webhook:p": target(10)},
+		Audit:        map[string]TargetMetrics{"audit_kafka:1": target(5)},
 		Spill:        &TargetSpillStats{Bytes: 100, Files: 1},
-		LogVolume:    map[string]uint64{"error": 3},
+
+		LogVolumeLastHour: logVolumeWindow(t0, LogVolumeSegment{N: 1, ErrorLines: 3}),
 	}
 	b := &DeliveryTargetMetrics{
 		Nodes:        1,
-		Notification: map[string]TargetMetrics{"notify_webhook:p": {N: 1, TotalEvents: 7}},
-		Logs:         map[string]TargetMetrics{"logger_webhook:main": {N: 1, TotalEvents: 2}},
+		Notification: map[string]TargetMetrics{"notify_webhook:p": target(7)},
+		Logs:         map[string]TargetMetrics{"logger_webhook:main": target(2)},
 		Spill:        &TargetSpillStats{Bytes: 50, Files: 2},
-		LogVolume:    map[string]uint64{"error": 1, "warning": 4},
+
+		LogVolumeLastHour: logVolumeWindow(t0, LogVolumeSegment{N: 1, ErrorLines: 1, WarningLines: 4}),
+		LogVolumeLastDay:  logVolumeWindow(t0, LogVolumeSegment{N: 1, FatalLines: 1}),
 	}
 
 	var got DeliveryTargetMetrics
@@ -186,26 +241,36 @@ func TestDeliveryTargetMetricsMerge(t *testing.T) {
 	if got.Nodes != 2 {
 		t.Errorf("Nodes = %d, want 2", got.Nodes)
 	}
-	if n := got.Notification["notify_webhook:p"]; n.N != 2 || n.TotalEvents != 17 {
+	if n := got.Notification["notify_webhook:p"]; n.N != 2 || n.LastHour.Total().Events != 17 {
 		t.Errorf("notification = %+v, want N=2 events=17", n)
 	}
 	// A class only one node reported must survive.
-	if got.Audit["audit_kafka:1"].TotalEvents != 5 || got.Logs["logger_webhook:main"].TotalEvents != 2 {
+	if got.Audit["audit_kafka:1"].LastHour.Total().Events != 5 ||
+		got.Logs["logger_webhook:main"].LastHour.Total().Events != 2 {
 		t.Errorf("audit/logs lost: %+v / %+v", got.Audit, got.Logs)
 	}
 	if got.Spill == nil || got.Spill.Bytes != 150 || got.Spill.Files != 3 {
 		t.Errorf("Spill = %+v, want 150/3", got.Spill)
 	}
-	if !maps.Equal(got.LogVolume, map[string]uint64{"error": 4, "warning": 4}) {
-		t.Errorf("LogVolume = %v", got.LogVolume)
+	// Log volume is node-level, so it sums across reports like everything else --
+	// and a window only one node reported must survive.
+	if tot := got.LogVolumeLastHour.Total(); tot != (LogVolumeSegment{N: 2, ErrorLines: 4, WarningLines: 4}) {
+		t.Errorf("LogVolumeLastHour total = %+v", tot)
+	}
+	if tot := got.LogVolumeLastDay.Total(); tot != (LogVolumeSegment{N: 1, FatalLines: 1}) {
+		t.Errorf("LogVolumeLastDay total = %+v", tot)
 	}
 }
 
 func TestDeliveryTargetMetricsMergeNil(t *testing.T) {
+	t0 := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
 	full := &DeliveryTargetMetrics{
-		Nodes:        1,
-		Notification: map[string]TargetMetrics{"notify_webhook:p": {N: 1, TotalEvents: 10}},
-		Spill:        &TargetSpillStats{Bytes: 100},
+		Nodes: 1,
+		Notification: map[string]TargetMetrics{
+			"notify_webhook:p": {N: 1, LastHour: targetWindow(t0, TargetSegment{N: 1, Events: 10})},
+		},
+		Spill:             &TargetSpillStats{Bytes: 100},
+		LogVolumeLastHour: logVolumeWindow(t0, LogVolumeSegment{N: 1, ErrorLines: 7}),
 	}
 
 	var got DeliveryTargetMetrics
@@ -213,7 +278,8 @@ func TestDeliveryTargetMetricsMergeNil(t *testing.T) {
 	got.Merge(&DeliveryTargetMetrics{})
 	got.Merge(nil)
 
-	if got.Notification["notify_webhook:p"].TotalEvents != 10 || got.Spill == nil {
+	if got.Notification["notify_webhook:p"].LastHour.Total().Events != 10 || got.Spill == nil ||
+		got.LogVolumeLastHour.Total().ErrorLines != 7 {
 		t.Errorf("a node reporting nothing blanked a real report: %+v", got)
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1027,9 +1027,13 @@ type DriveReclaimStats struct {
 	// same pass but reclaim different things.
 	TmpWriteDirPurged uint64 `json:"tmp_write_dir_purged,omitempty"`
 
-	// TrashPurged and TrashPurgedBytes are objects finally deleted from trash.
-	// Reclamation is two-stage -- the counters above move things INTO trash, these
-	// remove them -- so a gap between them is capacity not yet returned.
+	// TrashPurged and TrashPurgedBytes are objects finally deleted from trash by
+	// the generic trash sweeper. This covers a wider population than the counters
+	// above: the trash also receives entries from metacache cleanup and other
+	// delete/rename paths, which do not increment them. No backlog can therefore
+	// be derived by subtracting these from the counters above -- unrelated
+	// removals can cancel or exceed the staged counts, and trash already present
+	// when the counters start is purged with no matching staging increment.
 	TrashPurged      uint64 `json:"trash_purged,omitempty"`
 	TrashPurgedBytes uint64 `json:"trash_purged_bytes,omitempty"`
 

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -475,7 +475,7 @@ func apiView(ops map[string]madmin.SegmentedAPIMetrics) segView[madmin.APIStats,
 		opLeaf: func(op string, s madmin.APIStats, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
 			return &APIEndpointNode{endpoint: op, stats: s, segmentTime: segTime, interval: interval, parent: parent, path: path}
 		},
-		sumLeaf: func(s madmin.APIStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
+		sumLeaf: func(s madmin.APIStats, segTime time.Time, _, _ int, parent MetricNode, path string) MetricNode {
 			return &APITimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
 		},
 	}
@@ -606,16 +606,21 @@ func (node *APILastDayAllNode) GetChildren() []MetricChild {
 	})
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(segmented.FirstTime, segmented.Interval, len(segmented.Segments))
 	for i := len(segmented.Segments) - 1; i >= 0; i-- {
 		seg := segmented.Segments[i]
 		if seg.Requests == 0 {
 			continue
 		}
-		segmentTime := segmented.FirstTime.Add(time.Duration(i*segmented.Interval) * time.Second)
+		segmentTime := segmentStart(segmented.FirstTime, segmented.Interval, i)
+		name := segmentKey(segmentTime)
+		if owners[name] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(segmented.Interval) * time.Second)
 
 		children = append(children, MetricChild{
-			Name:        segmentTime.UTC().Format("15:04Z"),
+			Name:        name,
 			Description: formatAPITimeSegmentDesc(seg, segmented.Interval, segmentTime, endTime),
 		})
 	}
@@ -639,16 +644,14 @@ func (node *APILastDayAllNode) GetChild(name string) (MetricNode, error) {
 	}
 
 	// Handle time segments - find by time format (with UTC indicator)
-	for i := len(segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := segmented.FirstTime.Add(time.Duration(i*segmented.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return &APITimeSegmentAllNode{
-				segment:     segmented.Segments[i],
-				segmentTime: segmentTime,
-				parent:      node,
-				path:        node.path + "/" + name,
-			}, nil
-		}
+	owners := segmentSecOwners(segmented.FirstTime, segmented.Interval, len(segmented.Segments))
+	if i, ok := owners[name]; ok {
+		return &APITimeSegmentAllNode{
+			segment:     segmented.Segments[i],
+			segmentTime: segmentStart(segmented.FirstTime, segmented.Interval, i),
+			parent:      node,
+			path:        node.path + "/" + name,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)
@@ -695,16 +698,21 @@ func (node *APILastDayEndpointNode) GetChildren() []MetricChild {
 	})
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
 		seg := node.segmented.Segments[i]
 		if seg.Requests == 0 {
 			continue
 		}
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
+		name := segmentKey(segmentTime)
+		if owners[name] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
 
 		children = append(children, MetricChild{
-			Name:        segmentTime.UTC().Format("15:04Z"),
+			Name:        name,
 			Description: formatAPITimeSegmentDesc(seg, node.segmented.Interval, segmentTime, endTime),
 		})
 	}
@@ -734,18 +742,16 @@ func (node *APILastDayEndpointNode) GetChild(name string) (MetricNode, error) {
 	}
 
 	// Handle time segments - find by time format (with UTC indicator)
-	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return &APIEndpointNode{
-				endpoint:    node.apiName,
-				stats:       node.segmented.Segments[i],
-				segmentTime: segmentTime,
-				interval:    node.segmented.Interval,
-				parent:      node,
-				path:        node.path + "/" + name,
-			}, nil
-		}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	if i, ok := owners[name]; ok {
+		return &APIEndpointNode{
+			endpoint:    node.apiName,
+			stats:       node.segmented.Segments[i],
+			segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
+			interval:    node.segmented.Interval,
+			parent:      node,
+			path:        node.path + "/" + name,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)

--- a/mnav/bytime.go
+++ b/mnav/bytime.go
@@ -46,7 +46,7 @@ type segView[T any, PT segPtr[T]] struct {
 	segDesc     func(total T, interval int, segTime, end time.Time) string // _by_time list row
 	opDesc      func(op string, s T, interval int) string                  // per-segment op list row
 	opLeaf      func(op string, s T, segTime time.Time, interval int, parent MetricNode, path string) MetricNode
-	sumLeaf     func(total T, segTime time.Time, interval int, parent MetricNode, path string) MetricNode
+	sumLeaf     func(total T, segTime time.Time, interval, merged int, parent MetricNode, path string) MetricNode
 }
 
 // newByTimeNode returns the "_by_time" entry: pick a time segment first, then see
@@ -82,16 +82,21 @@ func segmentAt[T any, PT segPtr[T]](s madmin.Segmented[T, PT], segTime time.Time
 	return zero, false
 }
 
-// segmentSummary sums every operation's value at segTime (== totalSegmented slot).
-func segmentSummary[T any, PT segPtr[T]](ops map[string]madmin.Segmented[T, PT], segTime time.Time) T {
+// segmentSummary sums every operation's value at segTime (== totalSegmented slot),
+// and reports how many contributed. The count is what a per-node field has to be
+// divided by: each operation carries its own sample per node, so a summary over
+// three operations reports a five-node cluster as fifteen.
+func segmentSummary[T any, PT segPtr[T]](ops map[string]madmin.Segmented[T, PT], segTime time.Time) (T, int) {
 	var total T
+	var merged int
 	pt := PT(&total)
 	for _, op := range sortedKeys(ops) {
 		if v, ok := segmentAt(ops[op], segTime); ok {
 			pt.Add(&v)
+			merged++
 		}
 	}
-	return total
+	return total, merged
 }
 
 // byTimeNode lists the last-day time segments, newest first, empties filtered.
@@ -111,15 +116,20 @@ func (node *byTimeNode[T, PT]) GetLeafData() map[string]string     { return nil 
 
 func (node *byTimeNode[T, PT]) GetChildren() []MetricChild {
 	total := totalSegmented(node.view.ops)
+	owners := segmentSecOwners(total.FirstTime, total.Interval, len(total.Segments))
 	var children []MetricChild
 	for i := len(total.Segments) - 1; i >= 0; i-- {
 		if node.view.empty(&total.Segments[i]) {
 			continue
 		}
-		segTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
+		segTime := segmentStart(total.FirstTime, total.Interval, i)
+		name := segmentKey(segTime)
+		if owners[name] != i {
+			continue
+		}
 		end := segTime.Add(time.Duration(total.Interval) * time.Second)
 		children = append(children, MetricChild{
-			Name:        segTime.UTC().Format("15:04Z"),
+			Name:        name,
 			Description: node.view.segDesc(total.Segments[i], total.Interval, segTime, end),
 		})
 	}
@@ -128,17 +138,15 @@ func (node *byTimeNode[T, PT]) GetChildren() []MetricChild {
 
 func (node *byTimeNode[T, PT]) GetChild(name string) (MetricNode, error) {
 	total := totalSegmented(node.view.ops)
-	for i := range total.Segments {
-		segTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
-		if segTime.UTC().Format("15:04Z") == name {
-			return &byTimeSegmentNode[T, PT]{
-				view:     node.view,
-				segTime:  segTime,
-				interval: total.Interval,
-				parent:   node,
-				path:     node.path + "/" + name,
-			}, nil
-		}
+	owners := segmentSecOwners(total.FirstTime, total.Interval, len(total.Segments))
+	if i, ok := owners[name]; ok {
+		return &byTimeSegmentNode[T, PT]{
+			view:     node.view,
+			segTime:  segmentStart(total.FirstTime, total.Interval, i),
+			interval: total.Interval,
+			parent:   node,
+			path:     node.path + "/" + name,
+		}, nil
 	}
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }
@@ -179,8 +187,8 @@ func (node *byTimeSegmentNode[T, PT]) GetChildren() []MetricChild {
 
 func (node *byTimeSegmentNode[T, PT]) GetChild(name string) (MetricNode, error) {
 	if name == "_ALL" {
-		total := segmentSummary(node.view.ops, node.segTime)
-		return node.view.sumLeaf(total, node.segTime, node.interval, node, node.path+"/_ALL"), nil
+		total, merged := segmentSummary(node.view.ops, node.segTime)
+		return node.view.sumLeaf(total, node.segTime, node.interval, merged, node, node.path+"/_ALL"), nil
 	}
 	seg, ok := node.view.ops[name]
 	if !ok {
@@ -194,6 +202,6 @@ func (node *byTimeSegmentNode[T, PT]) GetChild(name string) (MetricNode, error) 
 }
 
 func (node *byTimeSegmentNode[T, PT]) GetLeafData() map[string]string {
-	total := segmentSummary(node.view.ops, node.segTime)
-	return node.view.sumLeaf(total, node.segTime, node.interval, node, node.path).GetLeafData()
+	total, merged := segmentSummary(node.view.ops, node.segTime)
+	return node.view.sumLeaf(total, node.segTime, node.interval, merged, node, node.path).GetLeafData()
 }

--- a/mnav/collected_at_test.go
+++ b/mnav/collected_at_test.go
@@ -121,6 +121,50 @@ func TestCollectedAtUnknownShowsAbsolute(t *testing.T) {
 	}
 }
 
+// An unset timestamp has no stamp and no age to show, so its row is omitted
+// rather than rendered as the zero time -- which would read as year one, or as an
+// age of two millennia once measured against collection.
+func TestUnsetTimestampOmitsRow(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		CollectedAt: captureAt,
+		Aggregated: madmin.Metrics{
+			Locks: &madmin.LockMetrics{
+				CollectedAt: captureAt,
+				// Counts recorded, no timestamp on either field.
+				Purge: &madmin.LockPurgeStats{Readers: 4, Writers: 2, Expired: 1},
+			},
+			IAM: &madmin.IAMMetrics{
+				CollectedAt: captureAt,
+				Cache:       &madmin.IAMCacheStats{Policies: 3},
+			},
+		},
+	})
+
+	for _, tc := range []struct{ path, key string }{
+		{"locks/purge", "Sampled At"},
+		{"locks", "Cleanup Sampled"},
+		{"locks", "Oldest Lock Held"},
+		{"iam", "Inventory Sampled"},
+	} {
+		leaf, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := leafValue(leaf.GetLeafData(), tc.key); got != "" {
+			t.Errorf("%s[%s] = %q, want the row omitted for an unset timestamp", tc.path, tc.key, got)
+		}
+	}
+
+	// The rows that do not depend on a timestamp must still be there.
+	leaf, err := nav.Navigate("locks/purge")
+	if err != nil {
+		t.Fatalf("navigate locks/purge: %v", err)
+	}
+	if got, want := leafValue(leaf.GetLeafData(), "Read Locks"), "4"; got != want {
+		t.Errorf("Read Locks = %q, want %q", got, want)
+	}
+}
+
 // The same rule on an age-only row: it degrades to the absolute stamp, since
 // there is no stamp elsewhere on the row to fall back to.
 func TestCollectedAtUnknownAgeOnlyRow(t *testing.T) {

--- a/mnav/collected_at_test.go
+++ b/mnav/collected_at_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// Ages are measured against the collection time, so metrics restored from a
+// capture read as they did when taken rather than as decades stale. A capture
+// timestamp far in the past makes a wall-clock regression obvious.
+var captureAt = time.Date(2001, 5, 14, 8, 15, 0, 0, time.UTC)
+
+func TestCollectedAtFromRoot(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		CollectedAt: captureAt,
+		Aggregated: madmin.Metrics{Locks: &madmin.LockMetrics{
+			Purge: &madmin.LockPurgeStats{
+				SampledAt:    captureAt.Add(-90 * time.Second),
+				OldestHeldAt: captureAt.Add(-5 * time.Minute),
+				Readers:      3,
+				Writers:      1,
+			},
+		}},
+	})
+	leaf, err := nav.Navigate("locks/purge")
+	if err != nil {
+		t.Fatalf("navigate locks/purge: %v", err)
+	}
+	d := leaf.GetLeafData()
+	if got := leafValue(d, "Sampled At"); !strings.Contains(got, "1m30s ago") {
+		t.Errorf("Sampled At = %q, want an age measured against collection time", got)
+	}
+	if got := leafValue(d, "Oldest Lock"); !strings.Contains(got, "held 5m0s") {
+		t.Errorf("Oldest Lock = %q, want an age measured against collection time", got)
+	}
+}
+
+// A metric family carries its own collection time. The nearest ancestor that
+// knows one wins, so a family scraped at a different moment than the envelope
+// reports against its own timestamp.
+func TestCollectedAtFamilyBeatsRoot(t *testing.T) {
+	diskAt := captureAt.Add(30 * time.Minute)
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		CollectedAt: captureAt,
+		Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{
+			CollectedAt: diskAt,
+			NDisks:      1,
+			Reclaim: madmin.DriveReclaimStats{
+				CleanupCycles: 1,
+				LastCleanupAt: diskAt.Add(-45 * time.Second),
+			},
+		}},
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	if got := leafValue(leaf.GetLeafData(), "Last Cleanup"); !strings.Contains(got, "45s ago") {
+		t.Errorf("Last Cleanup = %q, want the age against the disk collection time", got)
+	}
+
+	// Same rule one family over, reached through an intermediate node: the purge
+	// leaf resolves its parent's timestamp, not the envelope's.
+	lockAt := captureAt.Add(20 * time.Minute)
+	nav = NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		CollectedAt: captureAt,
+		Aggregated: madmin.Metrics{Locks: &madmin.LockMetrics{
+			CollectedAt: lockAt,
+			Purge: &madmin.LockPurgeStats{
+				SampledAt: lockAt.Add(-2 * time.Minute),
+				Readers:   1,
+			},
+		}},
+	})
+	if leaf, err = nav.Navigate("locks/purge"); err != nil {
+		t.Fatalf("navigate locks/purge: %v", err)
+	}
+	if got := leafValue(leaf.GetLeafData(), "Sampled At"); !strings.Contains(got, "2m0s ago") {
+		t.Errorf("Sampled At = %q, want the age against the lock collection time", got)
+	}
+}
+
+// With no collection time anywhere on the chain there is no reference point, so
+// the absolute timestamp must be shown rather than an age. Substituting the wall
+// clock here would reintroduce the bug on exactly the captures that lack one.
+func TestCollectedAtUnknownShowsAbsolute(t *testing.T) {
+	stamp := time.Date(2003, 9, 2, 4, 5, 6, 0, time.UTC)
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{
+			NDisks:  1,
+			Reclaim: madmin.DriveReclaimStats{CleanupCycles: 1, LastCleanupAt: stamp},
+		}},
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	got := leafValue(leaf.GetLeafData(), "Last Cleanup")
+	if want := "2003-09-02 04:05:06"; got != want {
+		t.Errorf("Last Cleanup = %q, want the bare stamp %q with no derived age", got, want)
+	}
+}
+
+// The same rule on an age-only row: it degrades to the absolute stamp, since
+// there is no stamp elsewhere on the row to fall back to.
+func TestCollectedAtUnknownAgeOnlyRow(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Locks: &madmin.LockMetrics{
+			Purge: &madmin.LockPurgeStats{
+				SampledAt: time.Date(2003, 9, 2, 4, 5, 6, 0, time.UTC),
+				Readers:   1,
+			},
+		}},
+	})
+	leaf, err := nav.Navigate("locks")
+	if err != nil {
+		t.Fatalf("navigate locks: %v", err)
+	}
+	if got, want := leafValue(leaf.GetLeafData(), "Cleanup Sampled"), "04:05:06"; got != want {
+		t.Errorf("Cleanup Sampled = %q, want the bare stamp %q", got, want)
+	}
+}

--- a/mnav/cpu.go
+++ b/mnav/cpu.go
@@ -391,7 +391,7 @@ func (node *CPUSegmentedNode) GetLeafData() map[string]string {
 		idx++
 		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := fmt.Sprintf("%02d: %s->%s", idx, startTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
+		name := segmentRowKey(idx, startTime, endTime)
 
 		n := float64(seg.N)
 		user := seg.User / n
@@ -444,7 +444,7 @@ func (node *PowerSegmentedNode) GetLeafData() map[string]string {
 		idx++
 		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := fmt.Sprintf("%02d: %s->%s", idx, startTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
+		name := segmentRowKey(idx, startTime, endTime)
 		avg := seg.SumWatts / float64(seg.N)
 		data[name] = fmt.Sprintf("Avg: %s, Min: %s, Max: %s (%s nodes)",
 			humanize.SI(avg, "W"),

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -604,7 +604,7 @@ func diskView(ops map[string]madmin.SegmentedDiskActions) segView[madmin.DiskAct
 		opLeaf: func(op string, a madmin.DiskAction, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
 			return &DiskLastDayAllLeafNode{action: a, label: op, parent: parent, path: path}
 		},
-		sumLeaf: func(a madmin.DiskAction, _ time.Time, _ int, parent MetricNode, path string) MetricNode {
+		sumLeaf: func(a madmin.DiskAction, _ time.Time, _, _ int, parent MetricNode, path string) MetricNode {
 			return &DiskLastDayAllLeafNode{action: a, label: "All operations", parent: parent, path: path}
 		},
 	}
@@ -983,10 +983,14 @@ func (node *DiskIODailyStatsNode) GetChildren() []MetricChild {
 	dailyStats := &node.disk.IOStatsDay
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(dailyStats.FirstTime, dailyStats.Interval, len(dailyStats.Segments))
 	for i := len(dailyStats.Segments) - 1; i >= 0; i-- {
-		segmentTime := dailyStats.FirstTime.Add(time.Duration(i*dailyStats.Interval) * time.Second)
+		segmentTime := segmentStart(dailyStats.FirstTime, dailyStats.Interval, i)
 		endTime := segmentTime.Add(time.Duration(dailyStats.Interval) * time.Second)
-		segmentName := segmentTime.UTC().Format("15:04Z")
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		segment := dailyStats.Segments[i]
 		totalIOs := segment.ReadIOs + segment.WriteIOs + segment.DiscardIOs + segment.FlushIOs
@@ -1131,11 +1135,10 @@ func (node *DiskIODailyStatsNode) GetChild(name string) (MetricNode, error) {
 	}
 
 	// Handle time segments - find by time format (with UTC indicator)
-	for i := len(dailyStats.Segments) - 1; i >= 0; i-- {
-		segmentTime := dailyStats.FirstTime.Add(time.Duration(i*dailyStats.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return NewDiskIOTimeSegmentNode(dailyStats.Segments[i], segmentTime, dailyStats.Interval, node, fmt.Sprintf("%s/%s", node.path, name)), nil
-		}
+	owners := segmentSecOwners(dailyStats.FirstTime, dailyStats.Interval, len(dailyStats.Segments))
+	if i, ok := owners[name]; ok {
+		segmentTime := segmentStart(dailyStats.FirstTime, dailyStats.Interval, i)
+		return NewDiskIOTimeSegmentNode(dailyStats.Segments[i], segmentTime, dailyStats.Interval, node, fmt.Sprintf("%s/%s", node.path, name)), nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)
@@ -1256,12 +1259,17 @@ func (node *DiskLastDayAllNode) GetChildren() []MetricChild {
 
 	children := []MetricChild{{Name: "Total", Description: "Aggregated totals across all time segments"}}
 
+	owners := segmentSecOwners(total.FirstTime, total.Interval, len(total.Segments))
 	for i := len(total.Segments) - 1; i >= 0; i-- {
 		seg := total.Segments[i]
 		if seg.Count == 0 {
 			continue
 		}
-		segmentTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
+		segmentTime := segmentStart(total.FirstTime, total.Interval, i)
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(total.Interval) * time.Second)
 
 		avg := ""
@@ -1273,7 +1281,7 @@ func (node *DiskLastDayAllNode) GetChildren() []MetricChild {
 			day = "Yesterday "
 		}
 		children = append(children, MetricChild{
-			Name: segmentTime.UTC().Format("15:04Z"),
+			Name: segmentName,
 			Description: fmt.Sprintf("%s%s -> %s (%d ops%s)",
 				day, segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"),
 				seg.Count, avg),
@@ -1292,13 +1300,12 @@ func (node *DiskLastDayAllNode) GetChild(name string) (MetricNode, error) {
 		return &DiskLastDayAllLeafNode{action: total.Total(), label: "Total", parent: node, path: node.path + "/Total"}, nil
 	}
 
-	for i := range total.Segments {
-		segmentTime := total.FirstTime.Add(time.Duration(i*total.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			endTime := segmentTime.Add(time.Duration(total.Interval) * time.Second)
-			label := fmt.Sprintf("%s -> %s", segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
-			return &DiskLastDayAllLeafNode{action: total.Segments[i], label: label, parent: node, path: node.path + "/" + name}, nil
-		}
+	owners := segmentSecOwners(total.FirstTime, total.Interval, len(total.Segments))
+	if i, ok := owners[name]; ok {
+		segmentTime := segmentStart(total.FirstTime, total.Interval, i)
+		endTime := segmentTime.Add(time.Duration(total.Interval) * time.Second)
+		label := fmt.Sprintf("%s -> %s", segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
+		return &DiskLastDayAllLeafNode{action: total.Segments[i], label: label, parent: node, path: node.path + "/" + name}, nil
 	}
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }
@@ -1381,10 +1388,14 @@ func (node *DiskLastDayOperationNode) GetChildren() []MetricChild {
 	})
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
 		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		segmentName := segmentTime.UTC().Format("15:04Z")
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		// Get operation count for this segment
 		var operations uint64
@@ -1435,18 +1446,16 @@ func (node *DiskLastDayOperationNode) GetChild(name string) (MetricNode, error) 
 	}
 
 	// Handle time segments - find by time format (with UTC indicator)
-	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return &DiskOperationTimeSegmentNode{
-				operationType: node.operationType,
-				segment:       node.segmented.Segments[i],
-				segmentTime:   segmentTime,
-				interval:      node.segmented.Interval,
-				parent:        node,
-				path:          fmt.Sprintf("%s/%s", node.path, name),
-			}, nil
-		}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	if i, ok := owners[name]; ok {
+		return &DiskOperationTimeSegmentNode{
+			operationType: node.operationType,
+			segment:       node.segmented.Segments[i],
+			segmentTime:   segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
+			interval:      node.segmented.Interval,
+			parent:        node,
+			path:          fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)
@@ -1695,6 +1704,7 @@ func (node *DiskIOLastDayAllNode) GetChildren() []MetricChild {
 
 	children := []MetricChild{{Name: "Total", Description: "Aggregated IO totals across all time segments"}}
 
+	owners := segmentSecOwners(node.dailyStats.FirstTime, node.dailyStats.Interval, len(node.dailyStats.Segments))
 	for i := len(node.dailyStats.Segments) - 1; i >= 0; i-- {
 		seg := node.dailyStats.Segments[i]
 		totalIOs := seg.ReadIOs + seg.WriteIOs + seg.DiscardIOs + seg.FlushIOs
@@ -1702,7 +1712,11 @@ func (node *DiskIOLastDayAllNode) GetChildren() []MetricChild {
 			continue
 		}
 
-		segmentTime := node.dailyStats.FirstTime.Add(time.Duration(i*node.dailyStats.Interval) * time.Second)
+		segmentTime := segmentStart(node.dailyStats.FirstTime, node.dailyStats.Interval, i)
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(node.dailyStats.Interval) * time.Second)
 
 		intervalSecs := float64(node.dailyStats.Interval)
@@ -1724,7 +1738,7 @@ func (node *DiskIOLastDayAllNode) GetChildren() []MetricChild {
 		}
 
 		children = append(children, MetricChild{
-			Name:        segmentTime.UTC().Format("15:04Z"),
+			Name:        segmentName,
 			Description: desc,
 		})
 	}
@@ -1744,11 +1758,10 @@ func (node *DiskIOLastDayAllNode) GetChild(name string) (MetricNode, error) {
 		}, nil
 	}
 
-	for i := range node.dailyStats.Segments {
-		segmentTime := node.dailyStats.FirstTime.Add(time.Duration(i*node.dailyStats.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return NewDiskIOTimeSegmentNode(node.dailyStats.Segments[i], segmentTime, node.dailyStats.Interval, node, node.path+"/"+name), nil
-		}
+	owners := segmentSecOwners(node.dailyStats.FirstTime, node.dailyStats.Interval, len(node.dailyStats.Segments))
+	if i, ok := owners[name]; ok {
+		segmentTime := segmentStart(node.dailyStats.FirstTime, node.dailyStats.Interval, i)
+		return NewDiskIOTimeSegmentNode(node.dailyStats.Segments[i], segmentTime, node.dailyStats.Interval, node, node.path+"/"+name), nil
 	}
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -71,6 +71,9 @@ func (node *DiskMetricsNavigator) GetChildren() []MetricChild {
 	children = append(children, MetricChild{Name: "space", Description: "Drive space information"})
 
 	// Optional features - only add if data exists
+	if diskReclaimActive(node.disk.Reclaim) {
+		children = append(children, MetricChild{Name: "reclaim", Description: "Background space reclamation (stale writes and trash)"})
+	}
 	if node.disk.HealingInfo != nil {
 		children = append(children, MetricChild{Name: "healing", Description: "Drive healing information"})
 	}
@@ -289,6 +292,8 @@ func (node *DiskMetricsNavigator) GetChild(name string) (MetricNode, error) {
 		return NewDiskIODailyStatsNode(node.disk, node, fmt.Sprintf("%s/io_last_day", node.path)), nil
 	case "space":
 		return NewDiskSpaceNode(&node.disk.Space, node, fmt.Sprintf("%s/space", node.path)), nil
+	case "reclaim":
+		return NewDiskReclaimNode(node.disk.Reclaim, node, fmt.Sprintf("%s/reclaim", node.path)), nil
 	case "healing":
 		return NewDiskHealingNode(node.disk.HealingInfo, node, fmt.Sprintf("%s/healing", node.path)), nil
 	case "cache":
@@ -2587,4 +2592,78 @@ func formatIOStats(data map[string]string, opType string, ios, merges, sectors, 
 		totalLine += fmt.Sprintf(", %s merged", humanize.Comma(int64(merges)))
 	}
 	data[opType+" Totals"] = totalLine
+}
+
+// diskReclaimActive reports whether background reclamation has anything to show.
+// DiskMetric.Reclaim is a value rather than a pointer, so presence cannot be
+// tested by nil: an all-zero block means no cleanup pass has completed yet.
+func diskReclaimActive(r madmin.DriveReclaimStats) bool {
+	return r.CleanupCycles > 0 || !r.LastCleanupAt.IsZero() ||
+		r.StaleMultipartPurged > 0 || r.TmpWriteDirPurged > 0 ||
+		r.TrashPurged > 0 || r.TrashPurgedBytes > 0
+}
+
+// DiskReclaimNode is background space reclamation on a drive: what the cleanup
+// passes moved into trash and what they finally removed from it.
+type DiskReclaimNode struct {
+	reclaim madmin.DriveReclaimStats
+	parent  MetricNode
+	path    string
+}
+
+// NewDiskReclaimNode constructs a new DiskReclaimNode.
+func NewDiskReclaimNode(reclaim madmin.DriveReclaimStats, parent MetricNode, path string) *DiskReclaimNode {
+	return &DiskReclaimNode{reclaim: reclaim, parent: parent, path: path}
+}
+
+func (node *DiskReclaimNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *DiskReclaimNode) GetMetricType() madmin.MetricType   { return madmin.MetricsDisk }
+func (node *DiskReclaimNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *DiskReclaimNode) GetParent() MetricNode              { return node.parent }
+func (node *DiskReclaimNode) GetPath() string                    { return node.path }
+func (node *DiskReclaimNode) ShouldPauseRefresh() bool           { return false }
+func (node *DiskReclaimNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *DiskReclaimNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *DiskReclaimNode) GetLeafData() map[string]string {
+	r := node.reclaim
+	if !diskReclaimActive(r) {
+		return map[string]string{"Status": "no cleanup pass has completed yet"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+
+	// Stage one: what the passes moved into trash, split by what was reclaimed.
+	// The two run in the same pass but retire different things -- an upload entry
+	// versus a whole temporary write window -- so a rise in one is a different
+	// story from a rise in the other.
+	add("Stale Multipart Purged", humanize.Comma(int64(r.StaleMultipartPurged)))
+	add("Tmp Write Dirs Purged", humanize.Comma(int64(r.TmpWriteDirPurged)))
+
+	// Stage two: what left the trash. The gap against stage one is capacity that
+	// has been given up on but not yet returned to the filesystem.
+	add("Trash Purged", fmt.Sprintf("%s object(s), %s",
+		humanize.Comma(int64(r.TrashPurged)), humanize.IBytes(r.TrashPurgedBytes)))
+	if staged := r.StaleMultipartPurged + r.TmpWriteDirPurged; staged > r.TrashPurged {
+		add("Awaiting Trash Purge", humanize.Comma(int64(staged-r.TrashPurged))+" entry/entries")
+	}
+
+	add("Cleanup Cycles", humanize.Comma(int64(r.CleanupCycles)))
+	// Age derived here; the wire carries the timestamp so the merge can take the
+	// oldest and surface a drive whose cleanup has stalled.
+	if !r.LastCleanupAt.IsZero() {
+		add("Last Cleanup", fmt.Sprintf("%s (%s ago)",
+			r.LastCleanupAt.Format("2006-01-02 15:04:05"),
+			roundDuration(time.Since(r.LastCleanupAt))))
+	} else {
+		add("Last Cleanup", "no pass has finished yet")
+	}
+	return data
 }

--- a/mnav/disk.go
+++ b/mnav/disk.go
@@ -36,6 +36,13 @@ type DiskMetricsNavigator struct {
 	opts   madmin.MetricsOptions
 }
 
+func (node *DiskMetricsNavigator) collectionTime() time.Time {
+	if node.disk == nil {
+		return time.Time{}
+	}
+	return node.disk.CollectedAt
+}
+
 func (node *DiskMetricsNavigator) GetOpts() madmin.MetricsOptions {
 	opts := getNodeOpts(node)
 	opts.DriveSetIdx = append(opts.DriveSetIdx, node.opts.DriveSetIdx...)
@@ -2640,28 +2647,26 @@ func (node *DiskReclaimNode) GetLeafData() map[string]string {
 		idx++
 	}
 
-	// Stage one: what the passes moved into trash, split by what was reclaimed.
-	// The two run in the same pass but retire different things -- an upload entry
-	// versus a whole temporary write window -- so a rise in one is a different
-	// story from a rise in the other.
+	// What the passes moved into trash, split by what was reclaimed. The two run
+	// in the same pass but retire different things -- an upload entry versus a
+	// whole temporary write window -- so a rise in one is a different story from
+	// a rise in the other.
 	add("Stale Multipart Purged", humanize.Comma(int64(r.StaleMultipartPurged)))
 	add("Tmp Write Dirs Purged", humanize.Comma(int64(r.TmpWriteDirPurged)))
 
-	// Stage two: what left the trash. The gap against stage one is capacity that
-	// has been given up on but not yet returned to the filesystem.
+	// What left the trash. Not comparable against the counters above: the sweeper
+	// also removes entries staged by paths that do not increment them, so no
+	// backlog can be derived from the difference.
 	add("Trash Purged", fmt.Sprintf("%s object(s), %s",
 		humanize.Comma(int64(r.TrashPurged)), humanize.IBytes(r.TrashPurgedBytes)))
-	if staged := r.StaleMultipartPurged + r.TmpWriteDirPurged; staged > r.TrashPurged {
-		add("Awaiting Trash Purge", humanize.Comma(int64(staged-r.TrashPurged))+" entry/entries")
-	}
 
 	add("Cleanup Cycles", humanize.Comma(int64(r.CleanupCycles)))
 	// Age derived here; the wire carries the timestamp so the merge can take the
-	// oldest and surface a drive whose cleanup has stalled.
+	// oldest and surface a drive whose cleanup has stalled. Measured against the
+	// collection time, not the wall clock: these metrics may have been loaded from
+	// a capture taken long ago.
 	if !r.LastCleanupAt.IsZero() {
-		add("Last Cleanup", fmt.Sprintf("%s (%s ago)",
-			r.LastCleanupAt.Format("2006-01-02 15:04:05"),
-			roundDuration(time.Since(r.LastCleanupAt))))
+		add("Last Cleanup", stampAge(node, r.LastCleanupAt, "2006-01-02 15:04:05", time.Second))
 	} else {
 		add("Last Cleanup", "no pass has finished yet")
 	}

--- a/mnav/disk_reclaim_test.go
+++ b/mnav/disk_reclaim_test.go
@@ -25,10 +25,16 @@ import (
 	"github.com/minio/madmin-go/v4"
 )
 
+// collectedAt is fixed so the derived cleanup age does not depend on the wall
+// clock: the reader measures against collection time, not time.Now.
+var reclaimCollectedAt = time.Date(2026, 2, 3, 10, 30, 0, 0, time.UTC)
+
 func reclaimNav(t *testing.T, r madmin.DriveReclaimStats) MetricNavigator {
 	t.Helper()
 	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
-		Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{NDisks: 4, Reclaim: r}},
+		Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{
+			CollectedAt: reclaimCollectedAt, NDisks: 4, Reclaim: r,
+		}},
 	})
 }
 
@@ -63,10 +69,11 @@ func TestDiskReclaimHiddenUntilItHasRun(t *testing.T) {
 	}
 }
 
-// The two stages are separate counters on purpose: the first moves things into
-// trash, the second removes them, and the gap is capacity not yet returned.
+// The counters are reported as-is. Notably no backlog is derived from them: the
+// trash sweeper also removes entries staged by paths that do not increment the
+// counters above it, so a difference would not be a backlog.
 func TestDiskReclaimLeaf(t *testing.T) {
-	last := time.Now().Add(-90 * time.Second)
+	last := reclaimCollectedAt.Add(-90 * time.Second)
 	nav := reclaimNav(t, madmin.DriveReclaimStats{
 		StaleMultipartPurged: 1200,
 		TmpWriteDirPurged:    25,
@@ -85,9 +92,7 @@ func TestDiskReclaimLeaf(t *testing.T) {
 		"Stale Multipart Purged": "1,200",
 		"Tmp Write Dirs Purged":  "25",
 		"Trash Purged":           "1,000 object(s), 5.0 GiB",
-		// 1200 + 25 staged, 1000 removed.
-		"Awaiting Trash Purge": "225 entry/entries",
-		"Cleanup Cycles":       "7",
+		"Cleanup Cycles":         "7",
 	} {
 		if got := leafValue(d, key); got != want {
 			t.Errorf("%s = %q, want %q", key, got, want)
@@ -99,16 +104,52 @@ func TestDiskReclaimLeaf(t *testing.T) {
 	}
 }
 
-// Nothing left in trash to remove means no gap row, rather than a zero.
-func TestDiskReclaimNoBacklog(t *testing.T) {
+// The counters cover different populations, so no backlog may be inferred from
+// the difference between them -- staged exceeding purged is not a backlog row.
+func TestDiskReclaimNoDerivedBacklog(t *testing.T) {
 	nav := reclaimNav(t, madmin.DriveReclaimStats{
-		StaleMultipartPurged: 10, TmpWriteDirPurged: 2, TrashPurged: 12, CleanupCycles: 3,
+		StaleMultipartPurged: 1200, TmpWriteDirPurged: 25, TrashPurged: 1000, CleanupCycles: 3,
 	})
 	leaf, err := nav.Navigate("drive/reclaim")
 	if err != nil {
 		t.Fatalf("navigate drive/reclaim: %v", err)
 	}
-	if got := leafValue(leaf.GetLeafData(), "Awaiting Trash Purge"); got != "" {
-		t.Errorf("Awaiting Trash Purge = %q, want no row when trash is drained", got)
+	for key, value := range leaf.GetLeafData() {
+		if strings.Contains(strings.ToLower(key), "awaiting") {
+			t.Errorf("derived backlog row %q = %q, want none", key, value)
+		}
+	}
+}
+
+// Metrics loaded from a capture must report the age at collection time, not an
+// age inflated by however long ago the capture was taken.
+func TestDiskReclaimAgeUsesCollectionTime(t *testing.T) {
+	nav := reclaimNav(t, madmin.DriveReclaimStats{
+		CleanupCycles: 2,
+		LastCleanupAt: reclaimCollectedAt.Add(-2 * time.Minute),
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	if got := leafValue(leaf.GetLeafData(), "Last Cleanup"); !strings.Contains(got, "2m0s ago") {
+		t.Errorf("Last Cleanup = %q, want the age measured against collection time", got)
+	}
+}
+
+// Clock skew across nodes can leave a cleanup stamped after collection. That
+// must not render as a negative age.
+func TestDiskReclaimFutureCleanupNotNegative(t *testing.T) {
+	nav := reclaimNav(t, madmin.DriveReclaimStats{
+		CleanupCycles: 2,
+		LastCleanupAt: reclaimCollectedAt.Add(5 * time.Second),
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	got := leafValue(leaf.GetLeafData(), "Last Cleanup")
+	if !strings.Contains(got, "(in 5s)") {
+		t.Errorf("Last Cleanup = %q, want a forward-looking age, not a negative one", got)
 	}
 }

--- a/mnav/disk_reclaim_test.go
+++ b/mnav/disk_reclaim_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+func reclaimNav(t *testing.T, r madmin.DriveReclaimStats) MetricNavigator {
+	t.Helper()
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Disk: &madmin.DiskMetric{NDisks: 4, Reclaim: r}},
+	})
+}
+
+// Reclaim is a value, not a pointer, so a drive on which no pass has completed
+// carries an all-zero block. That must not be listed as a child: it would read as
+// "reclamation measured, nothing reclaimed" on a server that has simply not swept
+// yet.
+func TestDiskReclaimHiddenUntilItHasRun(t *testing.T) {
+	node, err := reclaimNav(t, madmin.DriveReclaimStats{}).Navigate("drive")
+	if err != nil {
+		t.Fatalf("navigate drive: %v", err)
+	}
+	for _, name := range childNames(node.GetChildren()) {
+		if name == "reclaim" {
+			t.Error("reclaim listed although no cleanup pass has completed")
+		}
+	}
+
+	// A single completed cycle with nothing to reclaim is still a measurement.
+	node, err = reclaimNav(t, madmin.DriveReclaimStats{CleanupCycles: 1}).Navigate("drive")
+	if err != nil {
+		t.Fatalf("navigate drive: %v", err)
+	}
+	var found bool
+	for _, name := range childNames(node.GetChildren()) {
+		if name == "reclaim" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("reclaim not listed after a cycle completed: %v", childNames(node.GetChildren()))
+	}
+}
+
+// The two stages are separate counters on purpose: the first moves things into
+// trash, the second removes them, and the gap is capacity not yet returned.
+func TestDiskReclaimLeaf(t *testing.T) {
+	last := time.Now().Add(-90 * time.Second)
+	nav := reclaimNav(t, madmin.DriveReclaimStats{
+		StaleMultipartPurged: 1200,
+		TmpWriteDirPurged:    25,
+		TrashPurged:          1000,
+		TrashPurgedBytes:     5 * 1024 * 1024 * 1024,
+		CleanupCycles:        7,
+		LastCleanupAt:        last,
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	d := leaf.GetLeafData()
+
+	for key, want := range map[string]string{
+		"Stale Multipart Purged": "1,200",
+		"Tmp Write Dirs Purged":  "25",
+		"Trash Purged":           "1,000 object(s), 5.0 GiB",
+		// 1200 + 25 staged, 1000 removed.
+		"Awaiting Trash Purge": "225 entry/entries",
+		"Cleanup Cycles":       "7",
+	} {
+		if got := leafValue(d, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	// The age is derived here; the wire carries only the timestamp.
+	if got := leafValue(d, "Last Cleanup"); !strings.Contains(got, "1m30s ago") {
+		t.Errorf("Last Cleanup = %q, want it to carry the derived age", got)
+	}
+}
+
+// Nothing left in trash to remove means no gap row, rather than a zero.
+func TestDiskReclaimNoBacklog(t *testing.T) {
+	nav := reclaimNav(t, madmin.DriveReclaimStats{
+		StaleMultipartPurged: 10, TmpWriteDirPurged: 2, TrashPurged: 12, CleanupCycles: 3,
+	})
+	leaf, err := nav.Navigate("drive/reclaim")
+	if err != nil {
+		t.Fatalf("navigate drive/reclaim: %v", err)
+	}
+	if got := leafValue(leaf.GetLeafData(), "Awaiting Trash Purge"); got != "" {
+		t.Errorf("Awaiting Trash Purge = %q, want no row when trash is drained", got)
+	}
+}

--- a/mnav/healing.go
+++ b/mnav/healing.go
@@ -34,6 +34,13 @@ type HealingMetricsNode struct {
 	path    string
 }
 
+func (node *HealingMetricsNode) collectionTime() time.Time {
+	if node.healing == nil {
+		return time.Time{}
+	}
+	return node.healing.CollectedAt
+}
+
 // NewHealingMetricsNode creates a new HealingMetricsNode.
 func NewHealingMetricsNode(healing *madmin.HealingMetrics, parent MetricNode, path string) *HealingMetricsNode {
 	return &HealingMetricsNode{healing: healing, parent: parent, path: path}
@@ -483,7 +490,16 @@ func (node *HealSessionLeafNode) GetLeafData() map[string]string {
 		data["04:Ended"] = s.EndTime.Format("2006-01-02 15:04:05")
 		data["05:Duration"] = s.EndTime.Sub(s.StartTime).Round(time.Second).String()
 	} else if !s.StartTime.IsZero() {
-		data["05:Duration"] = time.Since(s.StartTime).Round(time.Second).String() + " (running)"
+		// Started is rendered absolutely above, so without a collection time to
+		// measure against there is nothing to add beyond the fact that it is running.
+		switch running, future, ok := since(node, s.StartTime); {
+		case !ok:
+			data["05:Duration"] = "running"
+		case future:
+			data["05:Duration"] = "0s (running)"
+		default:
+			data["05:Duration"] = running.Round(time.Second).String() + " (running)"
+		}
 	}
 	if !s.LastActivity.IsZero() {
 		data["06:Last activity"] = s.LastActivity.Format("15:04:05")

--- a/mnav/healing.go
+++ b/mnav/healing.go
@@ -211,13 +211,17 @@ func (node *HealingLastDayNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 	children := []MetricChild{{Name: "total", Description: "Aggregated totals across all segments"}}
+	owners := segmentSecOwners(node.lastDay.FirstTime, node.lastDay.Interval, len(node.lastDay.Segments))
 	for i := len(node.lastDay.Segments) - 1; i >= 0; i-- {
 		seg := node.lastDay.Segments[i]
 		if seg.Started == 0 {
 			continue
 		}
-		segTime := node.lastDay.FirstTime.Add(time.Duration(i*node.lastDay.Interval) * time.Second)
-		name := segTime.UTC().Format("15:04Z")
+		segTime := segmentStart(node.lastDay.FirstTime, node.lastDay.Interval, i)
+		name := segmentKey(segTime)
+		if owners[name] != i {
+			continue
+		}
 		children = append(children, MetricChild{
 			Name:        name,
 			Description: fmt.Sprintf("%s started, %s completed", humanize.Comma(seg.Started), humanize.Comma(seg.Completed)),
@@ -264,11 +268,9 @@ func (node *HealingLastDayNode) GetChild(name string) (MetricNode, error) {
 		}
 		return NewHealingCountsNode(&total, node, node.path+"/total"), nil
 	}
-	for i := range node.lastDay.Segments {
-		segTime := node.lastDay.FirstTime.Add(time.Duration(i*node.lastDay.Interval) * time.Second)
-		if segTime.UTC().Format("15:04Z") == name {
-			return NewHealingCountsNode(&node.lastDay.Segments[i], node, node.path+"/"+name), nil
-		}
+	owners := segmentSecOwners(node.lastDay.FirstTime, node.lastDay.Interval, len(node.lastDay.Segments))
+	if i, ok := owners[name]; ok {
+		return NewHealingCountsNode(&node.lastDay.Segments[i], node, node.path+"/"+name), nil
 	}
 	return nil, fmt.Errorf("segment not found: %s", name)
 }

--- a/mnav/iam.go
+++ b/mnav/iam.go
@@ -32,6 +32,13 @@ type IAMMetricsNode struct {
 	path   string
 }
 
+func (node *IAMMetricsNode) collectionTime() time.Time {
+	if node.iam == nil {
+		return time.Time{}
+	}
+	return node.iam.CollectedAt
+}
+
 // NewIAMMetricsNode constructs a new IAMMetricsNode.
 func NewIAMMetricsNode(iam *madmin.IAMMetrics, parent MetricNode, path string) *IAMMetricsNode {
 	return &IAMMetricsNode{iam: iam, parent: parent, path: path}
@@ -99,8 +106,7 @@ func (node *IAMMetricsNode) GetLeafData() map[string]string {
 		data["Policy Mappings"] = fmt.Sprintf("%d user, %d group, %d STS",
 			c.UserPolicyMappings, c.GroupPolicyMappings, c.STSPolicyMappings)
 		// Cached, so it can lag the section's own timestamp.
-		data["Inventory Sampled"] = fmt.Sprintf("%s ago",
-			time.Since(c.SampledAt).Round(time.Second))
+		data["Inventory Sampled"] = ageStamp(node, c.SampledAt, "15:04:05", time.Second)
 	} else {
 		data["Inventory"] = "not available (node still initialising)"
 	}

--- a/mnav/iam.go
+++ b/mnav/iam.go
@@ -37,15 +37,45 @@ func NewIAMMetricsNode(iam *madmin.IAMMetrics, parent MetricNode, path string) *
 	return &IAMMetricsNode{iam: iam, parent: parent, path: path}
 }
 
-func (node *IAMMetricsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *IAMMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsIAM }
+func (node *IAMMetricsNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *IAMMetricsNode) GetMetricType() madmin.MetricType { return madmin.MetricsIAM }
+
+// GetMetricFlags requests no historic window: this node refreshes continuously,
+// and asking for them here would pull 60+96 segments on every tick to render two
+// summary lines. They are fetched when the reader navigates into one.
 func (node *IAMMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
 func (node *IAMMetricsNode) GetParent() MetricNode              { return node.parent }
 func (node *IAMMetricsNode) GetPath() string                    { return node.path }
 func (node *IAMMetricsNode) ShouldPauseRefresh() bool           { return false }
-func (node *IAMMetricsNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+// GetChildren lists the windows unconditionally: their nodes explain a window
+// that is missing or empty, so they are always constructible.
+func (node *IAMMetricsNode) GetChildren() []MetricChild {
+	if node.iam == nil {
+		return []MetricChild{}
+	}
+	return []MetricChild{
+		{Name: "last_hour", Description: "Authz and store activity over the last hour, by segment"},
+		{Name: "last_day", Description: "Authz and store activity over the last day, by segment"},
+	}
+}
 
 func (node *IAMMetricsNode) GetChild(name string) (MetricNode, error) {
+	if node.iam == nil {
+		return nil, fmt.Errorf("no IAM data available")
+	}
+	switch name {
+	case "last_hour":
+		return &iamWindowNode{
+			seg: node.iam.LastHour, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/last_hour", node.path),
+		}, nil
+	case "last_day":
+		return &iamWindowNode{
+			seg: node.iam.LastDay, flags: madmin.MetricsDayStats, window: "day",
+			parent: node, path: fmt.Sprintf("%s/last_day", node.path),
+		}, nil
+	}
 	return nil, fmt.Errorf("child not found: %s", name)
 }
 
@@ -75,12 +105,374 @@ func (node *IAMMetricsNode) GetLeafData() map[string]string {
 		data["Inventory"] = "not available (node still initialising)"
 	}
 
+	// Authorization over the last minute, split by how the identity resolved: the
+	// paths differ in cost by orders of magnitude, so one combined figure would hide
+	// which kind of credential is slow.
+	if a := m.Auth; a != nil {
+		for _, path := range iamAuthPathOrder {
+			if ta, ok := a.ByPath[path]; ok {
+				data["Authz "+path] = formatTimedAction(ta)
+			}
+		}
+		if a.Denied > 0 {
+			data["Denied"] = strconv.FormatUint(a.Denied, 10)
+		}
+		if a.Errors > 0 {
+			data["Unresolved"] = strconv.FormatUint(a.Errors, 10)
+		}
+		// Against the user-path count this is the hit rate, which is why both are
+		// shown rather than a single derived percentage.
+		if a.CacheMiss > 0 {
+			data["Policy Cache Miss"] = strconv.FormatUint(a.CacheMiss, 10)
+		}
+	}
+
 	// Persistence latency: the refresh and admin path, not the request path.
 	for _, op := range sortedKeys(m.Store) {
 		a := m.Store[op]
 		data["Store "+op] = fmt.Sprintf("%d op(s), avg %s, max %s", a.Count,
 			durationOf(a.AccTime, a.Count),
 			time.Duration(a.MaxTime).Round(time.Millisecond))
+	}
+
+	// Summarized when the history happens to be loaded -- it is persisted to disk
+	// and restored on startup, and a child node may have fetched it -- but never
+	// requested from here, and never rendered as a zero when it is absent.
+	if sum := m.LastHour; sum != nil && len(sum.Segments) > 0 {
+		data["Last Hour"] = formatIAMWindow(sum)
+	}
+	if sum := m.LastDay; sum != nil && len(sum.Segments) > 0 {
+		data["Last Day"] = formatIAMWindow(sum)
+	}
+	return data
+}
+
+// iamAuthPathOrder fixes the order the paths render in, so a row does not move
+// between refreshes as the map iterates differently. It follows the order
+// IsAllowed tests them in.
+var iamAuthPathOrder = []string{
+	madmin.IAMPathPlugin,
+	madmin.IAMPathOwner,
+	madmin.IAMPathSTS,
+	madmin.IAMPathSvcAcct,
+	madmin.IAMPathUser,
+}
+
+// iamSegmentPaths pairs each path with its accessors, so every renderer walks
+// them in one order and a path added later cannot be missed by one of them.
+func iamSegmentPaths(s madmin.IAMSegment) []struct {
+	label string
+	count uint64
+	nanos uint64
+} {
+	return []struct {
+		label string
+		count uint64
+		nanos uint64
+	}{
+		{madmin.IAMPathPlugin, s.PluginCount, s.PluginNanos},
+		{madmin.IAMPathOwner, s.OwnerCount, s.OwnerNanos},
+		{madmin.IAMPathSTS, s.STSCount, s.STSNanos},
+		{madmin.IAMPathSvcAcct, s.SvcAcctCount, s.SvcAcctNanos},
+		{madmin.IAMPathUser, s.UserCount, s.UserNanos},
+	}
+}
+
+// iamStoreOps pairs each persistence operation with its accessors.
+func iamStoreOps(s madmin.IAMSegment) []struct {
+	label string
+	count uint64
+	nanos uint64
+} {
+	return []struct {
+		label string
+		count uint64
+		nanos uint64
+	}{
+		{"save", s.SaveCount, s.SaveNanos},
+		{"load", s.LoadCount, s.LoadNanos},
+		{"delete", s.DeleteCount, s.DeleteNanos},
+		{"list", s.ListCount, s.ListNanos},
+	}
+}
+
+// formatIAMWindow totals a segmented window into one line.
+func formatIAMWindow(w *madmin.SegmentedIAMMetrics) string {
+	if state := windowSummaryState(w); state != "" {
+		return state
+	}
+	return describeIAMSegment(w.Total(), 0)
+}
+
+// iamSegmentEmpty reports a segment with nothing to show. N is not part of the
+// test: a node that authorized nothing still reports itself in every slot, so an
+// idle cluster would come back as a wall of zeros.
+func iamSegmentEmpty(s *madmin.IAMSegment) bool {
+	return s.AuthCount() == 0 && s.StoreCount() == 0 && s.Errors == 0 && s.StoreErrors == 0
+}
+
+// describeIAMSegment renders one segment on a single line, kept short enough to
+// sit in a row label. The dominant path is named rather than every path: with a
+// plugin configured it answers everything, and without one the traffic is almost
+// always a single credential kind.
+func describeIAMSegment(s madmin.IAMSegment, interval int) string {
+	n := s.AuthCount()
+	out := fmt.Sprintf("%d authz", n)
+	if interval > 0 {
+		out += fmt.Sprintf(" (%.1f/s)", float64(n)/float64(interval))
+	}
+	if n > 0 {
+		out += ", avg " + durationOf(s.AuthNanos(), n)
+		if top := topIAMPath(s); top != "" {
+			out += ", " + top
+		}
+	}
+	if s.MaxNanos > 0 {
+		out += ", max " + time.Duration(s.MaxNanos).Round(time.Microsecond).String()
+	}
+	if s.Denied > 0 {
+		out += fmt.Sprintf(", %d denied", s.Denied)
+	}
+	if s.Errors > 0 {
+		out += fmt.Sprintf(", %d unresolved", s.Errors)
+	}
+	if store := s.StoreCount(); store > 0 {
+		out += fmt.Sprintf(", %d store (avg %s)", store,
+			durationOf(s.StoreNanos(), store))
+	}
+	if s.StoreErrors > 0 {
+		out += fmt.Sprintf(", %d store err", s.StoreErrors)
+	}
+	return out
+}
+
+// topIAMPath names the busiest path and its share, empty when one path took
+// everything: "100% user" says nothing a single-path deployment does not already
+// know.
+func topIAMPath(s madmin.IAMSegment) string {
+	total := s.AuthCount()
+	if total == 0 {
+		return ""
+	}
+	var best struct {
+		label string
+		count uint64
+	}
+	distinct := 0
+	for _, p := range iamSegmentPaths(s) {
+		if p.count == 0 {
+			continue
+		}
+		distinct++
+		if p.count > best.count {
+			best.label, best.count = p.label, p.count
+		}
+	}
+	if distinct < 2 {
+		return best.label
+	}
+	return fmt.Sprintf("%s %s", best.label, calculatePercentage(best.count, total))
+}
+
+// iamWindowNode is one persisted IAM window -- the hour or the day -- as a row
+// per time segment plus one navigable child per segment, so a burst of slow
+// authorizations can be told apart from a steady cost.
+type iamWindowNode struct {
+	seg    *madmin.SegmentedIAMMetrics
+	flags  madmin.MetricFlags
+	window string
+	parent MetricNode
+	path   string
+}
+
+func (node *iamWindowNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *iamWindowNode) GetMetricType() madmin.MetricType   { return madmin.MetricsIAM }
+func (node *iamWindowNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *iamWindowNode) GetParent() MetricNode              { return node.parent }
+func (node *iamWindowNode) GetPath() string                    { return node.path }
+func (node *iamWindowNode) ShouldPauseRefresh() bool           { return true }
+
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *iamWindowNode) hasSegments() bool {
+	return node.seg != nil && node.seg.Interval > 0 && len(node.seg.Segments) > 0
+}
+
+// wholeSecs is the span the whole window covers: one segment as wide as every
+// slot it holds, so an _ALL rate reads as the window average.
+func (node *iamWindowNode) wholeSecs() int {
+	return node.seg.Interval * len(node.seg.Segments)
+}
+
+func (node *iamWindowNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
+	}
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	withDate := windowCrossesDay(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if iamSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeIAMSegment(s, node.seg.Interval),
+		})
+	}
+	return children
+}
+
+func (node *iamWindowNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s IAM segments available", node.window)
+	}
+	leaf := func(s madmin.IAMSegment, segTime time.Time, interval, segments int) MetricNode {
+		return &iamSegmentLeafNode{
+			seg: s, segTime: segTime, interval: interval, segments: segments,
+			flags: node.flags, parent: node, path: node.path + "/" + name,
+		}
+	}
+	if name == "_ALL" {
+		return leaf(node.seg.Total(), node.seg.FirstTime, node.wholeSecs(), len(node.seg.Segments)), nil
+	}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	if i, ok := owners[name]; ok {
+		return leaf(node.seg.Segments[i], segmentStart(node.seg.FirstTime, node.seg.Interval, i), node.seg.Interval, 1), nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *iamWindowNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.seg, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	data := map[string]string{
+		"00:Total (last " + node.window + ")": formatIAMWindow(node.seg),
+		"01:Coverage":                         windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}
+	idx := 2
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if iamSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		end := start.Add(time.Duration(node.seg.Interval) * time.Second)
+		data[segmentRowKey(idx, start, end)] = describeIAMSegment(s, node.seg.Interval)
+		idx++
+	}
+	// The totals above are measured zeros, so they stay; only the reason there is
+	// no segment row is added.
+	if idx == 2 {
+		data["02:Segments"] = fmt.Sprintf("no IAM activity recorded in any of the %d segment(s) measured",
+			len(node.seg.Segments))
+	}
+	return data
+}
+
+// iamSegmentLeafNode is one IAM segment, or the whole window combined.
+type iamSegmentLeafNode struct {
+	seg      madmin.IAMSegment
+	segTime  time.Time
+	interval int
+	// segments is how many segments were merged into seg, so N can be divided back
+	// into a node count. One for a single segment, the whole window for _ALL.
+	segments int
+	flags    madmin.MetricFlags
+	parent   MetricNode
+	path     string
+}
+
+func (node *iamSegmentLeafNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *iamSegmentLeafNode) GetMetricType() madmin.MetricType   { return madmin.MetricsIAM }
+func (node *iamSegmentLeafNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *iamSegmentLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *iamSegmentLeafNode) GetPath() string                    { return node.path }
+func (node *iamSegmentLeafNode) ShouldPauseRefresh() bool           { return true }
+func (node *iamSegmentLeafNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *iamSegmentLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *iamSegmentLeafNode) GetLeafData() map[string]string {
+	s := node.seg
+	if iamSegmentEmpty(&s) {
+		return map[string]string{"Status": "no IAM activity in this time segment"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.interval > 0 {
+		add("Time Segment", windowCoverage(node.segTime, node.interval))
+	}
+
+	total := s.AuthCount()
+	add("Authorizations", strconv.FormatUint(total, 10))
+	if node.interval > 0 && total > 0 {
+		add("Rate", fmt.Sprintf("%.2f/s", float64(total)/float64(node.interval)))
+	}
+	if total > 0 {
+		add("Mean Latency", durationOf(s.AuthNanos(), total))
+	}
+	// The peak, not a per-path peak: whichever path is configured answers every
+	// request, so there is at most one path in contention for it.
+	if s.MaxNanos > 0 {
+		add("Slowest", time.Duration(s.MaxNanos).Round(time.Microsecond).String())
+	}
+	// One row per path that saw traffic, with its share, since that is the whole
+	// reason the split exists.
+	for _, p := range iamSegmentPaths(s) {
+		if p.count == 0 {
+			continue
+		}
+		add("Path "+p.label, fmt.Sprintf("%d (%s), avg %s", p.count,
+			calculatePercentage(p.count, total), durationOf(p.nanos, p.count)))
+	}
+	if s.Denied > 0 {
+		add("Denied", fmt.Sprintf("%d (%s)", s.Denied, calculatePercentage(s.Denied, total)))
+	}
+	// Unresolved lookups never reached a policy decision, so they are not part of
+	// the counts above and get no latency of their own.
+	if s.Errors > 0 {
+		add("Unresolved", strconv.FormatUint(s.Errors, 10))
+	}
+	if s.CacheMiss > 0 {
+		add("Policy Cache Miss", fmt.Sprintf("%d of %d user authz", s.CacheMiss, s.UserCount))
+	}
+
+	// Persistence is the refresh and admin path, and infrequent enough that these
+	// segments are the only place it can be seen at all.
+	for _, op := range iamStoreOps(s) {
+		if op.count == 0 {
+			continue
+		}
+		add("Store "+op.label, fmt.Sprintf("%d, avg %s", op.count,
+			durationOf(op.nanos, op.count)))
+	}
+	if s.StoreErrors > 0 {
+		add("Store Errors", strconv.FormatUint(s.StoreErrors, 10))
+	}
+
+	// Context only: every field above is a cross-node sum, and dividing one by the
+	// node count would invent a per-node figure that moves when a node joins or
+	// leaves. N itself is per segment, so it is divided by the merge count.
+	if s.N > 0 {
+		add("Nodes", formatNodeCount(s.N, node.segments))
 	}
 	return data
 }

--- a/mnav/iam.go
+++ b/mnav/iam.go
@@ -105,8 +105,11 @@ func (node *IAMMetricsNode) GetLeafData() map[string]string {
 		data["Groups"] = strconv.Itoa(c.Groups)
 		data["Policy Mappings"] = fmt.Sprintf("%d user, %d group, %d STS",
 			c.UserPolicyMappings, c.GroupPolicyMappings, c.STSPolicyMappings)
-		// Cached, so it can lag the section's own timestamp.
-		data["Inventory Sampled"] = ageStamp(node, c.SampledAt, "15:04:05", time.Second)
+		// Cached, so it can lag the section's own timestamp. Absent until the cache
+		// has been sampled, rather than rendered as the zero time.
+		if !c.SampledAt.IsZero() {
+			data["Inventory Sampled"] = ageStamp(node, c.SampledAt, "15:04:05", time.Second)
+		}
 	} else {
 		data["Inventory"] = "not available (node still initialising)"
 	}

--- a/mnav/iam_test.go
+++ b/mnav/iam_test.go
@@ -1,0 +1,340 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+var iamFirstTime = time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+func iamSegWindow(interval int, segments ...madmin.IAMSegment) *madmin.SegmentedIAMMetrics {
+	return &madmin.SegmentedIAMMetrics{
+		Interval:  interval,
+		FirstTime: iamFirstTime,
+		Segments:  segments,
+	}
+}
+
+// A busy segment: 600 regular-user authorizations costing 12ms in total, so the
+// mean is 20µs.
+func busyIAMSegment() madmin.IAMSegment {
+	return madmin.IAMSegment{
+		N: 2, UserCount: 600, UserNanos: 12_000_000, MaxNanos: 3_000_000,
+	}
+}
+
+func iamNav(t *testing.T, iam *madmin.IAMMetrics) MetricNavigator {
+	t.Helper()
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{IAM: iam},
+	})
+}
+
+// Both windows are listed whatever state they are in, and everything listed
+// resolves: their nodes are what explain a window that is missing or empty.
+func TestIAMChildren(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{})
+	node, err := nav.Navigate("iam")
+	if err != nil {
+		t.Fatalf("navigate iam: %v", err)
+	}
+	got := childNames(node.GetChildren())
+	if want := []string{"last_hour", "last_day"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+}
+
+// The section itself must not request the windows: it refreshes continuously, and
+// asking here would pull 156 segments a tick to render two summary lines. The
+// window nodes ask, and they pause the refresh while the reader is inside.
+func TestIAMSectionDoesNotRequestWindows(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{})
+	node, err := nav.Navigate("iam")
+	if err != nil {
+		t.Fatalf("navigate iam: %v", err)
+	}
+	if flags := node.GetMetricFlags(); flags != 0 {
+		t.Errorf("section flags = %v, want none", flags)
+	}
+	if node.ShouldPauseRefresh() {
+		t.Error("the live section must keep refreshing")
+	}
+
+	for name, want := range map[string]madmin.MetricFlags{
+		"last_hour": madmin.MetricsHourStats,
+		"last_day":  madmin.MetricsDayStats,
+	} {
+		child, err := nav.Navigate("iam/" + name)
+		if err != nil {
+			t.Fatalf("navigate iam/%s: %v", name, err)
+		}
+		if got := child.GetOpts().Flags; !got.Contains(want) {
+			t.Errorf("iam/%s requests %v, want it to include %v", name, got, want)
+		}
+		if !child.ShouldPauseRefresh() {
+			t.Errorf("iam/%s must pause the refresh while it is being read", name)
+		}
+	}
+}
+
+// History that happens to be loaded is summarized on the live section -- it is
+// persisted and restored on startup -- but a window that was never collected must
+// never be rendered as a measured zero.
+func TestIAMSectionSummarizesLoadedHistory(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{
+		LastHour: iamSegWindow(60, busyIAMSegment()),
+	})
+	node, err := nav.Navigate("iam")
+	if err != nil {
+		t.Fatalf("navigate iam: %v", err)
+	}
+	data := node.GetLeafData()
+	if got, want := data["Last Hour"], "600 authz, avg 20µs, user, max 3ms"; got != want {
+		t.Errorf("Last Hour = %q, want %q", got, want)
+	}
+	if _, ok := data["Last Day"]; ok {
+		t.Errorf("Last Day rendered although it was never collected: %q", data["Last Day"])
+	}
+}
+
+// The live section splits authorization by path, because the paths differ in cost
+// by orders of magnitude. A path nobody took is absent, not zero.
+func TestIAMSectionAuthByPath(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{
+		Auth: &madmin.IAMAuthStats{
+			ByPath: map[string]madmin.TimedAction{
+				madmin.IAMPathUser: {Count: 10, AccTime: 200_000, MaxTime: 50_000},
+				madmin.IAMPathSTS:  {Count: 2, AccTime: 400_000, MaxTime: 300_000},
+			},
+			Denied: 3, Errors: 1, CacheMiss: 4,
+		},
+	})
+	node, err := nav.Navigate("iam")
+	if err != nil {
+		t.Fatalf("navigate iam: %v", err)
+	}
+	data := node.GetLeafData()
+	if got, want := data["Authz user"], "10, avg 20µs, max 50µs"; got != want {
+		t.Errorf("Authz user = %q, want %q", got, want)
+	}
+	if got, want := data["Authz sts"], "2, avg 200µs, max 300µs"; got != want {
+		t.Errorf("Authz sts = %q, want %q", got, want)
+	}
+	if _, ok := data["Authz plugin"]; ok {
+		t.Error("a path nobody took was rendered")
+	}
+	for key, want := range map[string]string{
+		"Denied": "3", "Unresolved": "1", "Policy Cache Miss": "4",
+	} {
+		if got := data[key]; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// Rows carry the segment's own start, oldest first, and every listed child
+// resolves to that segment's leaf.
+func TestIAMWindowSegments(t *testing.T) {
+	mixed := madmin.IAMSegment{
+		N: 2,
+		// Two paths, so the busiest is named with its share.
+		UserCount: 30, UserNanos: 600_000,
+		STSCount: 10, STSNanos: 1_000_000,
+		MaxNanos: 400_000,
+		Denied:   2, Errors: 1, CacheMiss: 5,
+		LoadCount: 1, LoadNanos: 5_000_000, StoreErrors: 1,
+	}
+	nav := iamNav(t, &madmin.IAMMetrics{
+		// The first slot is empty, so it is neither a row nor a child.
+		LastHour: iamSegWindow(60, madmin.IAMSegment{N: 2}, busyIAMSegment(), mixed),
+	})
+	node, err := nav.Navigate("iam/last_hour")
+	if err != nil {
+		t.Fatalf("navigate iam/last_hour: %v", err)
+	}
+
+	got := childNames(node.GetChildren())
+	if want := []string{"_ALL", "10:01Z", "10:02Z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	data := node.GetLeafData()
+	for _, key := range []string{
+		"00:Total (last hour)", "01:Coverage", "02: 10:01Z", "03: 10:02Z",
+	} {
+		if _, ok := data[key]; !ok {
+			t.Errorf("missing row %q in %v", key, data)
+		}
+	}
+	if len(data) != 4 {
+		t.Errorf("rows = %v, want exactly 4 (total + coverage + two non-empty segments)", data)
+	}
+	if got, want := data["02: 10:01Z"], "600 authz (10.0/s), avg 20µs, user, max 3ms"; got != want {
+		t.Errorf("busy segment row = %q, want %q", got, want)
+	}
+	// The mixed segment names the busiest path with its share, and every unusual
+	// count it carries.
+	mixedRow := data["03: 10:02Z"]
+	for _, want := range []string{
+		"40 authz (0.7/s)", "avg 40µs", "user 75.0%", "max 400µs",
+		"2 denied", "1 unresolved", "1 store (avg 5ms)", "1 store err",
+	} {
+		if !strings.Contains(mixedRow, want) {
+			t.Errorf("mixed segment row %q is missing %q", mixedRow, want)
+		}
+	}
+}
+
+// The leaf is where the whole path split lives, with each path's share of the
+// segment.
+func TestIAMSegmentLeaf(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{
+		LastHour: iamSegWindow(60, madmin.IAMSegment{
+			N:         3,
+			UserCount: 30, UserNanos: 600_000,
+			OwnerCount: 10, OwnerNanos: 10_000,
+			MaxNanos: 400_000,
+			Denied:   2, Errors: 4, CacheMiss: 6,
+			SaveCount: 2, SaveNanos: 8_000_000, StoreErrors: 1,
+		}),
+	})
+	leaf, err := nav.Navigate("iam/last_hour/10:00Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	d := leaf.GetLeafData()
+
+	// Every mean and every share is derived here; the wire carries counts and sums.
+	for key, want := range map[string]string{
+		"Authorizations":    "40",
+		"Rate":              "0.67/s",
+		"Mean Latency":      "15µs",
+		"Slowest":           "400µs",
+		"Path user":         "30 (75.0%), avg 20µs",
+		"Path owner":        "10 (25.0%), avg 1µs",
+		"Denied":            "2 (5.0%)",
+		"Unresolved":        "4",
+		"Policy Cache Miss": "6 of 30 user authz",
+		"Store save":        "2, avg 4ms",
+		"Store Errors":      "1",
+		"Nodes":             "3 node(s)",
+	} {
+		if got := leafValue(d, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	// A path nobody took gets no row.
+	for _, key := range []string{"Path plugin", "Path sts", "Path svcacct", "Store load"} {
+		if got := leafValue(d, key); got != "" {
+			t.Errorf("%s = %q, want no row", key, got)
+		}
+	}
+}
+
+// A window nobody asked for and a window that is still filling are opposite
+// answers, and neither may read as a measured zero.
+func TestIAMWindowStates(t *testing.T) {
+	notRequested, err := iamNav(t, &madmin.IAMMetrics{}).Navigate("iam/last_day")
+	if err != nil {
+		t.Fatalf("navigate iam/last_day: %v", err)
+	}
+	if got := notRequested.GetLeafData()["Status"]; !strings.Contains(got, "not requested") {
+		t.Errorf("Status = %q, want it to say the window was not requested", got)
+	}
+	if len(notRequested.GetChildren()) != 0 {
+		t.Error("a window with no data listed children")
+	}
+	if _, err := notRequested.GetChild("_ALL"); err == nil {
+		t.Error("GetChild succeeded on a window with no segments")
+	}
+
+	requestedEmpty, err := iamNav(t, &madmin.IAMMetrics{
+		LastDay: &madmin.SegmentedIAMMetrics{Interval: 900},
+	}).Navigate("iam/last_day")
+	if err != nil {
+		t.Fatalf("navigate iam/last_day: %v", err)
+	}
+	if got := requestedEmpty.GetLeafData()["Status"]; !strings.Contains(got, "no data yet") {
+		t.Errorf("Status = %q, want it to say the window is still filling", got)
+	}
+}
+
+// A window whose every segment is empty still reports its measured totals, and
+// says why there is no segment row rather than showing none.
+func TestIAMWindowAllSegmentsEmpty(t *testing.T) {
+	nav := iamNav(t, &madmin.IAMMetrics{
+		LastDay: iamSegWindow(900, madmin.IAMSegment{N: 2}, madmin.IAMSegment{N: 2}),
+	})
+	node, err := nav.Navigate("iam/last_day")
+	if err != nil {
+		t.Fatalf("navigate iam/last_day: %v", err)
+	}
+	data := node.GetLeafData()
+	if got, want := data["00:Total (last day)"], "0 authz"; got != want {
+		t.Errorf("total = %q, want %q", got, want)
+	}
+	if got := data["02:Segments"]; !strings.Contains(got, "2 segment(s)") {
+		t.Errorf("Segments = %q, want it to name how many segments were measured", got)
+	}
+	if names := childNames(node.GetChildren()); !reflect.DeepEqual(names, []string{"_ALL"}) {
+		t.Errorf("children = %v, want only _ALL", names)
+	}
+}
+
+// Keys collide once a merged window runs past 24 hours. The newest slot wins, so
+// every key GetChildren lists resolves to the segment it described.
+func TestIAMWindowDuplicateKeys(t *testing.T) {
+	full := make([]madmin.IAMSegment, 97)
+	for i := range full {
+		full[i] = madmin.IAMSegment{N: 1, OwnerCount: uint64(i)}
+	}
+	nav := iamNav(t, &madmin.IAMMetrics{LastDay: iamSegWindow(900, full...)})
+	node, err := nav.Navigate("iam/last_day")
+	if err != nil {
+		t.Fatalf("navigate iam/last_day: %v", err)
+	}
+	for _, name := range childNames(node.GetChildren()) {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v: a listed key must resolve", name, err)
+		}
+	}
+	// The first and last slot share a wall-clock time; the newest owns it.
+	dup, err := node.GetChild("10:00Z")
+	if err != nil {
+		t.Fatalf("GetChild(10:00Z): %v", err)
+	}
+	if got := leafValue(dup.GetLeafData(), "Path owner"); !strings.HasPrefix(got, "96 ") {
+		t.Errorf("Path owner = %q, want the newest slot's 96", got)
+	}
+}

--- a/mnav/ilm.go
+++ b/mnav/ilm.go
@@ -33,6 +33,13 @@ type ILMMetricsNode struct {
 	path   string
 }
 
+func (node *ILMMetricsNode) collectionTime() time.Time {
+	if node.ilm == nil {
+		return time.Time{}
+	}
+	return node.ilm.CollectedAt
+}
+
 // NewILMMetricsNode constructs a new ILMMetricsNode.
 func NewILMMetricsNode(ilm *madmin.ILMMetrics, parent MetricNode, path string) *ILMMetricsNode {
 	return &ILMMetricsNode{ilm: ilm, parent: parent, path: path}
@@ -167,7 +174,17 @@ func (node *ILMQueueNode) GetLeafData() map[string]string {
 
 	// A recent head means throughput-bound, an old one means wedged. Derived here.
 	if !q.HeadQueuedAt.IsZero() {
-		data["Head Lag"] = fmt.Sprintf("<= %s", time.Since(q.HeadQueuedAt).Round(time.Second))
+		lag, future, ok := since(node, q.HeadQueuedAt)
+		switch {
+		case !ok:
+			// No collection time to measure the lag against, so report when the head
+			// was queued and leave the lag to the reader.
+			data["Head Lag"] = fmt.Sprintf("queued at %s", q.HeadQueuedAt.Format("15:04:05"))
+		case future:
+			data["Head Lag"] = "<= 0s"
+		default:
+			data["Head Lag"] = fmt.Sprintf("<= %s", lag.Round(time.Second))
+		}
 	}
 	return data
 }

--- a/mnav/kms.go
+++ b/mnav/kms.go
@@ -190,8 +190,13 @@ func (node *kmsSummaryNode) GetMetricType() madmin.MetricType   { return madmin.
 func (node *kmsSummaryNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
 func (node *kmsSummaryNode) GetParent() MetricNode              { return node.parent }
 func (node *kmsSummaryNode) GetPath() string                    { return node.path }
-func (node *kmsSummaryNode) ShouldPauseRefresh() bool           { return false }
-func (node *kmsSummaryNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+// ShouldPauseRefresh pauses only when this node actually asks for a historic
+// window, so the segments are pulled once rather than on every refresh tick.
+func (node *kmsSummaryNode) ShouldPauseRefresh() bool {
+	return node.flags&(madmin.MetricsHourStats|madmin.MetricsDayStats) != 0
+}
+func (node *kmsSummaryNode) GetChildren() []MetricChild { return []MetricChild{} }
 
 func (node *kmsSummaryNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children")
@@ -214,7 +219,10 @@ func (node *kmsSegmentedNode) GetMetricType() madmin.MetricType   { return madmi
 func (node *kmsSegmentedNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
 func (node *kmsSegmentedNode) GetParent() MetricNode              { return node.parent }
 func (node *kmsSegmentedNode) GetPath() string                    { return node.path }
-func (node *kmsSegmentedNode) ShouldPauseRefresh() bool           { return false }
+
+// ShouldPauseRefresh is true: this node requests a day window, and refetching 96
+// segments on every tick is what the pause exists to avoid.
+func (node *kmsSegmentedNode) ShouldPauseRefresh() bool { return true }
 
 func (node *kmsSegmentedNode) GetChildren() []MetricChild {
 	if len(node.data) == 0 {
@@ -311,7 +319,7 @@ func (node *kmsOpSegmentedNode) GetLeafData() map[string]string {
 		}
 		t := node.seg.FirstTime.Add(time.Duration(i) * interval)
 		end := t.Add(interval)
-		key := fmt.Sprintf("%02d:%s->%sZ", idx, t.UTC().Format("15:04"), end.UTC().Format("15:04"))
+		key := segmentRowKey(idx, t, end)
 		avg := s.Avg()
 		rps := float64(s.Count) / interval.Seconds()
 		line := fmt.Sprintf("%s->%s - %.1f req/s, %d calls, avg %v, min %v, max %v",
@@ -346,7 +354,7 @@ func kmsView(ops map[string]madmin.SegmentedKMSActions) segView[madmin.KMSAction
 		opLeaf: func(op string, a madmin.KMSAction, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
 			return &kmsActionLeafNode{op: op, action: a, segTime: segTime, interval: interval, parent: parent, path: path}
 		},
-		sumLeaf: func(a madmin.KMSAction, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
+		sumLeaf: func(a madmin.KMSAction, segTime time.Time, interval, _ int, parent MetricNode, path string) MetricNode {
 			return &kmsActionLeafNode{op: "_ALL", action: a, segTime: segTime, interval: interval, parent: parent, path: path}
 		},
 	}

--- a/mnav/locks.go
+++ b/mnav/locks.go
@@ -32,6 +32,13 @@ type LockMetricsNode struct {
 	path   string
 }
 
+func (node *LockMetricsNode) collectionTime() time.Time {
+	if node.locks == nil {
+		return time.Time{}
+	}
+	return node.locks.CollectedAt
+}
+
 // NewLockMetricsNode constructs a new LockMetricsNode.
 func NewLockMetricsNode(locks *madmin.LockMetrics, parent MetricNode, path string) *LockMetricsNode {
 	return &LockMetricsNode{locks: locks, parent: parent, path: path}
@@ -141,11 +148,10 @@ func (node *LockMetricsNode) GetLeafData() map[string]string {
 	if p := l.Purge; p != nil {
 		data["Read / Write Locks"] = fmt.Sprintf("%d / %d", p.Readers, p.Writers)
 		if !p.OldestHeldAt.IsZero() {
-			data["Oldest Lock Held"] = time.Since(p.OldestHeldAt).Round(time.Second).String()
+			data["Oldest Lock Held"] = ageStamp(node, p.OldestHeldAt, "15:04:05", time.Second)
 		}
 		if !p.SampledAt.IsZero() {
-			data["Cleanup Sampled"] = fmt.Sprintf("%s ago",
-				time.Since(p.SampledAt).Round(time.Second))
+			data["Cleanup Sampled"] = ageStamp(node, p.SampledAt, "15:04:05", time.Second)
 		}
 	}
 	return data
@@ -443,19 +449,24 @@ func (node *LockPurgeNode) GetLeafData() map[string]string {
 	p := node.purge
 	data := map[string]string{
 		// Up to one cleanup interval old; not comparable with the live counters.
-		"Sampled At": fmt.Sprintf("%s (%s ago)",
-			p.SampledAt.Format("15:04:05"), time.Since(p.SampledAt).Round(time.Second)),
+		"Sampled At":  stampAge(node, p.SampledAt, "15:04:05", time.Second),
 		"Read Locks":  strconv.FormatInt(p.Readers, 10),
 		"Write Locks": strconv.FormatInt(p.Writers, 10),
 	}
 	if p.Expired > 0 {
 		data["Expired (last pass)"] = strconv.FormatInt(p.Expired, 10)
 	}
-	// Age derived here; the wire carries only the timestamp.
+	// Age derived here; the wire carries only the timestamp. Without a collection
+	// time to measure against, the acquisition time is all that can be shown.
 	if !p.OldestHeldAt.IsZero() {
-		data["Oldest Lock"] = fmt.Sprintf("held %s (since %s)",
-			time.Since(p.OldestHeldAt).Round(time.Second),
-			p.OldestHeldAt.Format("15:04:05"))
+		stamp := p.OldestHeldAt.Format("15:04:05")
+		if held, future, ok := since(node, p.OldestHeldAt); !ok {
+			data["Oldest Lock"] = fmt.Sprintf("since %s", stamp)
+		} else if future {
+			data["Oldest Lock"] = fmt.Sprintf("acquired in %s (at %s)", held.Round(time.Second), stamp)
+		} else {
+			data["Oldest Lock"] = fmt.Sprintf("held %s (since %s)", held.Round(time.Second), stamp)
+		}
 	}
 	return data
 }

--- a/mnav/locks.go
+++ b/mnav/locks.go
@@ -37,28 +37,52 @@ func NewLockMetricsNode(locks *madmin.LockMetrics, parent MetricNode, path strin
 	return &LockMetricsNode{locks: locks, parent: parent, path: path}
 }
 
-func (node *LockMetricsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *LockMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsLocks }
+func (node *LockMetricsNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *LockMetricsNode) GetMetricType() madmin.MetricType { return madmin.MetricsLocks }
+
+// GetMetricFlags requests no historic window: this node refreshes continuously,
+// and asking for them here would pull 60+96 segments on every tick to render two
+// summary lines. They are fetched when the reader navigates into one.
 func (node *LockMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
 func (node *LockMetricsNode) GetParent() MetricNode              { return node.parent }
 func (node *LockMetricsNode) GetPath() string                    { return node.path }
 func (node *LockMetricsNode) ShouldPauseRefresh() bool           { return false }
 
+// GetChildren lists the cleanup pass only once it has sampled, but the windows
+// unconditionally: their nodes explain a window that is missing or empty, so they
+// are always constructible.
 func (node *LockMetricsNode) GetChildren() []MetricChild {
-	if node.locks == nil || node.locks.Purge == nil {
+	if node.locks == nil {
 		return []MetricChild{}
 	}
-	return []MetricChild{
-		{Name: "purge", Description: "Values sampled by the periodic lock-cleanup pass"},
+	children := make([]MetricChild, 0, 3)
+	if node.locks.Purge != nil {
+		children = append(children,
+			MetricChild{Name: "purge", Description: "Values sampled by the periodic lock-cleanup pass"})
 	}
+	return append(children,
+		MetricChild{Name: "last_hour", Description: "Locking activity over the last hour, by time segment"},
+		MetricChild{Name: "last_day", Description: "Locking activity over the last day, by time segment"},
+	)
 }
 
 func (node *LockMetricsNode) GetChild(name string) (MetricNode, error) {
 	if node.locks == nil {
 		return nil, fmt.Errorf("no lock data available")
 	}
-	if name == "purge" {
+	switch name {
+	case "purge":
 		return NewLockPurgeNode(node.locks.Purge, node, fmt.Sprintf("%s/purge", node.path)), nil
+	case "last_hour":
+		return &lockWindowNode{
+			seg: node.locks.LastHour, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/last_hour", node.path),
+		}, nil
+	case "last_day":
+		return &lockWindowNode{
+			seg: node.locks.LastDay, flags: madmin.MetricsDayStats, window: "day",
+			parent: node, path: fmt.Sprintf("%s/last_day", node.path),
+		}, nil
 	}
 	return nil, fmt.Errorf("child not found: %s", name)
 }
@@ -74,18 +98,316 @@ func (node *LockMetricsNode) GetLeafData() map[string]string {
 		// Resources, not locks: one resource can carry many readers.
 		"Locked Resources": strconv.FormatInt(l.Resources, 10),
 	}
-	if l.Waiting > 0 {
-		data["Waiting"] = strconv.FormatInt(l.Waiting, 10)
+	// Always rendered, including at zero: "0 waiting, 0 failed" is the reassurance
+	// an operator is looking for, and hiding it makes a healthy subsystem look
+	// unreported.
+	data["Waiting"] = strconv.FormatInt(l.Waiting, 10)
+
+	// The caller's view over the last minute. Read and write are separate lines
+	// because they queue for different reasons.
+	data["Acquire (read)"] = formatTimedAction(l.Acquire.Read)
+	data["Acquire (write)"] = formatTimedAction(l.Acquire.Write)
+	data["Held (read)"] = formatTimedAction(l.Held.Read)
+	data["Held (write)"] = formatTimedAction(l.Held.Write)
+	data["Release (read)"] = formatTimedAction(l.Release.Read)
+	data["Release (write)"] = formatTimedAction(l.Release.Write)
+
+	// Wasted waiting is the point of showing AccTime here, so it is rendered even
+	// when the count is zero.
+	data["Failed"] = fmt.Sprintf("%d (%d timed out, %d conflicts, %d canceled)",
+		l.AcquireFailed.Count(), l.TimedOut, l.Conflicts, l.Canceled)
+	if wasted := l.AcquireFailed.Read.AccTime + l.AcquireFailed.Write.AccTime; wasted > 0 {
+		data["Failed Waiting"] = time.Duration(wasted).Round(time.Millisecond).String()
 	}
-	// Rising Rejected means contention has become a throughput problem.
-	if l.Rejected > 0 {
-		data["Rejected"] = strconv.FormatUint(l.Rejected, 10)
+
+	if s := l.ServerLatency; s.N > 0 {
+		data["Lock Server RPC"] = fmt.Sprintf("avg %s, max %s across %d servers",
+			durationOf(s.AvgSumNanos, uint64(s.N)),
+			time.Duration(s.MaxNanos).Round(time.Microsecond), s.N)
 	}
-	if l.ExpiredTotal > 0 {
-		data["Expired (total)"] = strconv.FormatUint(l.ExpiredTotal, 10)
+
+	// Summarized when the history happens to be loaded -- it is persisted to disk
+	// and restored on startup, and a child node may have fetched it -- but never
+	// requested from here, and never rendered as a zero when it is absent.
+	if sum := l.LastHour; sum != nil && len(sum.Segments) > 0 {
+		data["Last Hour"] = formatLockWindow(sum)
 	}
-	if l.QuorumLost > 0 {
-		data["Quorum Lost"] = strconv.FormatUint(l.QuorumLost, 10)
+	if sum := l.LastDay; sum != nil && len(sum.Segments) > 0 {
+		data["Last Day"] = formatLockWindow(sum)
+	}
+
+	// The purge block is also a child node, but the read/write split and the
+	// oldest held lock are what you want at a glance, so summarize them here.
+	if p := l.Purge; p != nil {
+		data["Read / Write Locks"] = fmt.Sprintf("%d / %d", p.Readers, p.Writers)
+		if !p.OldestHeldAt.IsZero() {
+			data["Oldest Lock Held"] = time.Since(p.OldestHeldAt).Round(time.Second).String()
+		}
+		if !p.SampledAt.IsZero() {
+			data["Cleanup Sampled"] = fmt.Sprintf("%s ago",
+				time.Since(p.SampledAt).Round(time.Second))
+		}
+	}
+	return data
+}
+
+// formatLockWindow totals a segmented window into one line. The rare events are
+// named only when they happened, so a quiet cluster reads as quiet rather than as
+// a wall of zeros.
+func formatLockWindow(w *madmin.SegmentedLockMetrics) string {
+	if state := windowSummaryState(w); state != "" {
+		return state
+	}
+	t := w.Total()
+	out := fmt.Sprintf("%d acqs, avg %s", t.AcquireCount,
+		durationOf(t.AcquireNanos, t.AcquireCount))
+	if t.HeldCount > 0 {
+		out += ", held " + durationOf(t.HeldNanos, t.HeldCount)
+	}
+	if t.AcquireFailed > 0 {
+		out += fmt.Sprintf(", %d failed (%s)", t.AcquireFailed,
+			time.Duration(t.AcquireFailedNanos).Round(time.Millisecond))
+	}
+	for _, rare := range []struct {
+		label string
+		n     uint64
+	}{
+		{"rejected", t.Rejected},
+		{"expired", t.Expired},
+		{"quorum", t.QuorumLost},
+	} {
+		if rare.n > 0 {
+			out += fmt.Sprintf(", %d %s", rare.n, rare.label)
+		}
+	}
+	return out
+}
+
+// lockSegmentEmpty reports a segment with nothing to show. N is not part of the
+// test: a node that recorded no locking still reports itself in every slot, so an
+// idle cluster would come back as a wall of zeros.
+func lockSegmentEmpty(s *madmin.LockSegment) bool {
+	return s.AcquireCount == 0 && s.AcquireFailed == 0 && s.HeldCount == 0 &&
+		s.ReleaseCount == 0 && s.Rejected == 0 && s.Expired == 0 && s.QuorumLost == 0
+}
+
+// lockWindowNode is one persisted locking window -- the hour or the day -- as a
+// row per time segment plus one navigable child per segment, so a burst can be
+// told apart from a steady trickle.
+type lockWindowNode struct {
+	seg    *madmin.SegmentedLockMetrics
+	flags  madmin.MetricFlags
+	window string
+	parent MetricNode
+	path   string
+}
+
+func (node *lockWindowNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *lockWindowNode) GetMetricType() madmin.MetricType   { return madmin.MetricsLocks }
+func (node *lockWindowNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *lockWindowNode) GetParent() MetricNode              { return node.parent }
+func (node *lockWindowNode) GetPath() string                    { return node.path }
+func (node *lockWindowNode) ShouldPauseRefresh() bool           { return true }
+
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *lockWindowNode) hasSegments() bool {
+	return node.seg != nil && node.seg.Interval > 0 && len(node.seg.Segments) > 0
+}
+
+// wholeSecs is the span the whole window covers: one segment as wide as every
+// slot it holds, so an _ALL rate reads as the window average.
+func (node *lockWindowNode) wholeSecs() int {
+	return node.seg.Interval * len(node.seg.Segments)
+}
+
+func (node *lockWindowNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
+	}
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	withDate := windowCrossesDay(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if lockSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeLockSegment(s, node.seg.Interval),
+		})
+	}
+	return children
+}
+
+func (node *lockWindowNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s lock segments available", node.window)
+	}
+	leaf := func(s madmin.LockSegment, segTime time.Time, interval, segments int) MetricNode {
+		return &lockSegmentLeafNode{
+			seg: s, segTime: segTime, interval: interval, segments: segments,
+			flags: node.flags, parent: node, path: node.path + "/" + name,
+		}
+	}
+	if name == "_ALL" {
+		return leaf(node.seg.Total(), node.seg.FirstTime, node.wholeSecs(), len(node.seg.Segments)), nil
+	}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	if i, ok := owners[name]; ok {
+		return leaf(node.seg.Segments[i], segmentStart(node.seg.FirstTime, node.seg.Interval, i), node.seg.Interval, 1), nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *lockWindowNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.seg, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	data := map[string]string{
+		"00:Total (last " + node.window + ")": formatLockWindow(node.seg),
+		"01:Coverage":                         windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}
+	idx := 2
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if lockSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		end := start.Add(time.Duration(node.seg.Interval) * time.Second)
+		data[segmentRowKey(idx, start, end)] = describeLockSegment(s, node.seg.Interval)
+		idx++
+	}
+	// The totals above are measured zeros, so they stay; only the reason there is
+	// no segment row is added.
+	if idx == 2 {
+		data["02:Segments"] = fmt.Sprintf("no locking recorded in any of the %d segment(s) measured",
+			len(node.seg.Segments))
+	}
+	return data
+}
+
+// describeLockSegment renders one segment on a single line. Every mean is derived
+// here; the wire carries only counts and summed durations.
+func describeLockSegment(s madmin.LockSegment, interval int) string {
+	out := fmt.Sprintf("%d acqs", s.AcquireCount)
+	if interval > 0 {
+		out += fmt.Sprintf(" (%.1f/s)", float64(s.AcquireCount)/float64(interval))
+	}
+	out += ", wait " + durationOf(s.AcquireNanos, s.AcquireCount)
+	if s.HeldCount > 0 {
+		out += ", held " + durationOf(s.HeldNanos, s.HeldCount)
+	}
+	if s.ReleaseCount > 0 {
+		out += ", rel " + durationOf(s.ReleaseNanos, s.ReleaseCount)
+	}
+	if s.AcquireFailed > 0 {
+		out += fmt.Sprintf(", %d failed (avg %s)", s.AcquireFailed,
+			durationOf(s.AcquireFailedNanos, s.AcquireFailed))
+	}
+	for _, rare := range []struct {
+		label string
+		n     uint64
+	}{
+		{"rejected", s.Rejected},
+		{"expired", s.Expired},
+		{"quorum", s.QuorumLost},
+	} {
+		if rare.n > 0 {
+			out += fmt.Sprintf(", %d %s", rare.n, rare.label)
+		}
+	}
+	return out
+}
+
+// lockSegmentLeafNode is one lock segment, or the whole window combined.
+type lockSegmentLeafNode struct {
+	seg      madmin.LockSegment
+	segTime  time.Time
+	interval int
+	// segments is how many segments were merged into seg, so N can be divided back
+	// into a node count. One for a single segment, the whole window for _ALL.
+	segments int
+	flags    madmin.MetricFlags
+	parent   MetricNode
+	path     string
+}
+
+func (node *lockSegmentLeafNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *lockSegmentLeafNode) GetMetricType() madmin.MetricType   { return madmin.MetricsLocks }
+func (node *lockSegmentLeafNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *lockSegmentLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *lockSegmentLeafNode) GetPath() string                    { return node.path }
+func (node *lockSegmentLeafNode) ShouldPauseRefresh() bool           { return true }
+func (node *lockSegmentLeafNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *lockSegmentLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *lockSegmentLeafNode) GetLeafData() map[string]string {
+	s := node.seg
+	if lockSegmentEmpty(&s) {
+		return map[string]string{"Status": "no locking activity in this time segment"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.interval > 0 {
+		add("Time Segment", windowCoverage(node.segTime, node.interval))
+	}
+	add("Acquires", strconv.FormatUint(s.AcquireCount, 10))
+	if node.interval > 0 {
+		add("Grant Rate", fmt.Sprintf("%.2f/s", float64(s.AcquireCount)/float64(node.interval)))
+	}
+	add("Mean Acquire Wait", durationOf(s.AcquireNanos, s.AcquireCount))
+	if s.HeldCount > 0 {
+		add("Held", strconv.FormatUint(s.HeldCount, 10))
+		add("Mean Hold", durationOf(s.HeldNanos, s.HeldCount))
+	}
+	// Near zero for a plain lock and real for the coalesced paths, which is why it
+	// is worth its own row.
+	if s.ReleaseCount > 0 {
+		add("Released", strconv.FormatUint(s.ReleaseCount, 10))
+		add("Mean Release", durationOf(s.ReleaseNanos, s.ReleaseCount))
+	}
+	if s.AcquireFailed > 0 {
+		add("Failed", strconv.FormatUint(s.AcquireFailed, 10))
+		add("Mean Failed Wait", durationOf(s.AcquireFailedNanos, s.AcquireFailed))
+		// Attempts is the denominator: a grant and a failure are both attempts.
+		add("Failure Share", calculatePercentage(s.AcquireFailed, s.AcquireCount+s.AcquireFailed))
+	}
+	for _, rare := range []struct {
+		label string
+		n     uint64
+	}{
+		{"Rejected", s.Rejected},
+		{"Expired", s.Expired},
+		{"Quorum Lost", s.QuorumLost},
+	} {
+		if rare.n > 0 {
+			add(rare.label, strconv.FormatUint(rare.n, 10))
+		}
+	}
+	// Context only: every field above is a cross-node sum, and dividing one by the
+	// node count would invent a per-node figure that moves when a node joins or
+	// leaves. N itself is per segment, so it is divided by the merge count.
+	if s.N > 0 {
+		add("Nodes", formatNodeCount(s.N, node.segments))
 	}
 	return data
 }

--- a/mnav/locks.go
+++ b/mnav/locks.go
@@ -448,10 +448,14 @@ func (node *LockPurgeNode) GetLeafData() map[string]string {
 	}
 	p := node.purge
 	data := map[string]string{
-		// Up to one cleanup interval old; not comparable with the live counters.
-		"Sampled At":  stampAge(node, p.SampledAt, "15:04:05", time.Second),
 		"Read Locks":  strconv.FormatInt(p.Readers, 10),
 		"Write Locks": strconv.FormatInt(p.Writers, 10),
+	}
+	// Up to one cleanup interval old; not comparable with the live counters. Omitted
+	// rather than formatted as the zero time when the pass carries counts but no
+	// timestamp, matching how LockMetricsNode summarizes it.
+	if !p.SampledAt.IsZero() {
+		data["Sampled At"] = stampAge(node, p.SampledAt, "15:04:05", time.Second)
 	}
 	if p.Expired > 0 {
 		data["Expired (last pass)"] = strconv.FormatInt(p.Expired, 10)

--- a/mnav/locks_test.go
+++ b/mnav/locks_test.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+var lockFirstTime = time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+func lockWindow(interval int, segments ...madmin.LockSegment) *madmin.SegmentedLockMetrics {
+	return &madmin.SegmentedLockMetrics{
+		Interval:  interval,
+		FirstTime: lockFirstTime,
+		Segments:  segments,
+	}
+}
+
+// A busy segment: 100 grants waiting 2s in total, so the mean wait is 20ms.
+func busyLockSegment() madmin.LockSegment {
+	return madmin.LockSegment{
+		N: 2, AcquireCount: 100, AcquireNanos: 2_000_000_000,
+		HeldCount: 90, HeldNanos: 900_000_000,
+		ReleaseCount: 90, ReleaseNanos: 90_000_000,
+	}
+}
+
+func lockNav(t *testing.T, locks *madmin.LockMetrics) MetricNavigator {
+	t.Helper()
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Locks: locks},
+	})
+}
+
+// The cleanup pass has not sampled on a fresh cluster, but the windows must still
+// be listed -- and everything listed must be constructible.
+func TestLockChildrenWithoutPurge(t *testing.T) {
+	nav := lockNav(t, &madmin.LockMetrics{LastHour: lockWindow(60, busyLockSegment())})
+	node, err := nav.Navigate("locks")
+	if err != nil {
+		t.Fatalf("navigate locks: %v", err)
+	}
+	got := childNames(node.GetChildren())
+	if want := []string{"last_hour", "last_day"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	// Once the pass has sampled, purge joins the list and still resolves.
+	nav = lockNav(t, &madmin.LockMetrics{Purge: &madmin.LockPurgeStats{Readers: 3}})
+	node, err = nav.Navigate("locks")
+	if err != nil {
+		t.Fatalf("navigate locks: %v", err)
+	}
+	got = childNames(node.GetChildren())
+	if want := []string{"purge", "last_hour", "last_day"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children with purge = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+}
+
+// Rows carry the real span they cover, oldest first, and every listed child
+// resolves to that segment's leaf.
+func TestLockWindowSegments(t *testing.T) {
+	rare := madmin.LockSegment{
+		N: 2, AcquireCount: 10, AcquireNanos: 100_000_000,
+		AcquireFailed: 5, AcquireFailedNanos: 500_000_000,
+		Rejected: 2, Expired: 1, QuorumLost: 3,
+	}
+	nav := lockNav(t, &madmin.LockMetrics{
+		// The first slot is empty, so it is neither a row nor a child.
+		LastHour: lockWindow(60, madmin.LockSegment{N: 2}, busyLockSegment(), rare),
+	})
+	node, err := nav.Navigate("locks/last_hour")
+	if err != nil {
+		t.Fatalf("navigate locks/last_hour: %v", err)
+	}
+
+	got := childNames(node.GetChildren())
+	if want := []string{"_ALL", "10:01Z", "10:02Z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	data := node.GetLeafData()
+	for _, key := range []string{
+		"00:Total (last hour)", "01:Coverage",
+		"02: 10:01Z", "03: 10:02Z",
+	} {
+		if _, ok := data[key]; !ok {
+			t.Errorf("missing row %q in %v", key, data)
+		}
+	}
+	if len(data) != 4 {
+		t.Errorf("rows = %v, want exactly 4 (total + coverage + two non-empty segments)", data)
+	}
+	// The busy segment is the older of the two, so it is the first segment row.
+	if got, want := data["02: 10:01Z"], "100 acqs (1.7/s), wait 20ms, held 10ms, rel 1ms"; got != want {
+		t.Errorf("first segment row = %q, want %q", got, want)
+	}
+
+	// The mean wait is derived from AcquireNanos/AcquireCount, never sent.
+	busy, err := nav.Navigate("locks/last_hour/10:01Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	bd := busy.GetLeafData()
+	if got := leafValue(bd, "Mean Acquire Wait"); got != "20ms" {
+		t.Errorf("Mean Acquire Wait = %q, want 20ms", got)
+	}
+	if got := leafValue(bd, "Grant Rate"); got != "1.67/s" {
+		t.Errorf("Grant Rate = %q, want 1.67/s", got)
+	}
+	if got := leafValue(bd, "Mean Hold"); got != "10ms" {
+		t.Errorf("Mean Hold = %q, want 10ms", got)
+	}
+	if got := leafValue(bd, "Nodes"); got != "2 node(s)" {
+		t.Errorf("Nodes = %q, want 2 node(s)", got)
+	}
+	// A quiet segment names no rare event at all.
+	for _, key := range []string{"Rejected", "Expired", "Quorum Lost", "Failed"} {
+		if got := leafValue(bd, key); got != "" {
+			t.Errorf("%s = %q on a clean segment, want no row", key, got)
+		}
+	}
+
+	// The segment that had them names all three, plus the wasted waiting.
+	bad, err := nav.Navigate("locks/last_hour/10:02Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	xd := bad.GetLeafData()
+	for key, want := range map[string]string{
+		"Rejected": "2", "Expired": "1", "Quorum Lost": "3",
+		"Failed": "5", "Mean Failed Wait": "100ms", "Failure Share": "33.3%",
+	} {
+		if got := leafValue(xd, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	// _ALL is the whole window as one segment: 110 grants over three minutes.
+	all, err := nav.Navigate("locks/last_hour/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	if got := leafValue(all.GetLeafData(), "Acquires"); got != "110" {
+		t.Errorf("_ALL Acquires = %q, want 110", got)
+	}
+}
+
+// A window the caller did not request must read as unavailable, an empty one as no
+// data -- never as a row of real zeros.
+func TestLockWindowUnavailable(t *testing.T) {
+	nav := lockNav(t, &madmin.LockMetrics{
+		LastDay: &madmin.SegmentedLockMetrics{Interval: 900, FirstTime: lockFirstTime},
+	})
+
+	hour, err := nav.Navigate("locks/last_hour")
+	if err != nil {
+		t.Fatalf("navigate locks/last_hour: %v", err)
+	}
+	if got := hour.GetLeafData()["Status"]; !strings.Contains(got, "not requested") {
+		t.Errorf("nil window Status = %q, want it to say the stats were not requested", got)
+	}
+	if got := hour.GetChildren(); len(got) != 0 {
+		t.Errorf("nil window children = %v, want none", childNames(got))
+	}
+	if _, err := hour.GetChild("_ALL"); err == nil {
+		t.Error("GetChild on a nil window returned a node, want an error")
+	}
+
+	day, err := nav.Navigate("locks/last_day")
+	if err != nil {
+		t.Fatalf("navigate locks/last_day: %v", err)
+	}
+	if got, want := day.GetLeafData()["Status"], "no data yet: the last-day window holds no completed segment"; got != want {
+		t.Errorf("empty window Status = %q, want %q", got, want)
+	}
+
+	// Segments that exist but recorded nothing are measured zeros: the totals are
+	// real and stay, and only the missing segment rows are explained.
+	nav = lockNav(t, &madmin.LockMetrics{LastDay: lockWindow(900, madmin.LockSegment{N: 4})})
+	day, err = nav.Navigate("locks/last_day")
+	if err != nil {
+		t.Fatalf("navigate locks/last_day: %v", err)
+	}
+	idle := day.GetLeafData()
+	if got := idle["Status"]; got != "" {
+		t.Errorf("idle window Status = %q, want the measured totals instead", got)
+	}
+	if got, want := idle["00:Total (last day)"], "0 acqs, avg n/a"; got != want {
+		t.Errorf("idle window total = %q, want the measured %q", got, want)
+	}
+	if got, want := idle["02:Segments"], "no locking recorded in any of the 1 segment(s) measured"; got != want {
+		t.Errorf("idle window segment note = %q, want %q", got, want)
+	}
+	if got := childNames(day.GetChildren()); !reflect.DeepEqual(got, []string{"_ALL"}) {
+		t.Errorf("idle window children = %v, want just _ALL", got)
+	}
+}
+
+// The one-line summaries must keep the three window states apart: an absent
+// window is not a measured zero, and neither is one that is still filling.
+func TestFormatLockWindowStates(t *testing.T) {
+	if got, want := formatLockWindow(nil), "not collected"; got != want {
+		t.Errorf("nil window = %q, want %q", got, want)
+	}
+	if got, want := formatLockWindow(lockWindow(900)), "no data yet"; got != want {
+		t.Errorf("empty window = %q, want %q", got, want)
+	}
+	if got, want := formatLockWindow(lockWindow(900, madmin.LockSegment{N: 4})), "0 acqs, avg n/a"; got != want {
+		t.Errorf("idle window = %q, want the measured %q", got, want)
+	}
+}
+
+// A whole-window label states the span it covers and the instant it ends: an
+// interval as wide as the window would otherwise print one time twice.
+func TestLockWindowCoverageLabel(t *testing.T) {
+	// 95 quarter-hour slots, the shape a cross-node merge can produce.
+	segments := make([]madmin.LockSegment, 95)
+	segments[0] = busyLockSegment()
+	nav := lockNav(t, &madmin.LockMetrics{LastDay: lockWindow(900, segments...)})
+	node, err := nav.Navigate("locks/last_day")
+	if err != nil {
+		t.Fatalf("navigate locks/last_day: %v", err)
+	}
+	wantUTC := "Covering 23h45m, until Aug 13, 09:45Z"
+	wantCoverage(t, "window coverage", node.GetLeafData()["01:Coverage"], wantUTC)
+	for _, child := range node.GetChildren() {
+		if child.Name != "_ALL" {
+			continue
+		}
+		if !strings.Contains(child.Description, wantUTC) {
+			t.Errorf("_ALL described as %q, want it to contain %q", child.Description, wantUTC)
+		}
+	}
+	all, err := nav.Navigate("locks/last_day/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	wantCoverage(t, "_ALL time segment", leafValue(all.GetLeafData(), "Time Segment"), wantUTC)
+}
+
+// A key is a bare wall-clock time, so a window that reaches 24 hours -- what
+// Segmented.Add yields when two nodes' FirstTime differ by one interval -- has two
+// slots wanting one name. The newest keeps it, and the list agrees with lookup.
+func TestLockWindowDuplicateSegmentKeys(t *testing.T) {
+	// 97 quarter-hour slots span 24h15m, so slot 0 and slot 96 are both 10:00Z.
+	segments := make([]madmin.LockSegment, 97)
+	segments[0] = madmin.LockSegment{N: 1, AcquireCount: 7, AcquireNanos: 7_000_000}
+	segments[96] = madmin.LockSegment{N: 1, AcquireCount: 11, AcquireNanos: 11_000_000}
+	nav := lockNav(t, &madmin.LockMetrics{LastDay: lockWindow(900, segments...)})
+	node, err := nav.Navigate("locks/last_day")
+	if err != nil {
+		t.Fatalf("navigate locks/last_day: %v", err)
+	}
+
+	names := childNames(node.GetChildren())
+	if want := []string{"_ALL", "10:00Z"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("children = %v, want %v (the older 10:00Z slot dropped)", names, want)
+	}
+	for _, name := range names {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	// The surviving segment is the newest: 11 acquires, not the older slot's 7.
+	dup, err := node.GetChild("10:00Z")
+	if err != nil {
+		t.Fatalf("GetChild(10:00Z): %v", err)
+	}
+	if got := leafValue(dup.GetLeafData(), "Acquires"); got != "11" {
+		t.Errorf("Acquires = %q, want 11 from the newest slot", got)
+	}
+	// And it is the newest by its label too: one interval short of a full extra day.
+	wantCoverage(t, "duplicate-key Time Segment",
+		leafValue(dup.GetLeafData(), "Time Segment"), "Covering 15m, until Aug 13, 10:15Z")
+}
+
+// The section refreshes continuously, so it must not pull the windows: it renders
+// their summaries only when the history is already loaded.
+func TestLockSectionRequestsNoHistory(t *testing.T) {
+	nav := lockNav(t, &madmin.LockMetrics{
+		LastHour: lockWindow(60, busyLockSegment()),
+		LastDay:  &madmin.SegmentedLockMetrics{Interval: 900, FirstTime: lockFirstTime},
+	})
+	node, err := nav.Navigate("locks")
+	if err != nil {
+		t.Fatalf("navigate locks: %v", err)
+	}
+	if got := node.GetMetricFlags(); got != 0 {
+		t.Errorf("section flags = %v, want none: the windows are fetched on entering one", got)
+	}
+	if opts := node.GetOpts(); opts.Flags != 0 {
+		t.Errorf("section opts flags = %v, want none", opts.Flags)
+	}
+	data := node.GetLeafData()
+	// Loaded history is summarized...
+	if got, want := data["Last Hour"], "100 acqs, avg 20ms, held 10ms"; got != want {
+		t.Errorf("Last Hour = %q, want %q", got, want)
+	}
+	// ...but a window with no segment is not, so it can never read as a zero.
+	if got, ok := data["Last Day"]; ok {
+		t.Errorf("Last Day = %q, want no row for a window holding no segment", got)
+	}
+}
+
+// Every window node must request the window it renders: parent inheritance hides a
+// wrong constant, so the node's own flags are what is asserted.
+func TestLockWindowFlags(t *testing.T) {
+	nav := lockNav(t, &madmin.LockMetrics{
+		LastHour: lockWindow(60, busyLockSegment()),
+		LastDay:  lockWindow(900, busyLockSegment()),
+	})
+	for _, tt := range []struct {
+		path string
+		want madmin.MetricFlags
+	}{
+		{"locks/last_hour", madmin.MetricsHourStats},
+		{"locks/last_hour/10:00Z", madmin.MetricsHourStats},
+		{"locks/last_hour/_ALL", madmin.MetricsHourStats},
+		{"locks/last_day", madmin.MetricsDayStats},
+		{"locks/last_day/10:00Z", madmin.MetricsDayStats},
+		{"locks/last_day/_ALL", madmin.MetricsDayStats},
+	} {
+		node, err := nav.Navigate(tt.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tt.path, err)
+		}
+		if got := node.GetMetricFlags(); got != tt.want {
+			t.Errorf("%s flags = %v, want exactly %v", tt.path, got, tt.want)
+		}
+		if opts := node.GetOpts(); !opts.Flags.Contains(tt.want) || opts.Type&madmin.MetricsLocks == 0 {
+			t.Errorf("%s opts = %v/%v, want lock metrics with %v", tt.path, opts.Type, opts.Flags, tt.want)
+		}
+		if !node.ShouldPauseRefresh() {
+			t.Errorf("%s does not pause refresh, want a paused time series", tt.path)
+		}
+	}
+}
+
+// wantCoverage asserts a coverage label's UTC part exactly and only that a local
+// time follows it. The local rendering depends on the machine's zone, so pinning
+// it would pass here and fail in CI, which runs in UTC.
+func wantCoverage(t *testing.T, where, got, wantUTC string) {
+	t.Helper()
+	if !strings.HasPrefix(got, wantUTC+" (") || !strings.HasSuffix(got, ").") {
+		t.Errorf("%s = %q, want %q followed by a parenthesised local time", where, got, wantUTC)
+	}
+}

--- a/mnav/mem.go
+++ b/mnav/mem.go
@@ -627,7 +627,7 @@ func (node *MemLastDayNode) GetLeafData() map[string]string {
 		idx++
 		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := fmt.Sprintf("%02d: %s->%sZ", idx, startTime.UTC().Format("15:04"), endTime.UTC().Format("15:04"))
+		name := segmentRowKey(idx, startTime, endTime)
 
 		n := uint64(seg.N)
 		perNodeUsed := seg.Used / n

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -147,6 +147,74 @@ type RealtimeMetricsNode struct {
 	metrics *madmin.RealtimeMetrics
 }
 
+// collectionTimer is implemented by nodes that know when their metrics were
+// collected. Metric families carry their own timestamp, so the nearest ancestor
+// implementing this is more precise than the root.
+type collectionTimer interface {
+	collectionTime() time.Time
+}
+
+// collectedAt reports when the metrics at node were collected, walking up to the
+// root for the nearest node that knows, and whether any node knew.
+//
+// Every age rendered from a wire timestamp must be measured against this rather
+// than the wall clock: the navigator is also pointed at metrics loaded from a
+// saved capture, where time.Since would add however long ago the capture was
+// taken to every age. When no node on the chain carries a collection time there
+// is no reference point at all, so callers must show the absolute timestamp
+// rather than substitute the wall clock -- that substitution is the same bug.
+func collectedAt(node MetricNode) (time.Time, bool) {
+	for n := node; n != nil; n = n.GetParent() {
+		if ct, ok := n.(collectionTimer); ok {
+			if t := ct.collectionTime(); !t.IsZero() {
+				return t, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+// since is the age of ts at the collection time of node. future reports that ts
+// is after collection: clock skew between merged nodes can stamp an event after
+// the collection that observed it, which must not render as a negative age. ok is
+// false when the collection time is unknown, leaving no age to derive.
+func since(node MetricNode, ts time.Time) (d time.Duration, future, ok bool) {
+	base, ok := collectedAt(node)
+	if !ok {
+		return 0, false, false
+	}
+	if d = base.Sub(ts); d < 0 {
+		return -d, true, true
+	}
+	return d, false, true
+}
+
+// stampAge renders ts in layout followed by its age at node's collection time,
+// rounded to r. Only the stamp is rendered when that time is unknown.
+func stampAge(node MetricNode, ts time.Time, layout string, r time.Duration) string {
+	d, future, ok := since(node, ts)
+	if !ok {
+		return ts.Format(layout)
+	}
+	if future {
+		return fmt.Sprintf("%s (in %s)", ts.Format(layout), d.Round(r))
+	}
+	return fmt.Sprintf("%s (%s ago)", ts.Format(layout), d.Round(r))
+}
+
+// ageStamp renders the age of ts at node's collection time, rounded to r, falling
+// back to ts in layout when that time is unknown.
+func ageStamp(node MetricNode, ts time.Time, layout string, r time.Duration) string {
+	d, future, ok := since(node, ts)
+	if !ok {
+		return ts.Format(layout)
+	}
+	if future {
+		return fmt.Sprintf("in %s", d.Round(r))
+	}
+	return fmt.Sprintf("%s ago", d.Round(r))
+}
+
 func getNodeOpts(node MetricNode) madmin.MetricsOptions {
 	var opts madmin.MetricsOptions
 	opts.Type = node.GetMetricType()
@@ -168,6 +236,13 @@ func getNodeOpts(node MetricNode) madmin.MetricsOptions {
 
 func (node *RealtimeMetricsNode) GetOpts() madmin.MetricsOptions {
 	return getNodeOpts(node)
+}
+
+func (node *RealtimeMetricsNode) collectionTime() time.Time {
+	if node.metrics == nil {
+		return time.Time{}
+	}
+	return node.metrics.CollectedAt
 }
 
 func (node *RealtimeMetricsNode) ShouldPauseUpdates() bool {

--- a/mnav/mnav.go
+++ b/mnav/mnav.go
@@ -198,7 +198,7 @@ func (node *RealtimeMetricsNode) GetChildren() []MetricChild {
 		{Name: "tier", Description: "Warm storage tier operations, latency and failures"},
 		{Name: "ilm", Description: "Lifecycle worker pools: queues, throughput, failures"},
 		{Name: "locks", Description: "Distributed locking: held, contention, expiry"},
-		{Name: "iam", Description: "Identity inventory and IAM store latency"},
+		{Name: "iam", Description: "Identity inventory, authorization cost and store latency"},
 		{Name: "by_host", Description: "Metrics broken down by individual host"},
 		{Name: "by_drive", Description: "Metrics broken down by individual drive"},
 		{Name: "by_drive_set", Description: "Metrics broken down by drive set"},
@@ -381,7 +381,7 @@ func (node *MetricsNode) GetChildren() []MetricChild {
 		{Name: "tier", Description: "Warm storage tier operations, latency and failures"},
 		{Name: "ilm", Description: "Lifecycle worker pools: queues, throughput, failures"},
 		{Name: "locks", Description: "Distributed locking: held, contention, expiry"},
-		{Name: "iam", Description: "Identity inventory and IAM store latency"},
+		{Name: "iam", Description: "Identity inventory, authorization cost and store latency"},
 	}
 }
 

--- a/mnav/mnav_test.go
+++ b/mnav/mnav_test.go
@@ -253,6 +253,28 @@ func TestByTimeAllViews(t *testing.T) {
 		}}}}
 		check(t, m, "kms/last_day", "decrypt", "Calls")
 	})
+
+	// The two targets are staggered across classes, so the flattened map must key
+	// them by the bare wire key and still align them on one timeline.
+	t.Run("targets", func(t *testing.T) {
+		w := func(first time.Time, events ...uint64) *madmin.SegmentedTargetMetrics {
+			segs := make([]madmin.TargetSegment, len(events))
+			for i, e := range events {
+				segs[i] = madmin.TargetSegment{N: 1, Events: e}
+			}
+			return &madmin.SegmentedTargetMetrics{Interval: 900, FirstTime: first, Segments: segs}
+		}
+		m := &madmin.RealtimeMetrics{Aggregated: madmin.Metrics{Targets: &madmin.DeliveryTargetMetrics{
+			Nodes: 1,
+			Notification: map[string]madmin.TargetMetrics{
+				"notify_webhook:a": {N: 1, Subsystem: "notify_webhook", Name: "a", LastDay: w(t0, 1, 2)},
+			},
+			Audit: map[string]madmin.TargetMetrics{
+				"audit_kafka:b": {N: 1, Subsystem: "audit_kafka", Name: "b", LastDay: w(t0.Add(15*time.Minute), 5, 9)},
+			},
+		}}}
+		check(t, m, "targets/last_day", "audit_kafka:b", "Events")
+	})
 }
 
 func TestDiskSetLeafData(t *testing.T) {

--- a/mnav/net.go
+++ b/mnav/net.go
@@ -488,7 +488,7 @@ func (node *NetLastDayNode) GetLeafData() map[string]string {
 		idx++
 		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := fmt.Sprintf("%02d: %s->%sZ", idx, startTime.UTC().Format("15:04"), endTime.UTC().Format("15:04"))
+		name := segmentRowKey(idx, startTime, endTime)
 
 		avgRx := seg.RxBytes / uint64(seg.N)
 		avgTx := seg.TxBytes / uint64(seg.N)

--- a/mnav/os.go
+++ b/mnav/os.go
@@ -455,8 +455,12 @@ func (node *OSLastDayNode) GetChildren() []MetricChild {
 	}
 
 	// Iterate segments in reverse (most recent first)
+	owners := segmentSecOwners(refSeg.FirstTime, refSeg.Interval, len(refSeg.Segments))
 	for i := len(refSeg.Segments) - 1; i >= 0; i-- {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
+		segmentTime := segmentStart(refSeg.FirstTime, refSeg.Interval, i)
+		if owners[segmentKey(segmentTime)] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(refSeg.Interval) * time.Second)
 
 		// Count ops and active op types in this segment
@@ -478,7 +482,7 @@ func (node *OSLastDayNode) GetChildren() []MetricChild {
 		}
 
 		opsPerSec := float64(totalOps) / float64(refSeg.Interval)
-		name := segmentTime.UTC().Format("15:04Z")
+		name := segmentKey(segmentTime)
 		children = append(children, MetricChild{
 			Name:        name,
 			Description: fmt.Sprintf("%s, ending %s, %d op types, %s ops/s", day, endTime.Local().Format("15:04"), activeTypes, formatOpsPerSec(opsPerSec)),
@@ -534,11 +538,10 @@ func (node *OSLastDayNode) GetChild(name string) (MetricNode, error) {
 	if refSeg == nil {
 		return nil, fmt.Errorf("segment not found: %s", name)
 	}
-	for i := range refSeg.Segments {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return NewOSLastDaySegmentNode(node.lastDay, i, segmentTime, node, fmt.Sprintf("%s/%s", node.path, name)), nil
-		}
+	owners := segmentSecOwners(refSeg.FirstTime, refSeg.Interval, len(refSeg.Segments))
+	if i, ok := owners[name]; ok {
+		segmentTime := segmentStart(refSeg.FirstTime, refSeg.Interval, i)
+		return NewOSLastDaySegmentNode(node.lastDay, i, segmentTime, node, fmt.Sprintf("%s/%s", node.path, name)), nil
 	}
 	return nil, fmt.Errorf("segment not found: %s", name)
 }

--- a/mnav/process.go
+++ b/mnav/process.go
@@ -775,6 +775,13 @@ func (node *ProcessLastDayNode) GetMetricFlags() madmin.MetricFlags { return mad
 func (node *ProcessLastDayNode) ShouldPauseRefresh() bool           { return true }
 func (node *ProcessLastDayNode) GetLeafData() map[string]string     { return nil }
 
+// segmentOwners maps this node's navigation keys -- segment end instants -- to the
+// slot that owns each.
+func (node *ProcessLastDayNode) segmentOwners() map[string]int {
+	step := time.Duration(node.segmented.Interval) * time.Second
+	return segmentOwners(node.segmented.FirstTime.Add(step), step, len(node.segmented.Segments))
+}
+
 func (node *ProcessLastDayNode) GetChildren() []MetricChild {
 	if node.segmented == nil || len(node.segmented.Segments) == 0 {
 		return nil
@@ -786,15 +793,21 @@ func (node *ProcessLastDayNode) GetChildren() []MetricChild {
 		Description: "Aggregated process statistics across all time segments",
 	})
 
+	// A segment is named by the instant it ends here, so the owner map starts one
+	// interval later than the window does.
+	owners := node.segmentOwners()
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
 		seg := node.segmented.Segments[i]
 		if seg.N == 0 {
 			continue
 		}
 
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
 		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		segmentName := endTime.UTC().Format("15:04Z")
+		segmentName := segmentKey(endTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		avgCPU := seg.CPUPercent / float64(seg.N)
 		avgRSS := seg.RSS / uint64(seg.N)
@@ -832,18 +845,14 @@ func (node *ProcessLastDayNode) GetChild(name string) (MetricNode, error) {
 		}, nil
 	}
 
-	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		if endTime.UTC().Format("15:04Z") == name {
-			return &ProcessTimeSegmentNode{
-				segment:     node.segmented.Segments[i],
-				segmentTime: segmentTime,
-				interval:    node.segmented.Interval,
-				parent:      node,
-				path:        node.path + "/" + name,
-			}, nil
-		}
+	if i, ok := node.segmentOwners()[name]; ok {
+		return &ProcessTimeSegmentNode{
+			segment:     node.segmented.Segments[i],
+			segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
+			interval:    node.segmented.Interval,
+			parent:      node,
+			path:        node.path + "/" + name,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -666,9 +666,13 @@ func (node *ReplicationLastDayNode) GetChildren() []MetricChild {
 	})
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		segmentName := segmentTime.UTC().Format("15:04Z")
+		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		// Get event count for this segment
 		var events int64
@@ -735,18 +739,16 @@ func (node *ReplicationLastDayNode) GetChild(name string) (MetricNode, error) {
 
 	// Handle time segments - find by time format (with UTC indicator)
 	if node.segmented != nil {
-		for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-			segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-			if segmentTime.UTC().Format("15:04Z") == name {
-				return &ReplicationTimeSegmentNode{
-					targetName:  node.targetName,
-					segment:     node.segmented.Segments[i],
-					segmentTime: segmentTime,
-					interval:    node.segmented.Interval,
-					parent:      node,
-					path:        node.path + "/" + name,
-				}, nil
-			}
+		owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+		if i, ok := owners[name]; ok {
+			return &ReplicationTimeSegmentNode{
+				targetName:  node.targetName,
+				segment:     node.segmented.Segments[i],
+				segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
+				interval:    node.segmented.Interval,
+				parent:      node,
+				path:        node.path + "/" + name,
+			}, nil
 		}
 	}
 
@@ -899,14 +901,19 @@ func (node *ReplicationLastDayAggregatedNode) GetChildren() []MetricChild {
 		Description: "Aggregated total across all targets",
 	}}
 
+	owners := segmentSecOwners(seg.FirstTime, seg.Interval, len(seg.Segments))
 	for i := len(seg.Segments) - 1; i >= 0; i-- {
 		if seg.Segments[i].Events == 0 {
 			continue
 		}
-		segTime := seg.FirstTime.Add(time.Duration(i*seg.Interval) * time.Second)
+		segTime := segmentStart(seg.FirstTime, seg.Interval, i)
+		name := segmentKey(segTime)
+		if owners[name] != i {
+			continue
+		}
 		endTime := segTime.Add(time.Duration(seg.Interval) * time.Second)
 		children = append(children, MetricChild{
-			Name:        segTime.UTC().Format("15:04Z"),
+			Name:        name,
 			Description: replicationSegmentDesc(segTime, endTime, seg.Segments[i]),
 		})
 	}
@@ -959,18 +966,15 @@ func (node *ReplicationLastDayAggregatedNode) GetChild(name string) (MetricNode,
 		}, nil
 	}
 
-	for i := len(seg.Segments) - 1; i >= 0; i-- {
-		segTime := seg.FirstTime.Add(time.Duration(i*seg.Interval) * time.Second)
-		if segTime.UTC().Format("15:04Z") == name {
-			return &ReplicationTimeSegmentNode{
-				targetName:  "all targets",
-				segment:     seg.Segments[i],
-				segmentTime: segTime,
-				interval:    seg.Interval,
-				parent:      node,
-				path:        fmt.Sprintf("%s/%s", node.path, name),
-			}, nil
-		}
+	if i, ok := segmentSecOwners(seg.FirstTime, seg.Interval, len(seg.Segments))[name]; ok {
+		return &ReplicationTimeSegmentNode{
+			targetName:  "all targets",
+			segment:     seg.Segments[i],
+			segmentTime: segmentStart(seg.FirstTime, seg.Interval, i),
+			interval:    seg.Interval,
+			parent:      node,
+			path:        fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
 	}
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }

--- a/mnav/rpc.go
+++ b/mnav/rpc.go
@@ -34,6 +34,13 @@ type RPCMetricsNode struct {
 	path   string
 }
 
+func (node *RPCMetricsNode) collectionTime() time.Time {
+	if node.rpc == nil {
+		return time.Time{}
+	}
+	return node.rpc.CollectedAt
+}
+
 func (node *RPCMetricsNode) GetOpts() madmin.MetricsOptions {
 	return getNodeOpts(node)
 }
@@ -1116,12 +1123,10 @@ func (node *RPCDestinationNode) GetLeafData() map[string]string {
 
 	// Connection timing
 	if !node.stats.LastConnectTime.IsZero() {
-		data["Last Connect"] = fmt.Sprintf("%s (%v ago)", node.stats.LastConnectTime.Format("2006-01-02 15:04:05"),
-			time.Since(node.stats.LastConnectTime).Round(time.Minute).String())
+		data["Last Connect"] = stampAge(node, node.stats.LastConnectTime, "2006-01-02 15:04:05", time.Minute)
 	}
 	if !node.stats.LastPongTime.IsZero() {
-		data["Last Pong"] = fmt.Sprintf("%s (%v ago)", node.stats.LastPongTime.Format("2006-01-02 15:04:05"),
-			time.Since(node.stats.LastPongTime).Round(time.Minute).String())
+		data["Last Pong"] = stampAge(node, node.stats.LastPongTime, "2006-01-02 15:04:05", time.Minute)
 	}
 
 	return data
@@ -1189,12 +1194,10 @@ func (node *RPCCallerNode) GetLeafData() map[string]string {
 
 	// Connection timing
 	if !node.stats.LastConnectTime.IsZero() {
-		data["Last Connect"] = fmt.Sprintf("%s (%v ago)", node.stats.LastConnectTime.Format("2006-01-02 15:04:05"),
-			time.Since(node.stats.LastConnectTime).Round(time.Minute).String())
+		data["Last Connect"] = stampAge(node, node.stats.LastConnectTime, "2006-01-02 15:04:05", time.Minute)
 	}
 	if !node.stats.LastPongTime.IsZero() {
-		data["Last Pong"] = fmt.Sprintf("%s (%v ago)", node.stats.LastPongTime.Format("2006-01-02 15:04:05"),
-			time.Since(node.stats.LastPongTime).Round(time.Minute).String())
+		data["Last Pong"] = stampAge(node, node.stats.LastPongTime, "2006-01-02 15:04:05", time.Minute)
 	}
 
 	return data

--- a/mnav/rpc.go
+++ b/mnav/rpc.go
@@ -194,7 +194,7 @@ func rpcView(ops map[string]madmin.SegmentedRPCMetrics) segView[madmin.RPCStats,
 		opLeaf: func(op string, s madmin.RPCStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
 			return &RPCHandlerSegmentNode{handler: op, stats: s, segmentTime: segTime, parent: parent, path: path}
 		},
-		sumLeaf: func(s madmin.RPCStats, segTime time.Time, _ int, parent MetricNode, path string) MetricNode {
+		sumLeaf: func(s madmin.RPCStats, segTime time.Time, _, _ int, parent MetricNode, path string) MetricNode {
 			return &RPCTimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
 		},
 	}
@@ -367,13 +367,17 @@ func (node *RPCLastDayAllNode) GetChildren() []MetricChild {
 
 	// Calculate union of all time segments across all handlers
 	timeSegments := node.calculateAllTimeSegments()
+	owners := node.segmentOwners(timeSegments)
 
 	// Add time segments, most recent first (filter out empty segments)
 	for i := len(timeSegments) - 1; i >= 0; i-- {
 		segment := timeSegments[i]
 		segmentTime := segment.Time
 		endTime := segmentTime.Add(time.Duration(segment.Interval) * time.Second)
-		segmentName := segmentTime.UTC().Format("15:04Z")
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		// Filter out time segments with no requests
 		if segment.TotalRequests == 0 {
@@ -406,6 +410,17 @@ type timeSegmentInfo struct {
 	Interval      int
 	TotalRequests int64
 	TotalTime     float64
+}
+
+// segmentOwners maps this node's navigation keys to the slot that owns each. The
+// union spans more than a day as soon as two handlers' FirstTime differ, so two
+// slots can carry the same wall-clock name; the newest keeps it.
+func (node *RPCLastDayAllNode) segmentOwners(segments []timeSegmentInfo) map[string]int {
+	times := make([]time.Time, len(segments))
+	for i, s := range segments {
+		times[i] = s.Time
+	}
+	return segmentTimeOwners(times)
 }
 
 // calculateAllTimeSegments calculates the union of all time segments across all handlers
@@ -488,30 +503,29 @@ func (node *RPCLastDayAllNode) GetChild(name string) (MetricNode, error) {
 	timeSegments := node.calculateAllTimeSegments()
 
 	// Handle time segments
-	for _, segment := range timeSegments {
-		segmentTime := segment.Time
-		if segmentTime.UTC().Format("15:04Z") == name {
-			// Create aggregated stats for this time segment
-			var aggregatedStats madmin.RPCStats
+	if i, ok := node.segmentOwners(timeSegments)[name]; ok {
+		segmentTime := timeSegments[i].Time
 
-			// Aggregate data from all handlers for this specific time
-			for _, segmented := range node.rpc.LastDay {
-				for i, handlerSegment := range segmented.Segments {
-					handlerSegmentTime := segmented.FirstTime.Add(time.Duration(i*segmented.Interval) * time.Second)
-					if handlerSegmentTime.Equal(segmentTime) {
-						aggregatedStats.Merge(handlerSegment)
-						break
-					}
+		// Create aggregated stats for this time segment
+		var aggregatedStats madmin.RPCStats
+
+		// Aggregate data from all handlers for this specific time
+		for _, segmented := range node.rpc.LastDay {
+			for i, handlerSegment := range segmented.Segments {
+				handlerSegmentTime := segmented.FirstTime.Add(time.Duration(i*segmented.Interval) * time.Second)
+				if handlerSegmentTime.Equal(segmentTime) {
+					aggregatedStats.Merge(handlerSegment)
+					break
 				}
 			}
-
-			return &RPCTimeSegmentAllNode{
-				segment:     aggregatedStats,
-				segmentTime: segmentTime,
-				parent:      node,
-				path:        node.path + "/" + name,
-			}, nil
 		}
+
+		return &RPCTimeSegmentAllNode{
+			segment:     aggregatedStats,
+			segmentTime: segmentTime,
+			parent:      node,
+			path:        node.path + "/" + name,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)
@@ -609,6 +623,7 @@ func (node *RPCLastDayHandlerNode) GetChildren() []MetricChild {
 	})
 
 	// Add time segments, most recent first (filter out empty segments)
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
 		segment := node.segmented.Segments[i]
 
@@ -617,9 +632,12 @@ func (node *RPCLastDayHandlerNode) GetChildren() []MetricChild {
 			continue
 		}
 
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
+		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
 		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		segmentName := segmentTime.UTC().Format("15:04Z")
+		segmentName := segmentKey(segmentTime)
+		if owners[segmentName] != i {
+			continue
+		}
 
 		rps := float64(segment.Requests) / float64(node.segmented.Interval)
 		day := ""
@@ -671,17 +689,15 @@ func (node *RPCLastDayHandlerNode) GetChild(name string) (MetricNode, error) {
 	}
 
 	// Handle time segments
-	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		segmentTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return &RPCHandlerSegmentNode{
-				handler:     node.handlerName,
-				stats:       node.segmented.Segments[i],
-				segmentTime: segmentTime,
-				parent:      node,
-				path:        node.path + "/" + name,
-			}, nil
-		}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	if i, ok := owners[name]; ok {
+		return &RPCHandlerSegmentNode{
+			handler:     node.handlerName,
+			stats:       node.segmented.Segments[i],
+			segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
+			parent:      node,
+			path:        node.path + "/" + name,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("time segment not found: %s", name)

--- a/mnav/runtime.go
+++ b/mnav/runtime.go
@@ -603,7 +603,7 @@ func (node *RuntimeLastDayNode) GetLeafData() map[string]string {
 		idx++
 		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
 		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := fmt.Sprintf("%02d: %s->%sZ", idx, startTime.UTC().Format("15:04"), endTime.UTC().Format("15:04"))
+		name := segmentRowKey(idx, startTime, endTime)
 		n := uint64(seg.N)
 
 		var parts []string

--- a/mnav/scanner.go
+++ b/mnav/scanner.go
@@ -631,8 +631,12 @@ func (node *ScannerLastDayNode) GetChildren() []MetricChild {
 		return children
 	}
 
+	owners := segmentSecOwners(refSeg.FirstTime, refSeg.Interval, len(refSeg.Segments))
 	for i := len(refSeg.Segments) - 1; i >= 0; i-- {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
+		segmentTime := segmentStart(refSeg.FirstTime, refSeg.Interval, i)
+		if owners[segmentKey(segmentTime)] != i {
+			continue
+		}
 		endTime := segmentTime.Add(time.Duration(refSeg.Interval) * time.Second)
 
 		var totalOps uint64
@@ -653,7 +657,7 @@ func (node *ScannerLastDayNode) GetChildren() []MetricChild {
 		}
 
 		opsPerSec := float64(totalOps) / float64(refSeg.Interval)
-		name := segmentTime.UTC().Format("15:04Z")
+		name := segmentKey(segmentTime)
 		children = append(children, MetricChild{
 			Name:        name,
 			Description: fmt.Sprintf("%s, ending %s, %d action types, %s ops/s", day, endTime.Local().Format("15:04"), activeTypes, formatOpsPerSec(opsPerSec)),
@@ -720,11 +724,10 @@ func (node *ScannerLastDayNode) GetChild(name string) (MetricNode, error) {
 	if refSeg == nil {
 		return nil, fmt.Errorf("segment not found: %s", name)
 	}
-	for i := range refSeg.Segments {
-		segmentTime := refSeg.FirstTime.Add(time.Duration(i*refSeg.Interval) * time.Second)
-		if segmentTime.UTC().Format("15:04Z") == name {
-			return NewScannerLastDaySegmentNode(node.lastDay, i, segmentTime, node, fmt.Sprintf("%s/%s", node.path, name)), nil
-		}
+	owners := segmentSecOwners(refSeg.FirstTime, refSeg.Interval, len(refSeg.Segments))
+	if i, ok := owners[name]; ok {
+		segmentTime := segmentStart(refSeg.FirstTime, refSeg.Interval, i)
+		return NewScannerLastDaySegmentNode(node.lastDay, i, segmentTime, node, fmt.Sprintf("%s/%s", node.path, name)), nil
 	}
 	return nil, fmt.Errorf("segment not found: %s", name)
 }

--- a/mnav/segments.go
+++ b/mnav/segments.go
@@ -140,6 +140,12 @@ func windowCoverage(start time.Time, seconds int) string {
 // coverDuration renders a span the way an operator states one: "23h45m", not
 // "23h45m0s".
 func coverDuration(d time.Duration) string {
+	// Below a minute, rounding to the minute would render every span as "0m". No
+	// family currently uses an interval that short, but this is a generic helper
+	// and a window that did would report its coverage as zero.
+	if d < time.Minute {
+		return strconv.Itoa(int(d.Round(time.Second)/time.Second)) + "s"
+	}
 	d = d.Round(time.Minute)
 	h, m := int(d/time.Hour), int(d/time.Minute)%60
 	switch {

--- a/mnav/segments.go
+++ b/mnav/segments.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// segmentStart is the wall-clock start of segment i of a window: segments are
+// oldest-first and aligned to FirstTime + i*Interval.
+func segmentStart(firstTime time.Time, interval, i int) time.Time {
+	return firstTime.Add(time.Duration(i*interval) * time.Second)
+}
+
+// segmentKey is the navigation name of the segment starting at t. It is a bare
+// wall-clock time, so it is unique only within 24 hours; segmentOwners resolves
+// the collision.
+func segmentKey(t time.Time) string {
+	return t.UTC().Format("15:04Z")
+}
+
+// segmentOwners maps every navigation key of a window to the slot that owns it.
+//
+// Keys collide once a window reaches 24 hours, and Segmented.Add produces exactly
+// that whenever two contributors' FirstTime differ by one interval -- the normal
+// outcome of a cross-node collect that straddles a segment boundary. The merged
+// timeline then runs one interval past a full day, so its first and last slot
+// carry the same wall-clock time. The newest slot wins and the oldest is dropped,
+// which is what keeps GetChildren and GetChild in agreement: every listed key
+// resolves, and resolves to the segment the reader saw described.
+func segmentOwners(firstTime time.Time, step time.Duration, count int) map[string]int {
+	owners := make(map[string]int, count)
+	for i := range count {
+		owners[segmentKey(firstTime.Add(time.Duration(i)*step))] = i
+	}
+	return owners
+}
+
+// segmentSecOwners is segmentOwners for a window whose interval is in seconds.
+func segmentSecOwners(firstTime time.Time, interval, count int) map[string]int {
+	return segmentOwners(firstTime, time.Duration(interval)*time.Second, count)
+}
+
+// segmentTimeOwners is segmentOwners for a timeline given as explicit instants
+// rather than a regular grid -- a union of several windows, whose slots need not be
+// evenly spaced. The latest instant owns a key two slots share.
+func segmentTimeOwners(times []time.Time) map[string]int {
+	owners := make(map[string]int, len(times))
+	for i, t := range times {
+		key := segmentKey(t)
+		if j, ok := owners[key]; ok && times[j].After(t) {
+			continue
+		}
+		owners[key] = i
+	}
+	return owners
+}
+
+// segmentAbs is an absolute instant for a label: month, day and UTC wall clock.
+// The date is part of it because a window reaches back across midnight, and it is
+// UTC rather than local so a label can be matched against the navigation key it
+// describes.
+func segmentAbs(t time.Time) string {
+	return t.UTC().Format("Jan 2, 15:04Z")
+}
+
+// segmentLocal is the same instant in the reader's zone, for a description to
+// carry alongside the UTC form. No date: it sits next to an absolute UTC label
+// that already has one, and its job is only to answer "when was that for me".
+func segmentLocal(t time.Time) string {
+	return t.Local().Format("15:04 MST")
+}
+
+// segmentDescTime is a segment's start for a description: the reader's local clock
+// only, because the row's own key already carries the UTC form and repeating it
+// wastes the width the statistics need. No end time either -- every segment in a
+// window is the same fixed size, stated once by the Coverage row.
+//
+// The date appears only when the window straddles midnight, which is the only time
+// a bare wall clock is ambiguous; an hour view therefore never carries one.
+func segmentDescTime(start time.Time, withDate bool) string {
+	if withDate {
+		return start.Local().Format("Jan 2, 15:04 MST")
+	}
+	return start.Local().Format("15:04 MST")
+}
+
+// windowCrossesDay reports whether a window spans more than one local day, so its
+// segment descriptions need a date to stay unambiguous.
+func windowCrossesDay(first time.Time, interval, count int) bool {
+	if count <= 1 {
+		return false
+	}
+	return first.Local().YearDay() != segmentStart(first, interval, count-1).Local().YearDay()
+}
+
+// segmentRowKey is a leaf-data key for one segment row: the numeric prefix carries
+// the ordering and uniqueness, the rest is the segment's UTC start.
+//
+// Deliberately short. This is the narrow column of a two-column table, so a full
+// span with a date wraps onto a second line and squeezes the value. The date and
+// the span are already stated once by the Coverage row, and the interval is
+// constant within a window, so the start alone locates the row -- in UTC, to match
+// what an operator greps out of a log.
+func segmentRowKey(idx int, start, _ time.Time) string {
+	return fmt.Sprintf("%02d: %s", idx, start.UTC().Format("15:04Z"))
+}
+
+// windowCoverage states how much time a window or a segment covers and the instant
+// it ends. A coverage duration plus one absolute end rather than a start-to-end
+// pair: a whole-window entry is as wide as every slot it holds, which two bare
+// wall-clock times would render as the zero-length range "13:45Z -> 13:45Z".
+func windowCoverage(start time.Time, seconds int) string {
+	d := time.Duration(seconds) * time.Second
+	end := start.Add(d)
+	return fmt.Sprintf("Covering %s, until %s (%s).",
+		coverDuration(d), segmentAbs(end), segmentLocal(end))
+}
+
+// coverDuration renders a span the way an operator states one: "23h45m", not
+// "23h45m0s".
+func coverDuration(d time.Duration) string {
+	d = d.Round(time.Minute)
+	h, m := int(d/time.Hour), int(d/time.Minute)%60
+	switch {
+	case h > 0 && m > 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	case h > 0:
+		return strconv.Itoa(h) + "h"
+	}
+	return strconv.Itoa(m) + "m"
+}
+
+// windowStatus explains a window that has nothing to place on a timeline, or ""
+// when it has segments and the caller should render them.
+//
+// The two states are kept apart because they are opposite answers: a nil window
+// was never asked for, while an empty one was asked for and is still filling. A
+// window that does hold segments is measured data, so its zeros are real and are
+// rendered as such.
+func windowStatus[T any, PT segPtr[T]](w *madmin.Segmented[T, PT], window string) string {
+	switch {
+	case w == nil:
+		return "not collected: last-" + window + " stats were not requested"
+	case w.Interval <= 0 || len(w.Segments) == 0:
+		return "no data yet: the last-" + window + " window holds no completed segment"
+	}
+	return ""
+}
+
+// windowSummaryState is windowStatus for a one-line summary, so that a window
+// which was never requested is never totaled into a measured zero.
+func windowSummaryState[T any, PT segPtr[T]](w *madmin.Segmented[T, PT]) string {
+	switch {
+	case w == nil:
+		return "not collected"
+	case len(w.Segments) == 0:
+		return "no data yet"
+	}
+	return ""
+}
+
+// formatTimedAction renders one timing on a single line. The mean is derived
+// here; the wire carries only the count and the summed duration.
+func formatTimedAction(a madmin.TimedAction) string {
+	if a.Count == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("%d, avg %s, max %s", a.Count,
+		durationOf(a.AccTime, a.Count),
+		time.Duration(a.MaxTime).Round(time.Microsecond))
+}
+
+// formatNodeCount renders how many nodes contributed to a value.
+//
+// A segment's N is one sample per node, so it is a node count only for a single
+// segment. Every value merged from more than one -- a whole-window _ALL entry,
+// most of all -- carries one sample per node per segment, and reading that raw
+// reports a five-node cluster as 300. Dividing by the number of segments merged
+// is what turns it back into a node count.
+//
+// A fractional result is real rather than a rounding artifact: a node that joined
+// or left mid-window contributed to only some of the segments. It is shown as an
+// average instead of being hidden.
+func formatNodeCount(n, segments int) string {
+	if segments <= 1 {
+		return fmt.Sprintf("%d node(s)", n)
+	}
+	avg := float64(n) / float64(segments)
+	if avg == math.Trunc(avg) {
+		return fmt.Sprintf("%d node(s)", int(avg))
+	}
+	return fmt.Sprintf("%.1f node(s) avg", avg)
+}

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// dupFirstTime is the start of a 97-slot quarter-hour timeline, so slot 0 and slot
+// 96 are both named 10:00Z.
+var dupFirstTime = time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+const dupKey = "10:00Z"
+
+// The newest instant owns a shared key even when the slots arrive out of order.
+func TestSegmentTimeOwners(t *testing.T) {
+	times := []time.Time{
+		dupFirstTime.Add(24 * time.Hour), // 10:00Z, one day on
+		dupFirstTime.Add(15 * time.Minute),
+		dupFirstTime, // 10:00Z
+	}
+	owners := segmentTimeOwners(times)
+	if got, want := len(owners), 2; got != want {
+		t.Fatalf("owners = %v, want %d distinct keys", owners, want)
+	}
+	if got, want := owners[dupKey], 0; got != want {
+		t.Errorf("owner of %s = %d, want slot %d (the newest instant)", dupKey, got, want)
+	}
+}
+
+// dupWindow is a day window whose first and last slot collide on one key, carrying
+// old in the oldest slot and new in the newest.
+func dupWindow[T any, PT segPtr[T]](old, recent T) madmin.Segmented[T, PT] {
+	segments := make([]T, 97)
+	segments[0] = old
+	segments[96] = recent
+	return madmin.Segmented[T, PT]{Interval: 900, FirstTime: dupFirstTime, Segments: segments}
+}
+
+// A key is a bare wall-clock time, so a window that reaches 24 hours -- what
+// Segmented.Add yields when two contributors' FirstTime differ by one interval --
+// has two slots wanting one name. Every family sharing the key format must list it
+// once and resolve it to the newest slot.
+func TestDuplicateSegmentKeysAcrossFamilies(t *testing.T) {
+	rpcDay := dupWindow[madmin.RPCStats, *madmin.RPCStats](
+		madmin.RPCStats{Requests: 7, RequestTimeSecs: 0.7},
+		madmin.RPCStats{Requests: 11, RequestTimeSecs: 1.1},
+	)
+	replDay := dupWindow[madmin.ReplicationStats, *madmin.ReplicationStats](
+		madmin.ReplicationStats{Nodes: 1, Events: 7},
+		madmin.ReplicationStats{Nodes: 1, Events: 11},
+	)
+	tableReads := make([]int64, 97)
+	tableReads[0], tableReads[96] = 7, 11
+
+	for _, tt := range []struct {
+		name string
+		node MetricNode
+		// dup is the key both slots want, "" for the start-of-segment default.
+		dup  string
+		key  string
+		want string
+	}{
+		{
+			name: "tables",
+			node: &tableSegmentedNode{
+				seg: &madmin.SegmentedTableIO{
+					IntervalSecs: 900, FirstTime: dupFirstTime, Reads: tableReads,
+				},
+				windowSecs: 86400, flag: madmin.MetricsDayStats,
+			},
+			key: "Reads", want: "11",
+		},
+		{
+			name: "rpc handler",
+			node: &RPCLastDayHandlerNode{handlerName: "storage.ReadAll", segmented: rpcDay},
+			key:  "Total Requests", want: "11",
+		},
+		{
+			name: "rpc all handlers",
+			node: &RPCLastDayAllNode{rpc: &madmin.RPCMetrics{
+				LastDay: map[string]madmin.SegmentedRPCMetrics{"storage.ReadAll": rpcDay},
+			}},
+			key: "Total Requests", want: "11",
+		},
+		{
+			name: "replication target",
+			node: NewReplicationLastDayNode("arn:target", &replDay, nil, "replication/target/last_day"),
+			key:  "Total Events", want: "11",
+		},
+		{
+			name: "replication aggregated",
+			node: NewReplicationLastDayAggregatedNode(&madmin.ReplicationMetrics{
+				Nodes:   1,
+				Targets: map[string]madmin.ReplicationTargetStats{"arn:target": {Nodes: 1, LastDay: &replDay}},
+			}, nil, "replication/last_day"),
+			key: "Total Events", want: "11",
+		},
+		{
+			name: "healing",
+			node: func() MetricNode {
+				w := dupWindow[madmin.HealingCounts, *madmin.HealingCounts](
+					madmin.HealingCounts{Started: 7}, madmin.HealingCounts{Started: 11},
+				)
+				return NewHealingLastDayNode(&w, nil, "healing/last_day")
+			}(),
+			key: "Started", want: "11",
+		},
+		{
+			// Named by the instant a segment ends, so its keys sit one interval on.
+			name: "process",
+			node: func() MetricNode {
+				w := dupWindow[madmin.ProcessSegment, *madmin.ProcessSegment](
+					madmin.ProcessSegment{N: 1, CPUPercent: 7}, madmin.ProcessSegment{N: 1, CPUPercent: 11},
+				)
+				return NewProcessLastDayNode(&w, nil, "process/last_day")
+			}(),
+			dup: "10:15Z", key: "CPU Usage", want: "11.00% average",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dup := tt.dup
+			if dup == "" {
+				dup = dupKey
+			}
+			names := childNames(tt.node.GetChildren())
+			seen := map[string]int{}
+			for _, name := range names {
+				seen[name]++
+				if _, err := tt.node.GetChild(name); err != nil {
+					t.Errorf("GetChild(%q) = %v, want a node: everything listed must resolve", name, err)
+				}
+			}
+			for name, n := range seen {
+				if n != 1 {
+					t.Errorf("child %q listed %d times in %v, want exactly once", name, n, names)
+				}
+			}
+			if seen[dup] == 0 {
+				t.Fatalf("children = %v, want the shared key %s among them", names, dup)
+			}
+
+			child, err := tt.node.GetChild(dup)
+			if err != nil {
+				t.Fatalf("GetChild(%q): %v", dup, err)
+			}
+			if got := leafValue(child.GetLeafData(), tt.key); got != tt.want {
+				t.Errorf("%s = %q, want %q from the newest slot", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// A row key is a UTC start and nothing else. It is what an operator greps a log
+// with, so it must not drift with the reader's zone, and it must not carry an end
+// time: every segment in a window is the same fixed size, stated once by the
+// Coverage row, and a full span wraps the narrow column and squeezes the value.
+//
+// Families used to format this themselves, and cpu keyed the reader's local clock
+// while its siblings keyed UTC -- the same instant under two names, and ambiguous
+// across a DST fold.
+func TestSegmentRowKeyIsUTCStartOnly(t *testing.T) {
+	// 00:30 UTC, which is a different day in the reader's zone if that zone is far
+	// enough east, so a key built from local time cannot coincidentally match.
+	start := time.Date(2026, 8, 12, 0, 30, 0, 0, time.UTC)
+	end := start.Add(15 * time.Minute)
+
+	for _, tz := range []string{"UTC", "Australia/Sydney", "America/Los_Angeles"} {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			t.Skipf("zone %s unavailable: %v", tz, err)
+		}
+		t.Run(tz, func(t *testing.T) {
+			// segmentRowKey must read the instant, not the zone it is carried in.
+			got := segmentRowKey(3, start.In(loc), end.In(loc))
+			if want := "03: 00:30Z"; got != want {
+				t.Errorf("segmentRowKey = %q, want %q", got, want)
+			}
+		})
+	}
+
+	// The key and the navigation name must name the same instant, or a row cannot be
+	// matched to the child that drills into it.
+	if key, name := segmentRowKey(0, start, end), segmentKey(start); !strings.HasSuffix(key, name) {
+		t.Errorf("row key %q does not end in the navigation name %q", key, name)
+	}
+}
+
+// The helper above is only worth as much as the families using it, so this checks
+// a real one end to end. CPU is the family that used to format its own key from
+// the reader's local clock.
+func TestCPUWindowRowKeyIsUTC(t *testing.T) {
+	loc, err := time.LoadLocation("Australia/Sydney")
+	if err != nil {
+		t.Skipf("zone unavailable: %v", err)
+	}
+	start := time.Date(2026, 8, 12, 0, 30, 0, 0, time.UTC)
+
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{CPU: &madmin.CPUMetrics{
+			LastHour: &madmin.SegmentedCPUMetrics{
+				Interval:  60,
+				FirstTime: start.In(loc),
+				Segments:  []madmin.CPUSegment{{N: 1, User: 10, System: 5, Idle: 85}},
+			},
+		}},
+	})
+	node, err := nav.Navigate("cpu/last_hour")
+	if err != nil {
+		t.Fatalf("navigate cpu/last_hour: %v", err)
+	}
+	data := node.GetLeafData()
+	var found bool
+	for key := range data {
+		if !strings.Contains(key, ":") || !strings.Contains(key, "0:30") && !strings.Contains(key, "10:30") {
+			continue
+		}
+		found = true
+		if !strings.HasSuffix(key, "00:30Z") {
+			t.Errorf("row key %q, want it to end in the UTC start 00:30Z: a local-clock "+
+				"key names the same instant differently for every reader", key)
+		}
+	}
+	if !found {
+		t.Errorf("no segment row found in %v", data)
+	}
+}
+
+// A segment's N is one sample per node, so an _ALL entry -- which sums every
+// segment in the window -- carries one per node per segment. Rendering that raw
+// reported a 5-node cluster over a 60-segment hour as "312 node sample(s)", which
+// reads as a node count and is off by the segment count.
+func TestFormatNodeCountDividesByMergeCount(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		n        int
+		segments int
+		want     string
+	}{
+		{"single segment", 5, 1, "5 node(s)"},
+		// The reported case: 60 one-minute segments, 5 nodes throughout.
+		{"whole hour, stable cluster", 300, 60, "5 node(s)"},
+		// A node that joined or left mid-window contributed to only some segments, so
+		// the average is fractional and that is real information, not noise.
+		{"whole hour, node joined midway", 312, 60, "5.2 node(s) avg"},
+		// Defensive: a merge count of zero must not divide by zero.
+		{"unknown merge count", 7, 0, "7 node(s)"},
+	} {
+		if got := formatNodeCount(tc.n, tc.segments); got != tc.want {
+			t.Errorf("%s: formatNodeCount(%d, %d) = %q, want %q",
+				tc.name, tc.n, tc.segments, got, tc.want)
+		}
+	}
+}
+
+// The same invariant end to end: an _ALL leaf must report the node count, not the
+// node count times the number of segments it summed.
+func TestWindowAllLeafReportsNodeCount(t *testing.T) {
+	const nodes, segments = 5, 12
+	segs := make([]madmin.LockSegment, segments)
+	for i := range segs {
+		segs[i] = madmin.LockSegment{N: nodes, AcquireCount: 10, AcquireNanos: 1_000_000}
+	}
+	nav := lockNav(t, &madmin.LockMetrics{
+		LastHour: &madmin.SegmentedLockMetrics{
+			Interval: 60, FirstTime: lockFirstTime, Segments: segs,
+		},
+	})
+	all, err := nav.Navigate("locks/last_hour/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	d := all.GetLeafData()
+	if got, want := leafValue(d, "Nodes"), "5 node(s)"; got != want {
+		t.Errorf("Nodes = %q, want %q: summing N over %d segments gives %d",
+			got, want, segments, nodes*segments)
+	}
+	// The counters really are cross-segment sums, so those must NOT be divided.
+	if got, want := leafValue(d, "Acquires"), "120"; got != want {
+		t.Errorf("Acquires = %q, want %q: a counter still sums over the window", got, want)
+	}
+}
+
+// Microsecond precision is what a sub-second latency needs and pure noise on a
+// figure of minutes, which is how a mean failed-wait rendered as
+// "13m19.506473s".
+func TestDurationOfScalesPrecision(t *testing.T) {
+	for _, tc := range []struct {
+		acc, count uint64
+		want       string
+	}{
+		{0, 0, "n/a"},
+		{583_000, 1, "583µs"},
+		{20_599_000, 1, "20.599ms"},
+		// A second or more keeps milliseconds, not microseconds.
+		{1_131_456_789, 1, "1.131s"},
+		// A minute or more keeps whole seconds: this is the reported case, which used
+		// to render as "13m19.506473s".
+		{799_506_473_000, 1, "13m20s"},
+		// Still an average, so the division happens first.
+		{799_506_473_000 * 4, 4, "13m20s"},
+	} {
+		if got := durationOf(tc.acc, tc.count); got != tc.want {
+			t.Errorf("durationOf(%d, %d) = %q, want %q", tc.acc, tc.count, got, tc.want)
+		}
+	}
+}

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -231,7 +231,9 @@ func TestCPUWindowRowKeyIsUTC(t *testing.T) {
 	data := node.GetLeafData()
 	var found bool
 	for key := range data {
-		if !strings.Contains(key, ":") || !strings.Contains(key, "0:30") && !strings.Contains(key, "10:30") {
+		// Matches the row whatever zone it was rendered in: 00:30Z is 10:30 in
+		// Sydney and 02:30 in Berlin, and every one of those ends in "0:30".
+		if !strings.Contains(key, "0:30") {
 			continue
 		}
 		found = true
@@ -321,6 +323,28 @@ func TestDurationOfScalesPrecision(t *testing.T) {
 	} {
 		if got := durationOf(tc.acc, tc.count); got != tc.want {
 			t.Errorf("durationOf(%d, %d) = %q, want %q", tc.acc, tc.count, got, tc.want)
+		}
+	}
+}
+
+// A span below a minute must not render as "0m": coverDuration is generic, and a
+// window with a short interval would have reported its coverage as zero.
+func TestCoverDurationSubMinute(t *testing.T) {
+	for _, tc := range []struct {
+		secs int
+		want string
+	}{
+		{1, "1s"},
+		{15, "15s"},
+		{59, "59s"},
+		{60, "1m"},
+		{90, "2m"},
+		{900, "15m"},
+		{3600, "1h"},
+		{86400 - 900, "23h45m"},
+	} {
+		if got := coverDuration(time.Duration(tc.secs) * time.Second); got != tc.want {
+			t.Errorf("coverDuration(%ds) = %q, want %q", tc.secs, got, tc.want)
 		}
 	}
 }

--- a/mnav/tables.go
+++ b/mnav/tables.go
@@ -240,19 +240,24 @@ func (node *tableSegmentedNode) GetChildren() []MetricChild {
 		return []MetricChild{}
 	}
 	interval := time.Duration(node.seg.IntervalSecs) * time.Second
+	owners := segmentOwners(node.seg.FirstTime, interval, len(stats))
 	var children []MetricChild
 	for i := len(stats) - 1; i >= 0; i-- {
 		if stats[i].IsZero() {
 			continue
 		}
 		t := node.seg.FirstTime.Add(time.Duration(i) * interval)
+		name := segmentKey(t)
+		if owners[name] != i {
+			continue
+		}
 		end := t.Add(interval)
 		day := ""
 		if !sameLocalDay(t, time.Now()) {
 			day = "Yesterday "
 		}
 		children = append(children, MetricChild{
-			Name: t.UTC().Format("15:04Z"),
+			Name: name,
 			Description: fmt.Sprintf("%s%s -> %s, %s", day,
 				t.Local().Format("15:04"), end.Local().Format("15:04"),
 				describeTableAPIStat(&stats[i], float64(node.seg.IntervalSecs))),
@@ -282,14 +287,11 @@ func (node *tableSegmentedNode) GetChild(name string) (MetricNode, error) {
 	}
 	stats := node.seg.AsTableIOStat()
 	interval := time.Duration(node.seg.IntervalSecs) * time.Second
-	for i := range stats {
-		t := node.seg.FirstTime.Add(time.Duration(i) * interval)
-		if t.UTC().Format("15:04Z") == name {
-			return &tableSegmentEntryNode{
-				stat: stats[i], windowSecs: float64(node.seg.IntervalSecs),
-				flag: node.flag, parent: node, path: node.path + "/" + name,
-			}, nil
-		}
+	if i, ok := segmentOwners(node.seg.FirstTime, interval, len(stats))[name]; ok {
+		return &tableSegmentEntryNode{
+			stat: stats[i], windowSecs: float64(node.seg.IntervalSecs),
+			flag: node.flag, parent: node, path: node.path + "/" + name,
+		}, nil
 	}
 	return nil, fmt.Errorf("segment not found: %s", name)
 }

--- a/mnav/targets.go
+++ b/mnav/targets.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v4"
+	"github.com/minio/minio-go/v7/pkg/set"
 )
 
 // TargetMetricsNode is the navigation node for asynchronous delivery targets:
@@ -41,21 +42,34 @@ func NewTargetMetricsNode(targets *madmin.DeliveryTargetMetrics, parent MetricNo
 	return &TargetMetricsNode{targets: targets, parent: parent, path: path}
 }
 
-func (node *TargetMetricsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *TargetMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *TargetMetricsNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *TargetMetricsNode) GetMetricType() madmin.MetricType { return madmin.MetricsTargets }
+
+// GetMetricFlags requests no historic window: this node refreshes continuously,
+// and asking for them here would pull 60+96 segments per target on every tick to
+// render a few summary lines. They are fetched on navigating into one.
 func (node *TargetMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
 func (node *TargetMetricsNode) GetParent() MetricNode              { return node.parent }
 func (node *TargetMetricsNode) GetPath() string                    { return node.path }
 func (node *TargetMetricsNode) ShouldPauseRefresh() bool           { return false }
 
-// GetChildren lists one child per configured target. The child name is the wire
-// key, since a target name is only unique within its config subsystem.
+// GetChildren lists the segmented windows, then one child per configured target.
+// The target child name is the wire key, since a target name is only unique within
+// its config subsystem. The windows are listed unconditionally: their nodes explain
+// a window that is missing or empty, so they are always constructible.
 func (node *TargetMetricsNode) GetChildren() []MetricChild {
 	if node.targets == nil {
 		return []MetricChild{}
 	}
 	t := node.targets
-	children := make([]MetricChild, 0, len(t.Notification)+len(t.Audit)+len(t.Logs))
+	children := make([]MetricChild, 0, 4+len(t.Notification)+len(t.Audit)+len(t.Logs))
+	children = append(children,
+		MetricChild{Name: "last_hour", Description: "Delivery flow per target over the last hour, by time segment"},
+		MetricChild{Name: "last_day", Description: "Delivery flow per target over the last day, by time segment"},
+		MetricChild{Name: "log_volume_last_hour", Description: "Log lines emitted by severity over the last hour, by time segment"},
+		MetricChild{Name: "log_volume_last_day", Description: "Log lines emitted by severity over the last day, by time segment"},
+	)
+	listed := set.NewStringSet()
 	for _, class := range []struct {
 		kind string
 		m    map[string]madmin.TargetMetrics
@@ -65,6 +79,14 @@ func (node *TargetMetricsNode) GetChildren() []MetricChild {
 		{"system log", t.Logs},
 	} {
 		for _, key := range sortedKeys(class.m) {
+			// The server's key is unique across the three classes, but the types do
+			// not enforce it, so first wins, in the order GetChild already resolves.
+			// Listing a key twice would give the reader two entries that both open
+			// the same node.
+			if listed.Contains(key) {
+				continue
+			}
+			listed.Add(key)
 			tm := class.m[key]
 			children = append(children, MetricChild{
 				Name:        key,
@@ -80,6 +102,32 @@ func (node *TargetMetricsNode) GetChild(name string) (MetricNode, error) {
 		return nil, fmt.Errorf("no delivery target data available")
 	}
 	t := node.targets
+	// A target key is "<subsystem>:<name>", so it can never collide with these.
+	switch name {
+	case "last_hour", "last_day":
+		hour := name == "last_hour"
+		ops, class := targetWindowMap(t, hour)
+		window := "day"
+		flag := madmin.MetricsDayStats
+		if hour {
+			window, flag = "hour", madmin.MetricsHourStats
+		}
+		return &targetWindowsNode{
+			ops: ops, class: class, flag: flag, window: window,
+			configured: len(t.Notification) + len(t.Audit) + len(t.Logs),
+			parent:     node, path: fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
+	case "log_volume_last_hour":
+		return &logVolumeWindowNode{
+			seg: t.LogVolumeLastHour, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
+	case "log_volume_last_day":
+		return &logVolumeWindowNode{
+			seg: t.LogVolumeLastDay, flags: madmin.MetricsDayStats, window: "day",
+			parent: node, path: fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
+	}
 	for _, m := range []map[string]madmin.TargetMetrics{t.Notification, t.Audit, t.Logs} {
 		if tm, ok := m[name]; ok {
 			return NewTargetNode(tm, node, fmt.Sprintf("%s/%s", node.path, name)), nil
@@ -101,9 +149,15 @@ func (node *TargetMetricsNode) GetLeafData() map[string]string {
 		"System Log Targets":   strconv.Itoa(len(t.Logs)),
 	}
 
-	// Log volume works even with no target configured.
-	for _, level := range sortedKeys(t.LogVolume) {
-		data["Logged "+level] = strconv.FormatUint(t.LogVolume[level], 10)
+	// Log volume works even with no target configured. Summarized when the history
+	// happens to be loaded -- it is persisted to disk and restored on startup, and a
+	// child node may have fetched it -- but never requested from here, and never
+	// rendered as a zero when it is absent.
+	if w := t.LogVolumeLastHour; w != nil && len(w.Segments) > 0 {
+		data["Logged (last hour)"] = formatLogVolumeWindow(w)
+	}
+	if w := t.LogVolumeLastDay; w != nil && len(w.Segments) > 0 {
+		data["Logged (last day)"] = formatLogVolumeWindow(w)
 	}
 
 	if t.Spill != nil && (t.Spill.Bytes > 0 || t.Spill.Files > 0) {
@@ -111,14 +165,15 @@ func (node *TargetMetricsNode) GetLeafData() map[string]string {
 			humanize.IBytes(uint64(t.Spill.Bytes)), t.Spill.Files)
 	}
 
-	// The failure states an operator scans for.
-	var drops, queued, capacity uint64
+	// The failure states an operator scans for. Drops only exist in the windows, and
+	// each window is only populated when its flag was requested, so both are totaled
+	// and reported under their own label rather than added together.
+	var hourDrops, dayDrops, queued, capacity uint64
 	var degraded []string
 	for _, m := range []map[string]madmin.TargetMetrics{t.Notification, t.Audit, t.Logs} {
 		for key, tm := range m {
-			for _, n := range tm.Drops {
-				drops += n
-			}
+			hourDrops += droppedIn(tm.LastHour)
+			dayDrops += droppedIn(tm.LastDay)
 			queued += uint64(max(tm.QueueLength, 0))
 			capacity += uint64(max(tm.QueueCapacity, 0))
 			if tm.NodesOnline < tm.N {
@@ -130,14 +185,54 @@ func (node *TargetMetricsNode) GetLeafData() map[string]string {
 		data["Queue"] = fmt.Sprintf("%d of %d (%s)", queued, capacity,
 			calculatePercentage(queued, capacity))
 	}
-	if drops > 0 {
-		data["Dropped Events"] = strconv.FormatUint(drops, 10)
+	if hourDrops > 0 {
+		data["Dropped Events (last hour)"] = strconv.FormatUint(hourDrops, 10)
+	}
+	if dayDrops > 0 {
+		data["Dropped Events (last day)"] = strconv.FormatUint(dayDrops, 10)
 	}
 	if len(degraded) > 0 {
 		sort.Strings(degraded)
 		data["Not Online Everywhere"] = strings.Join(degraded, ", ")
 	}
 	return data
+}
+
+// formatLogVolumeWindow totals a segmented log-volume window into one line.
+// Errors and warnings are named even at zero, because "0 errors in the last hour"
+// is the reassurance an operator is after; the quieter severities appear only when
+// something was logged at them.
+func formatLogVolumeWindow(w *madmin.SegmentedLogVolume) string {
+	if state := windowSummaryState(w); state != "" {
+		return state
+	}
+	t := w.Total()
+	out := fmt.Sprintf("%d errors, %d warnings", t.ErrorLines, t.WarningLines)
+	for _, rest := range []struct {
+		label string
+		n     uint64
+	}{
+		{"fatal", t.FatalLines},
+		{"info", t.InfoLines},
+		{"events", t.EventLines},
+	} {
+		if rest.n > 0 {
+			out += fmt.Sprintf(", %d %s", rest.n, rest.label)
+		}
+	}
+	return out
+}
+
+// droppedIn totals the events a window discarded, for any reason. A window that
+// was not requested is nil and totals to zero.
+func droppedIn(w *madmin.SegmentedTargetMetrics) uint64 {
+	return droppedInSegment(w.Total())
+}
+
+// droppedInSegment totals the events one segment discarded. The four reasons sum
+// to it, so the wire carries no total.
+func droppedInSegment(s madmin.TargetSegment) uint64 {
+	return s.DroppedQueueFull + s.DroppedRetriesExhausted + s.DroppedShutdown + s.DroppedOther
 }
 
 // TargetNode is one delivery target.
@@ -152,15 +247,43 @@ func NewTargetNode(target madmin.TargetMetrics, parent MetricNode, path string) 
 	return &TargetNode{target: target, parent: parent, path: path}
 }
 
-func (node *TargetNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *TargetNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *TargetNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *TargetNode) GetMetricType() madmin.MetricType { return madmin.MetricsTargets }
+
+// GetMetricFlags requests no historic window, for the reason on
+// TargetMetricsNode.GetMetricFlags: this node refreshes continuously, so its
+// windows are fetched on entering one of them.
 func (node *TargetNode) GetMetricFlags() madmin.MetricFlags { return 0 }
 func (node *TargetNode) GetParent() MetricNode              { return node.parent }
 func (node *TargetNode) GetPath() string                    { return node.path }
 func (node *TargetNode) ShouldPauseRefresh() bool           { return false }
-func (node *TargetNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+// GetChildren lists this target's own windows, which is where an operator sees
+// whether a day's drops were one burst or a steady trickle.
+func (node *TargetNode) GetChildren() []MetricChild {
+	return []MetricChild{
+		{Name: "last_hour", Description: "This target's delivery flow over the last hour, by time segment"},
+		{Name: "last_day", Description: "This target's delivery flow over the last day, by time segment"},
+	}
+}
 
 func (node *TargetNode) GetChild(name string) (MetricNode, error) {
+	key := node.target.Name
+	if node.target.Subsystem != "" {
+		key = node.target.Subsystem + ":" + key
+	}
+	switch name {
+	case "last_hour":
+		return &targetWindowNode{
+			seg: node.target.LastHour, key: key, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/last_hour", node.path),
+		}, nil
+	case "last_day":
+		return &targetWindowNode{
+			seg: node.target.LastDay, key: key, flags: madmin.MetricsDayStats, window: "day",
+			parent: node, path: fmt.Sprintf("%s/last_day", node.path),
+		}, nil
+	}
 	return nil, fmt.Errorf("child not found: %s", name)
 }
 
@@ -180,27 +303,14 @@ func (node *TargetNode) GetLeafData() map[string]string {
 		data["Checking"] = fmt.Sprintf("%d node(s)", t.NodesChecking)
 	}
 
-	data["Events"] = strconv.FormatUint(t.TotalEvents, 10)
-	// Count is requests, not events; the ratio is the batch factor.
-	if t.TotalRequests > 0 {
-		data["Requests"] = fmt.Sprintf("%d (%.1f events each)", t.TotalRequests,
-			float64(t.TotalEvents)/float64(t.TotalRequests))
+	// Flow only exists in the windows, so they are where events, requests, failures
+	// and drops are reported. Summarized here when the history happens to be loaded,
+	// never requested from here, and never rendered as a zero when it is absent.
+	if w := t.LastHour; w != nil && len(w.Segments) > 0 {
+		data["Last Hour"] = formatTargetWindow(w)
 	}
-	if t.FailedRequests > 0 {
-		data["Failed Requests"] = strconv.FormatUint(t.FailedRequests, 10)
-	}
-	if t.WriterErrors > 0 {
-		data["Writer Errors"] = strconv.FormatUint(t.WriterErrors, 10)
-	}
-
-	// The reasons sum to the total, so both can be shown.
-	var drops uint64
-	for _, reason := range sortedKeys(t.Drops) {
-		data["Dropped ("+reason+")"] = strconv.FormatUint(t.Drops[reason], 10)
-		drops += t.Drops[reason]
-	}
-	if drops > 0 {
-		data["Dropped"] = strconv.FormatUint(drops, 10)
+	if w := t.LastDay; w != nil && len(w.Segments) > 0 {
+		data["Last Day"] = formatTargetWindow(w)
 	}
 
 	if t.QueueCapacity > 0 {
@@ -231,6 +341,647 @@ func (node *TargetNode) GetLeafData() map[string]string {
 		if !t.LastErrorTime.IsZero() {
 			data["Last Error At"] = t.LastErrorTime.Format("2006-01-02 15:04:05")
 		}
+	}
+	return data
+}
+
+// formatTargetWindow totals a segmented window into one line. Failures and drop
+// reasons are named only when they happened, so a healthy target reads as healthy
+// rather than as a wall of zeros.
+func formatTargetWindow(w *madmin.SegmentedTargetMetrics) string {
+	if state := windowSummaryState(w); state != "" {
+		return state
+	}
+	t := w.Total()
+	out := strconv.FormatUint(t.Events, 10) + " events"
+	// Count is requests, not events; the ratio is the batch factor.
+	if t.Requests > 0 {
+		out += fmt.Sprintf(", %d reqs (%.1f ea, avg %s)", t.Requests,
+			float64(t.Events)/float64(t.Requests),
+			durationOf(t.RequestNanos, t.Requests))
+	}
+	for _, rare := range []struct {
+		label string
+		n     uint64
+	}{
+		{"failed", t.WriterErrors},
+		{"dropped (queue full)", t.DroppedQueueFull},
+		{"dropped (retries exhausted)", t.DroppedRetriesExhausted},
+		{"dropped (shutdown)", t.DroppedShutdown},
+		{"dropped (other)", t.DroppedOther},
+	} {
+		if rare.n > 0 {
+			out += fmt.Sprintf(", %d %s", rare.n, rare.label)
+		}
+	}
+	return out
+}
+
+// targetWindowMap flattens every target's window of one resolution into the keyed
+// shape the time-first navigation wants, plus the class each key came from.
+//
+// One resolution per map: Segmented.Add bails out silently when intervals differ,
+// so an hour window dropped into a day map would contribute nothing and its target
+// would disappear from every segment list.
+func targetWindowMap(t *madmin.DeliveryTargetMetrics, hour bool) (
+	map[string]madmin.SegmentedTargetMetrics, map[string]string,
+) {
+	if t == nil {
+		return nil, nil
+	}
+	size := len(t.Notification) + len(t.Audit) + len(t.Logs)
+	ops := make(map[string]madmin.SegmentedTargetMetrics, size)
+	class := make(map[string]string, size)
+	for _, c := range []struct {
+		kind string
+		m    map[string]madmin.TargetMetrics
+	}{
+		{"notification", t.Notification},
+		{"audit log", t.Audit},
+		{"system log", t.Logs},
+	} {
+		for _, key := range sortedKeys(c.m) {
+			tm := c.m[key]
+			w := tm.LastDay
+			if hour {
+				w = tm.LastHour
+			}
+			// nil is a window whose flag was not requested, so the target has nothing
+			// to say at this resolution and is left out. A window that was requested
+			// is kept even with no completed segment, so it reads as still filling
+			// rather than as never asked for.
+			if w == nil {
+				continue
+			}
+			// The server's key is unique across the three classes, but the types do
+			// not enforce it, so first wins, in the order GetChild already resolves.
+			// Blending two unrelated targets into one series would be worse than
+			// hiding one.
+			if _, dup := ops[key]; dup {
+				continue
+			}
+			ops[key] = *w
+			class[key] = c.kind
+		}
+	}
+	return ops, class
+}
+
+// targetView adapts one resolution of the per-target windows to the generic
+// _by_time navigation: pick a time segment, then see every target active in it.
+func targetView(ops map[string]madmin.SegmentedTargetMetrics, class map[string]string,
+	flag madmin.MetricFlags,
+) segView[madmin.TargetSegment, *madmin.TargetSegment] {
+	return segView[madmin.TargetSegment, *madmin.TargetSegment]{
+		ops:         ops,
+		metricType:  madmin.MetricsTargets,
+		metricFlags: flag,
+		empty:       targetSegmentEmpty,
+		segDesc: func(total madmin.TargetSegment, interval int, segTime, _ time.Time) string {
+			// Only a day window can straddle midnight, so only it needs the date.
+			return segmentDescTime(segTime, flag == madmin.MetricsDayStats) + ", " +
+				describeTargetSegment(total, interval)
+		},
+		opDesc: func(key string, s madmin.TargetSegment, interval int) string {
+			return class[key] + ": " + describeTargetSegment(s, interval)
+		},
+		opLeaf: func(key string, s madmin.TargetSegment, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
+			return &targetSegmentLeafNode{
+				key: key, kind: class[key], seg: s, segTime: segTime,
+				interval: interval, merged: 1, flags: flag, parent: parent, path: path,
+			}
+		},
+		sumLeaf: func(s madmin.TargetSegment, segTime time.Time, interval, merged int, parent MetricNode, path string) MetricNode {
+			return &targetSegmentLeafNode{
+				key: "_ALL", seg: s, segTime: segTime,
+				interval: interval, merged: merged, flags: flag, parent: parent, path: path,
+			}
+		},
+	}
+}
+
+// targetSegmentEmpty reports a segment with nothing to show. N is not part of the
+// test: an idle target still reports itself in every slot, so testing it would
+// filter nothing and return a wall of zeros.
+func targetSegmentEmpty(s *madmin.TargetSegment) bool {
+	return s.Events == 0 && s.Requests == 0 && s.WriterErrors == 0 && droppedInSegment(*s) == 0
+}
+
+// targetWindowsNode groups one resolution of the per-target windows: browse by
+// time, by every target combined, or by one target's own series.
+type targetWindowsNode struct {
+	ops        map[string]madmin.SegmentedTargetMetrics
+	class      map[string]string
+	flag       madmin.MetricFlags
+	window     string
+	configured int
+	parent     MetricNode
+	path       string
+}
+
+func (node *targetWindowsNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *targetWindowsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *targetWindowsNode) GetMetricFlags() madmin.MetricFlags { return node.flag }
+func (node *targetWindowsNode) GetParent() MetricNode              { return node.parent }
+func (node *targetWindowsNode) GetPath() string                    { return node.path }
+func (node *targetWindowsNode) ShouldPauseRefresh() bool           { return true }
+
+func (node *targetWindowsNode) GetChildren() []MetricChild {
+	if len(node.ops) == 0 {
+		return []MetricChild{}
+	}
+	children := make([]MetricChild, 0, len(node.ops)+2)
+	children = append(children,
+		MetricChild{Name: byTimeName, Description: "Browse by time segment (all targets)"},
+		MetricChild{Name: "_ALL", Description: fmt.Sprintf("All %d target(s) combined", len(node.ops))},
+	)
+	for _, key := range sortedKeys(node.ops) {
+		w := node.ops[key]
+		children = append(children, MetricChild{
+			Name:        key,
+			Description: node.class[key] + ": " + formatTargetWindow(&w),
+		})
+	}
+	return children
+}
+
+// merged is every target's window on one timeline. It starts from a zero value so
+// the wire segments are never mutated in place.
+func (node *targetWindowsNode) merged() madmin.SegmentedTargetMetrics {
+	var merged madmin.SegmentedTargetMetrics
+	for _, key := range sortedKeys(node.ops) {
+		w := node.ops[key]
+		merged.Add(&w)
+	}
+	return merged
+}
+
+func (node *targetWindowsNode) GetChild(name string) (MetricNode, error) {
+	if name == byTimeName {
+		return newByTimeNode(targetView(node.ops, node.class, node.flag), node,
+			node.path+"/"+byTimeName), nil
+	}
+	if name == "_ALL" {
+		merged := node.merged()
+		return &targetWindowNode{
+			seg: &merged, key: "_ALL", flags: node.flag, window: node.window,
+			parent: node, path: node.path + "/_ALL",
+		}, nil
+	}
+	w, ok := node.ops[name]
+	if !ok {
+		return nil, fmt.Errorf("target not found: %s", name)
+	}
+	return &targetWindowNode{
+		seg: &w, key: name, kind: node.class[name], flags: node.flag, window: node.window,
+		parent: node, path: node.path + "/" + name,
+	}, nil
+}
+
+func (node *targetWindowsNode) GetLeafData() map[string]string {
+	if node.configured == 0 {
+		return map[string]string{"Status": "no delivery targets configured"}
+	}
+	if len(node.ops) == 0 {
+		return map[string]string{"Status": "not collected: last-" + node.window + " stats were not requested"}
+	}
+	data := map[string]string{}
+	for i, key := range sortedKeys(node.ops) {
+		w := node.ops[key]
+		data[fmt.Sprintf("%02d:%s", i, key)] = node.class[key] + ": " + formatTargetWindow(&w)
+	}
+	return data
+}
+
+// targetWindowNode is one target's persisted window -- the hour or the day -- as a
+// row per time segment plus one navigable child per segment, so a burst can be told
+// apart from a steady trickle.
+type targetWindowNode struct {
+	seg    *madmin.SegmentedTargetMetrics
+	key    string
+	kind   string
+	flags  madmin.MetricFlags
+	window string
+	parent MetricNode
+	path   string
+}
+
+func (node *targetWindowNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *targetWindowNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *targetWindowNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *targetWindowNode) GetParent() MetricNode              { return node.parent }
+func (node *targetWindowNode) GetPath() string                    { return node.path }
+func (node *targetWindowNode) ShouldPauseRefresh() bool           { return true }
+
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *targetWindowNode) hasSegments() bool {
+	return node.seg != nil && node.seg.Interval > 0 && len(node.seg.Segments) > 0
+}
+
+// wholeSecs is the span the whole window covers: one segment as wide as every
+// slot it holds, so an _ALL rate reads as the window average.
+func (node *targetWindowNode) wholeSecs() int {
+	return node.seg.Interval * len(node.seg.Segments)
+}
+
+func (node *targetWindowNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
+	}
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	withDate := windowCrossesDay(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if targetSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeTargetSegment(s, node.seg.Interval),
+		})
+	}
+	return children
+}
+
+func (node *targetWindowNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s segments available", node.window)
+	}
+	leaf := func(s madmin.TargetSegment, segTime time.Time, interval, merged int) MetricNode {
+		return &targetSegmentLeafNode{
+			key: node.key, kind: node.kind, seg: s, segTime: segTime, interval: interval,
+			merged: merged, flags: node.flags, parent: node, path: node.path + "/" + name,
+		}
+	}
+	if name == "_ALL" {
+		return leaf(node.seg.Total(), node.seg.FirstTime, node.wholeSecs(), len(node.seg.Segments)), nil
+	}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	if i, ok := owners[name]; ok {
+		return leaf(node.seg.Segments[i], segmentStart(node.seg.FirstTime, node.seg.Interval, i), node.seg.Interval, 1), nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *targetWindowNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.seg, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	data := map[string]string{
+		"00:Total (last " + node.window + ")": formatTargetWindow(node.seg),
+		"01:Coverage":                         windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}
+	idx := 2
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if targetSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		end := start.Add(time.Duration(node.seg.Interval) * time.Second)
+		data[segmentRowKey(idx, start, end)] = describeTargetSegment(s, node.seg.Interval)
+		idx++
+	}
+	// The totals above are measured zeros, so they stay; only the reason there is
+	// no segment row is added.
+	if idx == 2 {
+		data["02:Segments"] = fmt.Sprintf("no delivery recorded in any of the %d segment(s) measured",
+			len(node.seg.Segments))
+	}
+	return data
+}
+
+// describeTargetSegment renders one delivery segment on a single line. The batch
+// factor and the mean latency are derived here; the wire carries only sums.
+func describeTargetSegment(s madmin.TargetSegment, interval int) string {
+	out := strconv.FormatUint(s.Events, 10) + " events"
+	if interval > 0 {
+		out += fmt.Sprintf(" (%.1f/s)", float64(s.Events)/float64(interval))
+	}
+	if s.Requests > 0 {
+		out += fmt.Sprintf(", %d reqs (%.1f ea, avg %s)", s.Requests,
+			float64(s.Events)/float64(s.Requests), durationOf(s.RequestNanos, s.Requests))
+	}
+	if s.WriterErrors > 0 {
+		out += fmt.Sprintf(", %d failed", s.WriterErrors)
+	}
+	if dropped := droppedInSegment(s); dropped > 0 {
+		out += fmt.Sprintf(", %d dropped", dropped)
+	}
+	return out
+}
+
+// targetSegmentLeafNode is one target within one time segment, or a cross-target
+// summary (key == "_ALL").
+type targetSegmentLeafNode struct {
+	key      string
+	kind     string
+	seg      madmin.TargetSegment
+	segTime  time.Time
+	interval int
+	// merged is how many segment values were summed into seg, so N can be divided
+	// back into a node count: one per segment for a whole window, one per target for
+	// a cross-target summary.
+	merged int
+	flags  madmin.MetricFlags
+	parent MetricNode
+	path   string
+}
+
+func (node *targetSegmentLeafNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *targetSegmentLeafNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *targetSegmentLeafNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *targetSegmentLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *targetSegmentLeafNode) GetPath() string                    { return node.path }
+func (node *targetSegmentLeafNode) ShouldPauseRefresh() bool           { return true }
+func (node *targetSegmentLeafNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *targetSegmentLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *targetSegmentLeafNode) GetLeafData() map[string]string {
+	s := node.seg
+	if targetSegmentEmpty(&s) {
+		return map[string]string{"Status": "no delivery activity in this time segment"}
+	}
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.key != "" && node.key != "_ALL" {
+		add("Target", node.key)
+	}
+	if node.kind != "" {
+		add("Class", node.kind)
+	}
+	if node.interval > 0 {
+		add("Time Segment", windowCoverage(node.segTime, node.interval))
+	}
+	add("Events", strconv.FormatUint(s.Events, 10))
+	if node.interval > 0 {
+		add("Event Rate", fmt.Sprintf("%.2f/s", float64(s.Events)/float64(node.interval)))
+	}
+	// Requests are delivery attempts, not events: the ratio is the batch factor.
+	if s.Requests > 0 {
+		add("Requests", strconv.FormatUint(s.Requests, 10))
+		add("Batch Factor", fmt.Sprintf("%.1f events per request", float64(s.Events)/float64(s.Requests)))
+		add("Mean Latency", durationOf(s.RequestNanos, s.Requests))
+	}
+	// No share of requests beside it: attempts are retried and a batching target
+	// increments only this, so the ratio can exceed 100%.
+	if s.WriterErrors > 0 {
+		add("Writer Errors", strconv.FormatUint(s.WriterErrors, 10))
+	}
+	reasons := 0
+	for _, drop := range []struct {
+		label string
+		n     uint64
+	}{
+		{"Dropped (queue full)", s.DroppedQueueFull},
+		{"Dropped (retries exhausted)", s.DroppedRetriesExhausted},
+		{"Dropped (shutdown)", s.DroppedShutdown},
+		{"Dropped (other)", s.DroppedOther},
+	} {
+		if drop.n > 0 {
+			add(drop.label, strconv.FormatUint(drop.n, 10))
+			reasons++
+		}
+	}
+	// Only when it is more than one reason restated: with a single reason the total
+	// is the same number under a second label.
+	if reasons > 1 {
+		add("Dropped Total", strconv.FormatUint(droppedInSegment(s), 10))
+	}
+	// Context only: every field above is a cross-node sum, and dividing one by the
+	// node count would invent a per-node figure that moves when a node joins or
+	// leaves. N itself is per merged value, so it is divided back down.
+	if s.N > 0 {
+		add("Nodes", formatNodeCount(s.N, node.merged))
+	}
+	return data
+}
+
+// logVolumeLines totals the lines a segment emitted. The wire carries no total.
+func logVolumeLines(s madmin.LogVolumeSegment) uint64 {
+	return s.ErrorLines + s.WarningLines + s.FatalLines + s.InfoLines + s.EventLines
+}
+
+// logVolumeSegmentEmpty reports a segment where nothing was logged. N is not part
+// of the test: a quiet node still reports itself in every slot.
+func logVolumeSegmentEmpty(s *madmin.LogVolumeSegment) bool {
+	return logVolumeLines(*s) == 0
+}
+
+// logVolumeWindowNode is the node-level log-line window -- the hour or the day --
+// as a row per time segment plus one navigable child per segment.
+type logVolumeWindowNode struct {
+	seg    *madmin.SegmentedLogVolume
+	flags  madmin.MetricFlags
+	window string
+	parent MetricNode
+	path   string
+}
+
+func (node *logVolumeWindowNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *logVolumeWindowNode) GetMetricType() madmin.MetricType   { return madmin.MetricsTargets }
+func (node *logVolumeWindowNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *logVolumeWindowNode) GetParent() MetricNode              { return node.parent }
+func (node *logVolumeWindowNode) GetPath() string                    { return node.path }
+func (node *logVolumeWindowNode) ShouldPauseRefresh() bool           { return true }
+
+func (node *logVolumeWindowNode) hasSegments() bool {
+	return node.seg != nil && node.seg.Interval > 0 && len(node.seg.Segments) > 0
+}
+
+// wholeSecs is the span the whole window covers: one segment as wide as every
+// slot it holds, so an _ALL rate reads as the window average.
+func (node *logVolumeWindowNode) wholeSecs() int {
+	return node.seg.Interval * len(node.seg.Segments)
+}
+
+func (node *logVolumeWindowNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
+	}
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	withDate := windowCrossesDay(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if logVolumeSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeLogVolumeSegment(s, node.seg.Interval),
+		})
+	}
+	return children
+}
+
+func (node *logVolumeWindowNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s log volume segments available", node.window)
+	}
+	leaf := func(s madmin.LogVolumeSegment, segTime time.Time, interval, merged int) MetricNode {
+		return &logVolumeSegmentLeafNode{
+			seg: s, segTime: segTime, interval: interval,
+			merged: merged, flags: node.flags, parent: node, path: node.path + "/" + name,
+		}
+	}
+	if name == "_ALL" {
+		return leaf(node.seg.Total(), node.seg.FirstTime, node.wholeSecs(), len(node.seg.Segments)), nil
+	}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	if i, ok := owners[name]; ok {
+		return leaf(node.seg.Segments[i], segmentStart(node.seg.FirstTime, node.seg.Interval, i), node.seg.Interval, 1), nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *logVolumeWindowNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.seg, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	data := map[string]string{
+		"00:Total (last " + node.window + ")": formatLogVolumeWindow(node.seg),
+		"01:Coverage":                         windowCoverage(node.seg.FirstTime, node.wholeSecs()),
+	}
+	idx := 2
+	for i := range node.seg.Segments {
+		s := node.seg.Segments[i]
+		if logVolumeSegmentEmpty(&s) {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		end := start.Add(time.Duration(node.seg.Interval) * time.Second)
+		data[segmentRowKey(idx, start, end)] = describeLogVolumeSegment(s, node.seg.Interval)
+		idx++
+	}
+	// The totals above are measured zeros, so they stay; only the reason there is
+	// no segment row is added.
+	if idx == 2 {
+		data["02:Segments"] = fmt.Sprintf("nothing logged in any of the %d segment(s) measured",
+			len(node.seg.Segments))
+	}
+	return data
+}
+
+// describeLogVolumeSegment renders one segment on a single line. Errors and
+// warnings are named even at zero, matching the summary line this hangs under.
+func describeLogVolumeSegment(s madmin.LogVolumeSegment, interval int) string {
+	out := fmt.Sprintf("%d errors, %d warnings", s.ErrorLines, s.WarningLines)
+	for _, rest := range []struct {
+		label string
+		n     uint64
+	}{
+		{"fatal", s.FatalLines},
+		{"info", s.InfoLines},
+		{"events", s.EventLines},
+	} {
+		if rest.n > 0 {
+			out += fmt.Sprintf(", %d %s", rest.n, rest.label)
+		}
+	}
+	// Per minute rather than per second: a quarter-hour segment holding a handful of
+	// lines rounds to 0.0/s and says nothing.
+	if lines := logVolumeLines(s); lines > 0 && interval > 0 {
+		out += fmt.Sprintf(", %.1f lines/min", float64(lines)*60/float64(interval))
+	}
+	return out
+}
+
+// logVolumeSegmentLeafNode is the lines emitted within one time segment, or the
+// whole window combined.
+type logVolumeSegmentLeafNode struct {
+	seg      madmin.LogVolumeSegment
+	segTime  time.Time
+	interval int
+	// merged is how many segment values were summed into seg, so N can be divided
+	// back into a node count.
+	merged int
+	flags  madmin.MetricFlags
+	parent MetricNode
+	path   string
+}
+
+func (node *logVolumeSegmentLeafNode) GetOpts() madmin.MetricsOptions { return getNodeOpts(node) }
+func (node *logVolumeSegmentLeafNode) GetMetricType() madmin.MetricType {
+	return madmin.MetricsTargets
+}
+
+func (node *logVolumeSegmentLeafNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *logVolumeSegmentLeafNode) GetParent() MetricNode              { return node.parent }
+func (node *logVolumeSegmentLeafNode) GetPath() string                    { return node.path }
+func (node *logVolumeSegmentLeafNode) ShouldPauseRefresh() bool           { return true }
+func (node *logVolumeSegmentLeafNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *logVolumeSegmentLeafNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *logVolumeSegmentLeafNode) GetLeafData() map[string]string {
+	s := node.seg
+	data := map[string]string{}
+	idx := 0
+	add := func(k, v string) {
+		data[fmt.Sprintf("%02d:%s", idx, k)] = v
+		idx++
+	}
+	if node.interval > 0 {
+		add("Time Segment", windowCoverage(node.segTime, node.interval))
+	}
+	// Errors and warnings are rendered at zero: "0 errors at 14:05" is the
+	// reassurance an operator is after.
+	add("Errors", strconv.FormatUint(s.ErrorLines, 10))
+	add("Warnings", strconv.FormatUint(s.WarningLines, 10))
+	for _, rest := range []struct {
+		label string
+		n     uint64
+	}{
+		{"Fatal", s.FatalLines},
+		{"Info", s.InfoLines},
+		{"Events", s.EventLines},
+	} {
+		if rest.n > 0 {
+			add(rest.label, strconv.FormatUint(rest.n, 10))
+		}
+	}
+	// Lines emitted, so suppression already happened upstream: this is not a count
+	// of errors that occurred.
+	lines := logVolumeLines(s)
+	add("Total Lines", strconv.FormatUint(lines, 10))
+	if node.interval > 0 {
+		add("Line Rate", fmt.Sprintf("%.2f/min", float64(lines)*60/float64(node.interval)))
+	}
+	// Context only: the severities are cross-node sums, so dividing one by the node
+	// count would invent a per-node rate that moves when a node restarts. N itself is
+	// per merged value, so it is divided back down.
+	if s.N > 0 {
+		add("Nodes", formatNodeCount(s.N, node.merged))
 	}
 	return data
 }

--- a/mnav/targets_test.go
+++ b/mnav/targets_test.go
@@ -1,0 +1,715 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+func targetWindow(segments ...madmin.TargetSegment) *madmin.SegmentedTargetMetrics {
+	return &madmin.SegmentedTargetMetrics{
+		Interval:  60,
+		FirstTime: time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC),
+		Segments:  segments,
+	}
+}
+
+// The batch factor and the mean latency are derived from the segment totals; the
+// wire carries only sums.
+func TestFormatTargetWindow(t *testing.T) {
+	got := formatTargetWindow(targetWindow(
+		madmin.TargetSegment{N: 1, Events: 60, Requests: 20, RequestNanos: 20_000_000},
+		madmin.TargetSegment{N: 1, Events: 40, Requests: 10, RequestNanos: 10_000_000, DroppedShutdown: 3},
+	))
+	want := "100 events, 30 reqs (3.3 ea, avg 1ms), 3 dropped (shutdown)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// A healthy target names no failure at all rather than a wall of zeros.
+	got = formatTargetWindow(targetWindow(
+		madmin.TargetSegment{N: 1, Events: 5, Requests: 5, RequestNanos: 5_000},
+	))
+	if want = "5 events, 5 reqs (1.0 ea, avg 1µs)"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// Errors and warnings are named at zero so a quiet cluster reads as quiet rather
+// than as unreported; the other severities only appear when they happened.
+func TestFormatLogVolumeWindow(t *testing.T) {
+	window := func(segments ...madmin.LogVolumeSegment) *madmin.SegmentedLogVolume {
+		return &madmin.SegmentedLogVolume{
+			Interval:  60,
+			FirstTime: time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC),
+			Segments:  segments,
+		}
+	}
+
+	got := formatLogVolumeWindow(window(
+		madmin.LogVolumeSegment{N: 1, ErrorLines: 3, WarningLines: 10, InfoLines: 4},
+		madmin.LogVolumeSegment{N: 1, ErrorLines: 1, EventLines: 2, FatalLines: 1},
+	))
+	want := "4 errors, 10 warnings, 1 fatal, 4 info, 2 events"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// Measured zeros are named; the two states that measured nothing are not.
+	if got, want = formatLogVolumeWindow(window(madmin.LogVolumeSegment{N: 1})), "0 errors, 0 warnings"; got != want {
+		t.Errorf("idle window = %q, want %q", got, want)
+	}
+	if got, want = formatLogVolumeWindow(window()), "no data yet"; got != want {
+		t.Errorf("empty window = %q, want %q", got, want)
+	}
+	if got, want = formatLogVolumeWindow(nil), "not collected"; got != want {
+		t.Errorf("nil window = %q, want %q", got, want)
+	}
+}
+
+// The three window states must stay apart in the one-line summary too: an absent
+// window is not a measured zero, and neither is one that is still filling.
+func TestFormatTargetWindowStates(t *testing.T) {
+	if got, want := formatTargetWindow(nil), "not collected"; got != want {
+		t.Errorf("nil window = %q, want %q", got, want)
+	}
+	if got, want := formatTargetWindow(targetWindow()), "no data yet"; got != want {
+		t.Errorf("empty window = %q, want %q", got, want)
+	}
+	if got, want := formatTargetWindow(targetWindow(madmin.TargetSegment{N: 1})), "0 events"; got != want {
+		t.Errorf("idle window = %q, want the measured %q", got, want)
+	}
+}
+
+// Drops are only in the windows, so the summary must total every reason -- and a
+// window the caller did not request must contribute nothing.
+func TestDroppedIn(t *testing.T) {
+	got := droppedIn(targetWindow(madmin.TargetSegment{
+		N: 1, DroppedQueueFull: 1, DroppedRetriesExhausted: 2,
+		DroppedShutdown: 4, DroppedOther: 8,
+	}))
+	if got != 15 {
+		t.Errorf("droppedIn = %d, want 15", got)
+	}
+	if got = droppedIn(nil); got != 0 {
+		t.Errorf("droppedIn(nil) = %d, want 0", got)
+	}
+}
+
+var targetFirstTime = time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+// The day window is a coarser resolution, and the two must never share a map:
+// Segmented.Add drops everything whose interval differs.
+func targetDayWindow(segments ...madmin.TargetSegment) *madmin.SegmentedTargetMetrics {
+	return &madmin.SegmentedTargetMetrics{
+		Interval:  900,
+		FirstTime: targetFirstTime,
+		Segments:  segments,
+	}
+}
+
+func logVolumeWindow(interval int, segments ...madmin.LogVolumeSegment) *madmin.SegmentedLogVolume {
+	return &madmin.SegmentedLogVolume{
+		Interval:  interval,
+		FirstTime: targetFirstTime,
+		Segments:  segments,
+	}
+}
+
+// busyTargetSegment delivers 60 events in 20 requests taking 20ms in total, so the
+// batch factor is 3.0 and the mean latency 1ms.
+func busyTargetSegment() madmin.TargetSegment {
+	return madmin.TargetSegment{N: 2, Events: 60, Requests: 20, RequestNanos: 20_000_000}
+}
+
+func targetNav(t *testing.T, targets *madmin.DeliveryTargetMetrics) MetricNavigator {
+	t.Helper()
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Targets: targets},
+	})
+}
+
+// twoTargets is one notification and one audit target, each with both windows.
+func twoTargets() *madmin.DeliveryTargetMetrics {
+	return &madmin.DeliveryTargetMetrics{
+		Nodes: 2,
+		Notification: map[string]madmin.TargetMetrics{
+			"notify_webhook:primary": {
+				N: 2, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
+				LastHour: targetWindow(busyTargetSegment()),
+				LastDay:  targetDayWindow(busyTargetSegment()),
+			},
+		},
+		Audit: map[string]madmin.TargetMetrics{
+			"audit_kafka:1": {
+				N: 2, Subsystem: "audit_kafka", Name: "1", Type: "kafka",
+				LastHour: targetWindow(madmin.TargetSegment{N: 2, Events: 10, Requests: 1, RequestNanos: 5_000_000, DroppedQueueFull: 4, WriterErrors: 2}),
+				LastDay:  targetDayWindow(madmin.TargetSegment{N: 2, Events: 10, Requests: 1, RequestNanos: 5_000_000}),
+			},
+		},
+		LogVolumeLastHour: logVolumeWindow(60, madmin.LogVolumeSegment{N: 2, WarningLines: 4, InfoLines: 7}),
+		LogVolumeLastDay:  logVolumeWindow(900, madmin.LogVolumeSegment{N: 2, ErrorLines: 3}),
+	}
+}
+
+// The windows are listed before the targets, and everything listed resolves.
+func TestTargetMetricsWindowChildren(t *testing.T) {
+	nav := targetNav(t, twoTargets())
+	node, err := nav.Navigate("targets")
+	if err != nil {
+		t.Fatalf("navigate targets: %v", err)
+	}
+	got := childNames(node.GetChildren())
+	want := []string{
+		"last_hour", "last_day", "log_volume_last_hour", "log_volume_last_day",
+		"notify_webhook:primary", "audit_kafka:1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	// A target carries its own two windows, and both resolve.
+	tgt, err := nav.Navigate("targets/notify_webhook:primary")
+	if err != nil {
+		t.Fatalf("navigate target: %v", err)
+	}
+	if got, want := childNames(tgt.GetChildren()), []string{"last_hour", "last_day"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("target children = %v, want %v", got, want)
+	}
+	for _, name := range []string{"last_hour", "last_day"} {
+		if _, err := tgt.GetChild(name); err != nil {
+			t.Errorf("target GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+}
+
+// One resolution per view: the keyed child list is exactly the targets that have a
+// window at that resolution, time-first entry included.
+func TestTargetWindowsChildren(t *testing.T) {
+	targets := twoTargets()
+	// This target reported only the day window, so it must not appear in the hour
+	// view -- mixing resolutions loses every series but the first.
+	targets.Logs = map[string]madmin.TargetMetrics{
+		"logger_webhook:main": {
+			N: 1, Subsystem: "logger_webhook", Name: "main", Type: "webhook",
+			LastDay: targetDayWindow(busyTargetSegment()),
+		},
+	}
+	nav := targetNav(t, targets)
+
+	for path, want := range map[string][]string{
+		"targets/last_hour": {byTimeName, "_ALL", "audit_kafka:1", "notify_webhook:primary"},
+		"targets/last_day":  {byTimeName, "_ALL", "audit_kafka:1", "logger_webhook:main", "notify_webhook:primary"},
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		got := childNames(node.GetChildren())
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s children = %v, want %v", path, got, want)
+		}
+		for _, name := range got {
+			if _, err := node.GetChild(name); err != nil {
+				t.Errorf("%s GetChild(%q) = %v, want a node", path, name, err)
+			}
+		}
+		// The class is labeled, so a reader never has to parse a key.
+		for _, child := range node.GetChildren() {
+			switch child.Name {
+			case "audit_kafka:1":
+				if !strings.HasPrefix(child.Description, "audit log: ") {
+					t.Errorf("%s: audit child described as %q", path, child.Description)
+				}
+			case "logger_webhook:main":
+				if !strings.HasPrefix(child.Description, "system log: ") {
+					t.Errorf("%s: log child described as %q", path, child.Description)
+				}
+			case "notify_webhook:primary":
+				if !strings.HasPrefix(child.Description, "notification: ") {
+					t.Errorf("%s: notification child described as %q", path, child.Description)
+				}
+			}
+		}
+	}
+}
+
+// Rows carry the real span they cover, oldest first, and the derived figures are
+// computed here -- the wire carries only sums.
+func TestTargetWindowSegments(t *testing.T) {
+	nav := targetNav(t, &madmin.DeliveryTargetMetrics{
+		Nodes: 2,
+		Notification: map[string]madmin.TargetMetrics{
+			"notify_webhook:primary": {
+				N: 2, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
+				// The middle slot is idle, so it is neither a row nor a child.
+				LastHour: targetWindow(
+					busyTargetSegment(),
+					madmin.TargetSegment{N: 2},
+					madmin.TargetSegment{N: 2, Events: 5, Requests: 5, RequestNanos: 5_000_000, DroppedShutdown: 3, DroppedOther: 1},
+				),
+			},
+		},
+	})
+	node, err := nav.Navigate("targets/notify_webhook:primary/last_hour")
+	if err != nil {
+		t.Fatalf("navigate window: %v", err)
+	}
+
+	got := childNames(node.GetChildren())
+	if want := []string{"_ALL", "10:00Z", "10:02Z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	data := node.GetLeafData()
+	if len(data) != 4 {
+		t.Errorf("rows = %v, want exactly 4 (total + coverage + two active segments)", data)
+	}
+	wantCoverage(t, "01:Coverage", data["01:Coverage"], "Covering 3m, until Aug 12, 10:03Z")
+	if got, want := data["02: 10:00Z"], "60 events (1.0/s), 20 reqs (3.0 ea, avg 1ms)"; got != want {
+		t.Errorf("first segment row = %q, want %q", got, want)
+	}
+	if got, want := data["03: 10:02Z"], "5 events (0.1/s), 5 reqs (1.0 ea, avg 1ms), 4 dropped"; got != want {
+		t.Errorf("second segment row = %q, want %q", got, want)
+	}
+
+	// Batch factor and mean latency are derived per segment.
+	seg, err := nav.Navigate("targets/notify_webhook:primary/last_hour/10:00Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	sd := seg.GetLeafData()
+	for key, want := range map[string]string{
+		"Events": "60", "Requests": "20", "Event Rate": "1.00/s",
+		"Batch Factor": "3.0 events per request", "Mean Latency": "1ms",
+		"Nodes": "2 node(s)", "Target": "notify_webhook:primary",
+	} {
+		if got := leafValue(sd, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	// A clean segment names no failure at all.
+	for _, key := range []string{"Writer Errors", "Dropped Total", "Dropped (shutdown)"} {
+		if got := leafValue(sd, key); got != "" {
+			t.Errorf("%s = %q on a clean segment, want no row", key, got)
+		}
+	}
+
+	// The segment that dropped names each reason and their total.
+	bad, err := nav.Navigate("targets/notify_webhook:primary/last_hour/10:02Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	bd := bad.GetLeafData()
+	for key, want := range map[string]string{
+		"Dropped (shutdown)": "3", "Dropped (other)": "1", "Dropped Total": "4",
+	} {
+		if got := leafValue(bd, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	// _ALL is the whole window as one segment: 65 events across three minutes.
+	all, err := nav.Navigate("targets/notify_webhook:primary/last_hour/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	if got := leafValue(all.GetLeafData(), "Events"); got != "65" {
+		t.Errorf("_ALL Events = %q, want 65", got)
+	}
+}
+
+// A window the caller did not request must read as unavailable, an empty one as no
+// data -- never as a row of real zeros.
+func TestTargetWindowUnavailable(t *testing.T) {
+	nav := targetNav(t, &madmin.DeliveryTargetMetrics{
+		Nodes: 1,
+		Notification: map[string]madmin.TargetMetrics{
+			"notify_webhook:primary": {
+				N: 1, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
+				LastDay: &madmin.SegmentedTargetMetrics{Interval: 900, FirstTime: targetFirstTime},
+			},
+		},
+	})
+
+	// The target's own hour window was never populated.
+	hour, err := nav.Navigate("targets/notify_webhook:primary/last_hour")
+	if err != nil {
+		t.Fatalf("navigate window: %v", err)
+	}
+	if got := hour.GetLeafData()["Status"]; !strings.Contains(got, "not requested") {
+		t.Errorf("nil window Status = %q, want it to say the stats were not requested", got)
+	}
+	if got := hour.GetChildren(); len(got) != 0 {
+		t.Errorf("nil window children = %v, want none", childNames(got))
+	}
+	if _, err := hour.GetChild("_ALL"); err == nil {
+		t.Error("GetChild on a nil window returned a node, want an error")
+	}
+
+	day, err := nav.Navigate("targets/notify_webhook:primary/last_day")
+	if err != nil {
+		t.Fatalf("navigate window: %v", err)
+	}
+	if got, want := day.GetLeafData()["Status"], "no data yet: the last-day window holds no completed segment"; got != want {
+		t.Errorf("empty window Status = %q, want %q", got, want)
+	}
+
+	// The grouping node has a configured target but no window to show for it.
+	group, err := nav.Navigate("targets/last_hour")
+	if err != nil {
+		t.Fatalf("navigate targets/last_hour: %v", err)
+	}
+	if got := group.GetLeafData()["Status"]; !strings.Contains(got, "not requested") {
+		t.Errorf("empty group Status = %q, want it to say the stats were not requested", got)
+	}
+	if got := group.GetChildren(); len(got) != 0 {
+		t.Errorf("empty group children = %v, want none", childNames(got))
+	}
+
+	// The day window was requested for that target and came back empty, so the
+	// target is still listed -- as still filling, never as a measured zero.
+	dayGroup, err := nav.Navigate("targets/last_day")
+	if err != nil {
+		t.Fatalf("navigate targets/last_day: %v", err)
+	}
+	found := false
+	for _, child := range dayGroup.GetChildren() {
+		if child.Name != "notify_webhook:primary" {
+			continue
+		}
+		found = true
+		if want := "notification: no data yet"; child.Description != want {
+			t.Errorf("empty day window described as %q, want %q", child.Description, want)
+		}
+	}
+	if !found {
+		t.Errorf("day group children = %v, want the target with the requested window",
+			childNames(dayGroup.GetChildren()))
+	}
+
+	// With nothing configured at all, say so rather than blaming the flags.
+	nav = targetNav(t, &madmin.DeliveryTargetMetrics{Nodes: 1})
+	group, err = nav.Navigate("targets/last_day")
+	if err != nil {
+		t.Fatalf("navigate targets/last_day: %v", err)
+	}
+	if got, want := group.GetLeafData()["Status"], "no delivery targets configured"; got != want {
+		t.Errorf("unconfigured group Status = %q, want %q", got, want)
+	}
+
+	// Log volume works with no target configured, so its own window is what decides.
+	lv, err := nav.Navigate("targets/log_volume_last_hour")
+	if err != nil {
+		t.Fatalf("navigate log volume: %v", err)
+	}
+	if got := lv.GetLeafData()["Status"]; !strings.Contains(got, "not requested") {
+		t.Errorf("nil log volume Status = %q, want it to say the stats were not requested", got)
+	}
+}
+
+// Errors and warnings render at zero: "0 errors at 10:00" is the reassurance.
+func TestLogVolumeWindowSegments(t *testing.T) {
+	nav := targetNav(t, &madmin.DeliveryTargetMetrics{
+		Nodes: 2,
+		LogVolumeLastHour: logVolumeWindow(60,
+			madmin.LogVolumeSegment{N: 2, InfoLines: 30},
+			madmin.LogVolumeSegment{N: 2},
+			madmin.LogVolumeSegment{N: 2, ErrorLines: 2, WarningLines: 5, FatalLines: 1, EventLines: 3},
+		),
+	})
+	node, err := nav.Navigate("targets/log_volume_last_hour")
+	if err != nil {
+		t.Fatalf("navigate log volume: %v", err)
+	}
+	got := childNames(node.GetChildren())
+	if want := []string{"_ALL", "10:00Z", "10:02Z"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	for _, name := range got {
+		if _, err := node.GetChild(name); err != nil {
+			t.Errorf("GetChild(%q) = %v, want a node", name, err)
+		}
+	}
+
+	data := node.GetLeafData()
+	if got, want := data["02: 10:00Z"], "0 errors, 0 warnings, 30 info, 30.0 lines/min"; got != want {
+		t.Errorf("first segment row = %q, want %q", got, want)
+	}
+	if got, want := data["03: 10:02Z"], "2 errors, 5 warnings, 1 fatal, 3 events, 11.0 lines/min"; got != want {
+		t.Errorf("second segment row = %q, want %q", got, want)
+	}
+
+	// The quiet segment still names both severities, at zero.
+	quiet, err := nav.Navigate("targets/log_volume_last_hour/10:00Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	qd := quiet.GetLeafData()
+	for key, want := range map[string]string{
+		"Errors": "0", "Warnings": "0", "Info": "30", "Total Lines": "30",
+		"Line Rate": "30.00/min", "Nodes": "2 node(s)",
+	} {
+		if got := leafValue(qd, key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{"Fatal", "Events"} {
+		if got := leafValue(qd, key); got != "" {
+			t.Errorf("%s = %q on a segment that logged none, want no row", key, got)
+		}
+	}
+
+	// _ALL totals the window: 30 + 11 lines.
+	all, err := nav.Navigate("targets/log_volume_last_hour/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	if got := leafValue(all.GetLeafData(), "Total Lines"); got != "41" {
+		t.Errorf("_ALL Total Lines = %q, want 41", got)
+	}
+}
+
+// The section and each target refresh continuously, so neither may pull the
+// windows: they render summaries only when the history is already loaded.
+func TestTargetSectionRequestsNoHistory(t *testing.T) {
+	targets := twoTargets()
+	// Requested and returned empty: present, but nothing to summarize.
+	tm := targets.Notification["notify_webhook:primary"]
+	tm.LastDay = &madmin.SegmentedTargetMetrics{Interval: 900, FirstTime: targetFirstTime}
+	targets.Notification["notify_webhook:primary"] = tm
+	nav := targetNav(t, targets)
+
+	for _, path := range []string{"targets", "targets/notify_webhook:primary"} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		if got := node.GetMetricFlags(); got != 0 {
+			t.Errorf("%s flags = %v, want none: the windows are fetched on entering one", path, got)
+		}
+		if opts := node.GetOpts(); opts.Flags != 0 {
+			t.Errorf("%s opts flags = %v, want none", path, opts.Flags)
+		}
+	}
+
+	tgt, err := nav.Navigate("targets/notify_webhook:primary")
+	if err != nil {
+		t.Fatalf("navigate target: %v", err)
+	}
+	data := tgt.GetLeafData()
+	if got, want := data["Last Hour"], "60 events, 20 reqs (3.0 ea, avg 1ms)"; got != want {
+		t.Errorf("Last Hour = %q, want %q", got, want)
+	}
+	if got, ok := data["Last Day"]; ok {
+		t.Errorf("Last Day = %q, want no row for a window holding no segment", got)
+	}
+
+	section, err := nav.Navigate("targets")
+	if err != nil {
+		t.Fatalf("navigate targets: %v", err)
+	}
+	sd := section.GetLeafData()
+	if got, want := sd["Logged (last hour)"], "0 errors, 4 warnings, 7 info"; got != want {
+		t.Errorf("Logged (last hour) = %q, want %q", got, want)
+	}
+	// Drops live only in the windows, and the hour window here has 4 of them.
+	if got, want := sd["Dropped Events (last hour)"], "4"; got != want {
+		t.Errorf("Dropped Events (last hour) = %q, want %q", got, want)
+	}
+}
+
+// A key is only unique within its class map, so the section listing must resolve a
+// collision the same way GetChild does: first class wins, listed once.
+func TestTargetSectionDuplicateKeys(t *testing.T) {
+	targets := twoTargets()
+	shared := "notify_webhook:primary"
+	targets.Audit[shared] = madmin.TargetMetrics{
+		N: 1, Subsystem: "notify_webhook", Name: "primary", Type: "kafka",
+	}
+	node, err := targetNav(t, targets).Navigate("targets")
+	if err != nil {
+		t.Fatalf("navigate targets: %v", err)
+	}
+	seen := 0
+	for _, child := range node.GetChildren() {
+		if child.Name != shared {
+			continue
+		}
+		seen++
+		if want := "webhook notification target on 2 node(s)"; child.Description != want {
+			t.Errorf("shared key described as %q, want the notification class %q", child.Description, want)
+		}
+	}
+	if seen != 1 {
+		t.Errorf("shared key listed %d times, want exactly once", seen)
+	}
+	// And that one entry is what GetChild resolves.
+	child, err := node.GetChild(shared)
+	if err != nil {
+		t.Fatalf("GetChild(%q): %v", shared, err)
+	}
+	if got := leafValue(child.GetLeafData(), "Type"); got != "webhook" {
+		t.Errorf("resolved type = %q, want the notification target's webhook", got)
+	}
+}
+
+// A key is a bare wall-clock time, so a window that reaches 24 hours -- what
+// Segmented.Add yields when two nodes' FirstTime differ by one interval -- has two
+// slots wanting one name. The newest keeps it, and the list agrees with lookup.
+func TestTargetWindowDuplicateSegmentKeys(t *testing.T) {
+	// 97 quarter-hour slots span 24h15m, so slot 0 and slot 96 are both 10:00Z.
+	segments := make([]madmin.TargetSegment, 97)
+	segments[0] = madmin.TargetSegment{N: 1, Events: 7}
+	segments[96] = madmin.TargetSegment{N: 1, Events: 11}
+	nav := targetNav(t, &madmin.DeliveryTargetMetrics{
+		Nodes: 1,
+		Notification: map[string]madmin.TargetMetrics{
+			"notify_webhook:primary": {
+				N: 1, Subsystem: "notify_webhook", Name: "primary", Type: "webhook",
+				LastDay: targetDayWindow(segments...),
+			},
+		},
+	})
+
+	for _, path := range []string{
+		"targets/notify_webhook:primary/last_day",
+		"targets/last_day/notify_webhook:primary",
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		names := childNames(node.GetChildren())
+		if want := []string{"_ALL", "10:00Z"}; !reflect.DeepEqual(names, want) {
+			t.Fatalf("%s children = %v, want %v (the older 10:00Z slot dropped)", path, names, want)
+		}
+		for _, name := range names {
+			if _, err := node.GetChild(name); err != nil {
+				t.Errorf("%s GetChild(%q) = %v, want a node", path, name, err)
+			}
+		}
+		dup, err := node.GetChild("10:00Z")
+		if err != nil {
+			t.Fatalf("%s GetChild(10:00Z): %v", path, err)
+		}
+		if got := leafValue(dup.GetLeafData(), "Events"); got != "11" {
+			t.Errorf("%s Events = %q, want 11 from the newest slot", path, got)
+		}
+		wantCoverage(t, "duplicate-key Time Segment",
+			leafValue(dup.GetLeafData(), "Time Segment"), "Covering 15m, until Aug 13, 10:15Z")
+	}
+
+	// The time-first navigation shares the key format, so it resolves the same way.
+	byTime, err := nav.Navigate("targets/last_day/" + byTimeName)
+	if err != nil {
+		t.Fatalf("navigate by time: %v", err)
+	}
+	names := childNames(byTime.GetChildren())
+	if want := []string{"10:00Z"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("by-time children = %v, want %v", names, want)
+	}
+	seg, err := byTime.GetChild("10:00Z")
+	if err != nil {
+		t.Fatalf("by-time GetChild(10:00Z): %v", err)
+	}
+	if got := leafValue(seg.GetLeafData(), "Events"); got != "11" {
+		t.Errorf("by-time Events = %q, want 11 from the newest slot", got)
+	}
+}
+
+// A total that only restates one reason is the same number under two labels, which
+// the API forbids; with two reasons it is new information.
+func TestTargetSegmentDropTotal(t *testing.T) {
+	segLeaf := func(s madmin.TargetSegment) map[string]string {
+		return (&targetSegmentLeafNode{seg: s, segTime: targetFirstTime, interval: 60}).GetLeafData()
+	}
+	one := segLeaf(madmin.TargetSegment{N: 1, Events: 5, DroppedQueueFull: 3})
+	if got, want := leafValue(one, "Dropped (queue full)"), "3"; got != want {
+		t.Errorf("Dropped (queue full) = %q, want %q", got, want)
+	}
+	if got := leafValue(one, "Dropped Total"); got != "" {
+		t.Errorf("Dropped Total = %q, want no row when it restates one reason", got)
+	}
+	two := segLeaf(madmin.TargetSegment{N: 1, Events: 5, DroppedQueueFull: 3, DroppedShutdown: 1})
+	if got, want := leafValue(two, "Dropped Total"), "4"; got != want {
+		t.Errorf("Dropped Total = %q, want %q", got, want)
+	}
+}
+
+// Every node must request the window it renders: parent inheritance hides a wrong
+// constant, so the node's own flags are what is asserted.
+func TestTargetWindowFlags(t *testing.T) {
+	nav := targetNav(t, twoTargets())
+	key := "notify_webhook:primary"
+	for _, tt := range []struct {
+		path string
+		want madmin.MetricFlags
+	}{
+		{"targets/last_hour", madmin.MetricsHourStats},
+		{"targets/last_hour/" + byTimeName, madmin.MetricsHourStats},
+		{"targets/last_hour/" + byTimeName + "/10:00Z", madmin.MetricsHourStats},
+		{"targets/last_hour/" + byTimeName + "/10:00Z/" + key, madmin.MetricsHourStats},
+		{"targets/last_hour/" + byTimeName + "/10:00Z/_ALL", madmin.MetricsHourStats},
+		{"targets/last_hour/_ALL", madmin.MetricsHourStats},
+		{"targets/last_hour/" + key, madmin.MetricsHourStats},
+		{"targets/last_hour/" + key + "/10:00Z", madmin.MetricsHourStats},
+		{"targets/" + key + "/last_hour", madmin.MetricsHourStats},
+		{"targets/log_volume_last_hour", madmin.MetricsHourStats},
+		{"targets/log_volume_last_hour/10:00Z", madmin.MetricsHourStats},
+		{"targets/last_day", madmin.MetricsDayStats},
+		{"targets/last_day/" + byTimeName, madmin.MetricsDayStats},
+		{"targets/last_day/" + byTimeName + "/10:00Z", madmin.MetricsDayStats},
+		{"targets/last_day/" + byTimeName + "/10:00Z/" + key, madmin.MetricsDayStats},
+		{"targets/last_day/_ALL", madmin.MetricsDayStats},
+		{"targets/last_day/" + key, madmin.MetricsDayStats},
+		{"targets/last_day/" + key + "/10:00Z", madmin.MetricsDayStats},
+		{"targets/" + key + "/last_day", madmin.MetricsDayStats},
+		{"targets/log_volume_last_day", madmin.MetricsDayStats},
+		{"targets/log_volume_last_day/10:00Z", madmin.MetricsDayStats},
+	} {
+		node, err := nav.Navigate(tt.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tt.path, err)
+		}
+		if got := node.GetMetricFlags(); got != tt.want {
+			t.Errorf("%s flags = %v, want exactly %v", tt.path, got, tt.want)
+		}
+		if opts := node.GetOpts(); !opts.Flags.Contains(tt.want) || opts.Type&madmin.MetricsTargets == 0 {
+			t.Errorf("%s opts = %v/%v, want target metrics with %v", tt.path, opts.Type, opts.Flags, tt.want)
+		}
+		if !node.ShouldPauseRefresh() {
+			t.Errorf("%s does not pause refresh, want a paused time series", tt.path)
+		}
+	}
+}

--- a/mnav/tier.go
+++ b/mnav/tier.go
@@ -206,10 +206,25 @@ func (node *WarmTierNode) GetLeafData() map[string]string {
 	return data
 }
 
-// durationOf renders acc/count as a duration.
+// durationOf renders acc/count as a duration, at a precision that suits its
+// magnitude: microseconds are what a sub-second latency needs, and carrying them
+// into a figure of minutes only produces noise a reader has to scan past
+// ("13m19.506473s"). Roughly four significant figures either way.
 func durationOf(acc, count uint64) string {
 	if count == 0 {
 		return "n/a"
 	}
-	return time.Duration(acc / count).Round(time.Microsecond).String()
+	return roundDuration(time.Duration(acc / count)).String()
+}
+
+// roundDuration drops precision that the magnitude does not justify.
+func roundDuration(d time.Duration) time.Duration {
+	switch a := d.Abs(); {
+	case a >= time.Minute:
+		return d.Round(time.Second)
+	case a >= time.Second:
+		return d.Round(time.Millisecond)
+	default:
+		return d.Round(time.Microsecond)
+	}
 }


### PR DESCRIPTION
Adds clearly time segmented history to locks and targets.

Separate stats for IAM call types and add history as well.

Update mnav with new fields and overall for consistency in UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hourly and daily history views for IAM authorization, lock activity, target delivery, and log volume metrics.
  * Expanded summaries with authorization paths, cache misses, latency, persistence, failures, drops, coverage, and node counts.
  * Added disk cleanup and reclamation metrics, including reclaimed space and cycle status.
  * Added detailed per-time-segment navigation for supported metrics.

* **Bug Fixes**
  * Prevented duplicate or ambiguous time-segment entries.
  * Improved timestamp and age reporting, including clock-skew handling.
  * Preserved empty and unavailable history states accurately.

* **Style**
  * Improved duration formatting for clearer metric displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->