### PR TITLE
fix: satisfy gofumpt in golangci-lint v2.13

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -51,7 +51,7 @@ type MetricType uint32
 const MetricsNone MetricType = 0
 
 const (
-	MetricsScanner MetricType = 1 << (iota)
+	MetricsScanner MetricType = 1 << iota
 	MetricsDisk
 	MetricsOS
 	MetricsBatchJobs
@@ -77,7 +77,7 @@ const (
 
 	// MetricsAll must be last.
 	// Enables all metrics.
-	MetricsAll = 1<<(iota) - 1
+	MetricsAll = 1<<iota - 1
 )
 
 // Contains returns whether m contains all of x.
@@ -126,17 +126,17 @@ func (m MetricType) String() string {
 type MetricFlags uint64
 
 const (
-	MetricsDayStats      MetricFlags = 1 << (iota) // Include daily statistics (24h, 15-min segments)
-	MetricsByHost                                  // Aggregate metrics by host/node.
-	MetricsByDisk                                  // Aggregate metrics by disk.
-	MetricsLegacyDiskIO                            // Add legacy disk IO metrics.
-	MetricsByDiskSet                               // Aggregate metrics by disk pool+set index.
-	MetricsSMART                                   // Include S.M.A.R.T. disk health data.
-	MetricsHourStats                               // Include last-hour statistics (1h, 1-min segments)
-	MetricsTopWarehouses                           // Include top-25 metrics by warehouse
-	MetricsTopNamespaces                           // Include top-25 metrics by namespace
-	MetricsTopTables                               // Include top-25 tables
-	MetricsTablesCatalog                           // Include the tables catalog inventory (leader-only; walks the catalog)
+	MetricsDayStats      MetricFlags = 1 << iota // Include daily statistics (24h, 15-min segments)
+	MetricsByHost                                // Aggregate metrics by host/node.
+	MetricsByDisk                                // Aggregate metrics by disk.
+	MetricsLegacyDiskIO                          // Add legacy disk IO metrics.
+	MetricsByDiskSet                             // Aggregate metrics by disk pool+set index.
+	MetricsSMART                                 // Include S.M.A.R.T. disk health data.
+	MetricsHourStats                             // Include last-hour statistics (1h, 1-min segments)
+	MetricsTopWarehouses                         // Include top-25 metrics by warehouse
+	MetricsTopNamespaces                         // Include top-25 metrics by namespace
+	MetricsTopTables                             // Include top-25 tables
+	MetricsTablesCatalog                         // Include the tables catalog inventory (leader-only; walks the catalog)
 )
 
 // Contains returns whether m contains all of x.

--- a/metrics_msgp.go
+++ b/metrics_msgp.go
@@ -69,7 +69,7 @@ func (z *Segmented[T, PT]) DecodeMsg(dc *msgp.Reader) (err error) {
 				return err
 			}
 			if cap(z.Segments) >= int(zb0002) {
-				z.Segments = (z.Segments)[:zb0002]
+				z.Segments = z.Segments[:zb0002]
 			} else {
 				z.Segments = make([]T, zb0002)
 			}
@@ -269,7 +269,7 @@ func (z *Segmented[T, PT]) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return o, err
 			}
 			if cap(z.Segments) >= int(zb0002) {
-				z.Segments = (z.Segments)[:zb0002]
+				z.Segments = z.Segments[:zb0002]
 			} else {
 				z.Segments = make([]T, zb0002)
 			}

--- a/mnav/bytime.go
+++ b/mnav/bytime.go
@@ -163,6 +163,7 @@ type byTimeSegmentNode[T any, PT segPtr[T]] struct {
 
 func (node *byTimeSegmentNode[T, PT]) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
 func (node *byTimeSegmentNode[T, PT]) GetMetricType() madmin.MetricType { return node.view.metricType }
+
 func (node *byTimeSegmentNode[T, PT]) GetMetricFlags() madmin.MetricFlags {
 	return node.view.metricFlags
 }

--- a/mnav/scanner.go
+++ b/mnav/scanner.go
@@ -520,6 +520,7 @@ func (node *ScannerTimedActionNode) GetLeafData() map[string]string {
 		"bytes":       strconv.FormatUint(node.action.Bytes, 10),
 	}
 }
+
 func (node *ScannerTimedActionNode) GetMetricType() madmin.MetricType   { return madmin.MetricsScanner }
 func (node *ScannerTimedActionNode) GetMetricFlags() madmin.MetricFlags { return 0 }
 func (node *ScannerTimedActionNode) GetParent() MetricNode              { return node.parent }
@@ -775,6 +776,7 @@ func (node *ScannerLastDayTotalNode) GetLeafData() map[string]string {
 }
 
 func (node *ScannerLastDayTotalNode) GetMetricType() madmin.MetricType { return madmin.MetricsScanner }
+
 func (node *ScannerLastDayTotalNode) GetMetricFlags() madmin.MetricFlags {
 	return madmin.MetricsDayStats
 }


### PR DESCRIPTION
The lint job installs golangci-lint `latest`, which moved to v2.13.1 and bundles a newer gofumpt. Three of its rules now fire on code already in `main`, so the job fails on every PR:

- `1 << (iota)` → `1 << iota` (`metrics.go`, the `MetricType` and `MetricFlags` const blocks; comment alignment shifts with it)
- `(z.Segments)[:zb0002]` → `z.Segments[:zb0002]` (`metrics_msgp.go`, 2 spots — this file is hand-written, not msgp output, so `go generate` won't revert it)
- a blank line is required before a multi-line func that follows single-line ones (`mnav/bytime.go`, `mnav/scanner.go`)

Purely mechanical: produced by `golangci-lint fmt` with v2.13.1. `golangci-lint run` reports 0 issues, `go build ./...` and `go test ./...` pass.

Worth considering pinning `golangci-lint-action` to a specific version so the next upstream bump doesn't break unrelated PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)