### PR TITLE
feat: carry the AIStor Tables replica role on SRInfo

### DIFF
--- a/cluster-commands.go
+++ b/cluster-commands.go
@@ -764,6 +764,11 @@ type SRInfo struct {
 	ILMExpiryRules map[string]ILMExpiryRule      // map of ILM Expiry rule to content
 	State          SRStateInfo                   // peer state
 	APIVersion     string                        `json:"apiVersion,omitempty"`
+
+	// TablesReplicaEnabled reports whether the site runs the AIStor Tables
+	// replica catalog. Absent from peers that predate the field, which decode
+	// it as false.
+	TablesReplicaEnabled bool `json:"tablesReplicaEnabled,omitempty"`
 }
 
 // SRMetaInfo - returns replication metadata info for a site.


### PR DESCRIPTION
Adds `SRInfo.TablesReplicaEnabled`.

The site-replication status path in AIStor needs each peer's AIStor Tables
role. It currently reads that with a second admin round-trip per peer to
`get-config-kv`, and `GetConfigKVWithOptions` decrypts the response body with
`DecryptData` — argon2id at 64 MiB a call, behind the package-global
`argon2Mu`. A customer heap profile showed that path at 397 GB of allocation
and ~0.7 cores per node continuously, on a deployment with tables disabled.

`SRMetaInfo` is already fetched per peer on that same code path, is plain
JSON, and needs no extra request. Carrying the role there removes the second
round-trip and the KDF entirely.

Peers that predate the field omit it and decode as `false`, which is the value
the caller already falls back to when the config read fails, so there is no
behaviour change against an older peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster information now reports whether the AIStor Tables replica catalog is enabled.
  * Responses remain compatible with older peers that do not provide this information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->