### PR TITLE
fix: honour yield's result in the error-log and API-log iterators

### DIFF
--- a/api-logs.go
+++ b/api-logs.go
@@ -74,6 +74,7 @@ func (adm AdminClient) GetAPILogs(ctx context.Context, opts APILogOpts) iter.Seq
 			yield(log.API{}, err)
 			return
 		}
+		defer closeResponse(resp)
 		if resp.StatusCode != http.StatusOK {
 			yield(log.API{}, httpRespToErrorResponse(resp))
 			return
@@ -85,13 +86,16 @@ func (adm AdminClient) GetAPILogs(ctx context.Context, opts APILogOpts) iter.Seq
 				if errors.Is(err, io.EOF) {
 					break
 				}
-				continue
+				yield(log.API{}, err)
+				return
 			}
 			select {
 			case <-ctx.Done():
 				return
 			default:
-				yield(info, nil)
+				if !yield(info, nil) {
+					return
+				}
 			}
 		}
 	}

--- a/error-logs.go
+++ b/error-logs.go
@@ -80,6 +80,7 @@ func (adm AdminClient) GetErrorLogs(ctx context.Context, opts ErrorLogOpts) iter
 			yield(log.Error{}, err)
 			return
 		}
+		defer closeResponse(resp)
 		if resp.StatusCode != http.StatusOK {
 			yield(log.Error{}, httpRespToErrorResponse(resp))
 			return
@@ -91,13 +92,16 @@ func (adm AdminClient) GetErrorLogs(ctx context.Context, opts ErrorLogOpts) iter
 				if errors.Is(err, io.EOF) {
 					break
 				}
-				continue
+				yield(log.Error{}, err)
+				return
 			}
 			select {
 			case <-ctx.Done():
 				return
 			default:
-				yield(info, nil)
+				if !yield(info, nil) {
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
GetErrorLogs and GetAPILogs discarded what yield returned, so a consumer that stopped early panicked with "range function continued iteration after function for loop body returned false" — which any stream longer than the caller's limit would hit. A non-EOF decode error also continued silently, spinning forever on a malformed stream instead of reporting it. GetAuditLogs and GetAlerts already did both correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log retrieval now reports decoding errors instead of silently skipping them.
  * Log processing stops promptly when the consumer declines further entries.
  * Improved consistency when handling invalid log data across API and error logs.
  * Response resources are now reliably closed after log retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->