### PR TITLE
Add annotation state to system inventory status

### DIFF
--- a/system-inventory.go
+++ b/system-inventory.go
@@ -43,10 +43,13 @@ type SystemInventoryBucketStatus struct {
 }
 
 // SystemInventoryStatus reports whether the per-bucket system inventory feature
-// is enabled and the inventory table state for every eligible bucket.
+// is enabled, whether object annotation maintenance is currently active, and
+// the inventory table state for every eligible bucket. Annotations is true only
+// when both inventory and annotation maintenance are enabled.
 type SystemInventoryStatus struct {
-	Enabled bool                          `json:"enabled"`
-	Buckets []SystemInventoryBucketStatus `json:"buckets"`
+	Enabled     bool                          `json:"enabled"`
+	Annotations bool                          `json:"annotations"`
+	Buckets     []SystemInventoryBucketStatus `json:"buckets"`
 }
 
 // SystemInventoryStatus returns the system inventory feature state and the

--- a/system-inventory_test.go
+++ b/system-inventory_test.go
@@ -65,7 +65,7 @@ func TestSystemInventoryStatusRequest(t *testing.T) {
 func TestSystemInventoryStatusDecode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"enabled":true,"buckets":[{"bucket":"active","status":"Active"},{"bucket":"backfill","status":"Backfilling"},{"bucket":"off","status":"Disabled"}]}`))
+		w.Write([]byte(`{"enabled":true,"annotations":true,"buckets":[{"bucket":"active","status":"Active"},{"bucket":"backfill","status":"Backfilling"},{"bucket":"off","status":"Disabled"}]}`))
 	}))
 	defer server.Close()
 
@@ -76,6 +76,9 @@ func TestSystemInventoryStatusDecode(t *testing.T) {
 
 	if !got.Enabled {
 		t.Fatal("Enabled = false, want true")
+	}
+	if !got.Annotations {
+		t.Fatal("Annotations = false, want true")
 	}
 	if len(got.Buckets) != 3 {
 		t.Fatalf("Buckets len = %d, want 3", len(got.Buckets))
@@ -89,6 +92,26 @@ func TestSystemInventoryStatusDecode(t *testing.T) {
 		if got.Buckets[i] != want[i] {
 			t.Errorf("Buckets[%d] = %+v, want %+v", i, got.Buckets[i], want[i])
 		}
+	}
+}
+
+// Servers older than the annotations field omit it; it must decode as false.
+func TestSystemInventoryStatusDecodeOmittedAnnotations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"enabled":true,"buckets":[]}`))
+	}))
+	defer server.Close()
+
+	got, err := newSystemInventoryTestClient(t, server.URL).SystemInventoryStatus(context.Background())
+	if err != nil {
+		t.Fatalf("SystemInventoryStatus: %v", err)
+	}
+	if !got.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if got.Annotations {
+		t.Error("Annotations = true, want false")
 	}
 }
 


### PR DESCRIPTION
Adds the effective annotation-table maintenance state to `SystemInventoryStatus`.

The new `annotations` JSON field is backward-compatible: responses from older servers omit it and decode as `false`.

Includes tests for present and omitted fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System inventory status now indicates whether annotation maintenance is enabled.
  * Status responses remain compatible with older servers that omit the annotation setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->