### PR TITLE
Fix node merges bloating node count

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -2478,30 +2478,36 @@ func (m *ReplicationMetrics) Merge(other *ReplicationMetrics) {
 }
 
 // AllTargets returns aggregated stats for all targets.
+//
+// Node counts cannot be folded exactly along the target axis. A node gains a
+// map entry for a target only once it has processed an event for that target,
+// so reporter sets differ per target and the sums Merge leaves behind bound the
+// union of reporters without pinning it: max over targets is a lower bound, and
+// the number of nodes that responded is an upper one. Two targets reported by
+// one distinct node each give every target Nodes == 1 while two nodes really
+// contributed, so the lower bound undercounts; this clamps the sum to the upper
+// bound instead, which is exact whenever every responding node reported at
+// least one target, and never reads below the per-target maximum.
 func (m *ReplicationMetrics) AllTargets() ReplicationTargetStats {
 	var dst ReplicationTargetStats
-	var nodes, lastMinute, lastHour, sinceStart int
-	days := make([]*SegmentedReplicationStats, 0, len(m.Targets))
+	var maxNodes int
 	for _, v := range m.Targets {
 		dst.Merge(&v)
-		nodes = max(nodes, v.Nodes)
-		lastMinute = max(lastMinute, v.LastMinute.Nodes)
-		lastHour = max(lastHour, v.LastHour.Nodes)
-		sinceStart = max(sinceStart, v.SinceStart.Nodes)
-		if v.LastDay != nil {
-			days = append(days, v.LastDay)
-		}
+		maxNodes = max(maxNodes, v.Nodes)
 	}
-	// Merge sums Nodes, which is only correct along the node axis. The same
-	// nodes report every target, so folding across targets must not sum;
-	// keep the widest single observation instead.
-	dst.Nodes = nodes
-	dst.LastMinute.Nodes = lastMinute
-	dst.LastHour.Nodes = lastHour
-	dst.SinceStart.Nodes = sinceStart
-	// The day window keeps its own count per segment: a quarter hour that only
-	// some nodes reported must not be rounded up to the whole-window figure.
-	ReplicationDayNodes(dst.LastDay, days...)
+	nodes := m.Nodes
+	if nodes <= 0 {
+		// Nothing to clamp against, so fall back to the lower bound rather than
+		// zeroing every count.
+		nodes = maxNodes
+	}
+	dst.Nodes = min(dst.Nodes, nodes)
+	dst.LastMinute.Nodes = min(dst.LastMinute.Nodes, nodes)
+	dst.LastHour.Nodes = min(dst.LastHour.Nodes, nodes)
+	dst.SinceStart.Nodes = min(dst.SinceStart.Nodes, nodes)
+	// The day window is clamped per segment: a quarter hour that only some nodes
+	// reported must not be rounded up to the whole-window figure.
+	ReplicationDayNodes(dst.LastDay, nodes)
 	return dst
 }
 
@@ -2587,35 +2593,24 @@ type ReplicationStats struct {
 
 type SegmentedReplicationStats = Segmented[ReplicationStats, *ReplicationStats]
 
-// ReplicationDayNodes recomputes per-segment Nodes on dst, a window built by
-// folding the per-target windows in srcs together.
+// ReplicationDayNodes clamps per-segment Nodes on dst, a window built by folding
+// per-target windows together, to nodes -- the number of nodes that responded.
 //
 // Segmented.Add sums every field, so a segment's Nodes comes back multiplied by
-// the number of targets covering it. The same nodes report every target, so the
-// correct value is the per-segment maximum across srcs. Taking it per segment
-// rather than once for the whole window also keeps a segment that only some
-// nodes reported from being rounded up to the cluster size. Event counters are
-// left alone: those really do sum across targets.
-func ReplicationDayNodes(dst *SegmentedReplicationStats, srcs ...*SegmentedReplicationStats) {
-	if dst == nil || dst.Interval <= 0 {
+// the number of targets covering it. Reporter sets differ per target, so the
+// union behind a segment is not recoverable from that sum; the responding node
+// count is the tightest bound available. Clamping per segment rather than over
+// the whole window keeps a quarter hour that only some nodes reported from being
+// rounded up to the cluster size. Event counters are left alone: those really do
+// sum across targets.
+//
+// See ReplicationMetrics.AllTargets for why the union cannot be derived.
+func ReplicationDayNodes(dst *SegmentedReplicationStats, nodes int) {
+	if dst == nil {
 		return
 	}
-	step := time.Duration(dst.Interval) * time.Second
-	nodes := make([]int, len(dst.Segments))
-	for _, src := range srcs {
-		// Add drops mismatched resolutions, so they contribute nothing here either.
-		if src == nil || src.Interval != dst.Interval {
-			continue
-		}
-		off := int(src.FirstTime.Sub(dst.FirstTime) / step)
-		for i := range src.Segments {
-			if j := off + i; j >= 0 && j < len(nodes) {
-				nodes[j] = max(nodes[j], src.Segments[i].Nodes)
-			}
-		}
-	}
 	for i := range dst.Segments {
-		dst.Segments[i].Nodes = nodes[i]
+		dst.Segments[i].Nodes = min(dst.Segments[i].Nodes, nodes)
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -2481,12 +2481,16 @@ func (m *ReplicationMetrics) Merge(other *ReplicationMetrics) {
 func (m *ReplicationMetrics) AllTargets() ReplicationTargetStats {
 	var dst ReplicationTargetStats
 	var nodes, lastMinute, lastHour, sinceStart int
+	days := make([]*SegmentedReplicationStats, 0, len(m.Targets))
 	for _, v := range m.Targets {
 		dst.Merge(&v)
 		nodes = max(nodes, v.Nodes)
 		lastMinute = max(lastMinute, v.LastMinute.Nodes)
 		lastHour = max(lastHour, v.LastHour.Nodes)
 		sinceStart = max(sinceStart, v.SinceStart.Nodes)
+		if v.LastDay != nil {
+			days = append(days, v.LastDay)
+		}
 	}
 	// Merge sums Nodes, which is only correct along the node axis. The same
 	// nodes report every target, so folding across targets must not sum;
@@ -2495,13 +2499,9 @@ func (m *ReplicationMetrics) AllTargets() ReplicationTargetStats {
 	dst.LastMinute.Nodes = lastMinute
 	dst.LastHour.Nodes = lastHour
 	dst.SinceStart.Nodes = sinceStart
-	if dst.LastDay != nil {
-		// Per-segment counts cannot be recovered once the timelines are
-		// merged; nodes is an upper bound and never inflates.
-		for i := range dst.LastDay.Segments {
-			dst.LastDay.Segments[i].Nodes = nodes
-		}
-	}
+	// The day window keeps its own count per segment: a quarter hour that only
+	// some nodes reported must not be rounded up to the whole-window figure.
+	ReplicationDayNodes(dst.LastDay, days...)
 	return dst
 }
 
@@ -2593,6 +2593,38 @@ type SegmentedReplicationStats = Segmented[ReplicationStats, *ReplicationStats]
 // Add sums Nodes, which is only correct along the node axis. The same nodes
 // report every segment, so folding along the time axis must not sum; Nodes is
 // set to the widest single segment instead.
+// ReplicationDayNodes recomputes per-segment Nodes on dst, a window built by
+// folding the per-target windows in srcs together.
+//
+// Segmented.Add sums every field, so a segment's Nodes comes back multiplied by
+// the number of targets covering it. The same nodes report every target, so the
+// correct value is the per-segment maximum across srcs. Taking it per segment
+// rather than once for the whole window also keeps a segment that only some
+// nodes reported from being rounded up to the cluster size. Event counters are
+// left alone: those really do sum across targets.
+func ReplicationDayNodes(dst *SegmentedReplicationStats, srcs ...*SegmentedReplicationStats) {
+	if dst == nil || dst.Interval <= 0 {
+		return
+	}
+	step := time.Duration(dst.Interval) * time.Second
+	nodes := make([]int, len(dst.Segments))
+	for _, src := range srcs {
+		// Add drops mismatched resolutions, so they contribute nothing here either.
+		if src == nil || src.Interval != dst.Interval {
+			continue
+		}
+		off := int(src.FirstTime.Sub(dst.FirstTime) / step)
+		for i := range src.Segments {
+			if j := off + i; j >= 0 && j < len(nodes) {
+				nodes[j] = max(nodes[j], src.Segments[i].Nodes)
+			}
+		}
+	}
+	for i := range dst.Segments {
+		dst.Segments[i].Nodes = nodes[i]
+	}
+}
+
 func SegmentedReplicationTotal(s *SegmentedReplicationStats) ReplicationStats {
 	var res ReplicationStats
 	if s == nil {

--- a/metrics.go
+++ b/metrics.go
@@ -1847,7 +1847,6 @@ func (m *RPCMetrics) LastMinuteTotal() RPCStats {
 		}
 	}
 
-	// Since we are merging across APIs must reset track node count.
 	return res
 }
 
@@ -2179,6 +2178,22 @@ func (a *APIStats) Merge(other APIStats) {
 // SegmentedAPIMetrics are segmented API metrics.
 type SegmentedAPIMetrics = Segmented[APIStats, *APIStats]
 
+// SegmentedAPITotal folds every time segment into a single APIStats.
+//
+// Merge sums Nodes, which is only correct along the node axis. The same nodes
+// report every segment, so folding along the time axis must not sum; Nodes is
+// set to the widest single segment instead.
+func SegmentedAPITotal(s SegmentedAPIMetrics) APIStats {
+	var res APIStats
+	var nodes int
+	for _, seg := range s.Segments {
+		res.Merge(seg)
+		nodes = max(nodes, seg.Nodes)
+	}
+	res.Nodes = nodes
+	return res
+}
+
 // APIMetrics contains metrics for API operations.
 type APIMetrics struct {
 	// Time these metrics were collected
@@ -2400,6 +2415,11 @@ func (s *Segmented[T, PT]) Add(other *Segmented[T, PT]) {
 }
 
 // Total returns the total of all segments.
+//
+// Every field is folded with T's Add, so fields that are not additive along the
+// time axis -- a count of reporting nodes, say -- come back multiplied by the
+// segment count. T is opaque here, so callers whose T has such a field must
+// correct it; see SegmentedAPITotal and SegmentedReplicationTotal.
 func (s *Segmented[T, PT]) Total() T {
 	var res T
 	if s == nil {
@@ -2409,7 +2429,6 @@ func (s *Segmented[T, PT]) Total() T {
 	for i := range s.Segments {
 		pt.Add(&s.Segments[i])
 	}
-	// Since we are merging across APIs must reset track node count.
 	return res
 }
 
@@ -2461,8 +2480,27 @@ func (m *ReplicationMetrics) Merge(other *ReplicationMetrics) {
 // AllTargets returns aggregated stats for all targets.
 func (m *ReplicationMetrics) AllTargets() ReplicationTargetStats {
 	var dst ReplicationTargetStats
+	var nodes, lastMinute, lastHour, sinceStart int
 	for _, v := range m.Targets {
 		dst.Merge(&v)
+		nodes = max(nodes, v.Nodes)
+		lastMinute = max(lastMinute, v.LastMinute.Nodes)
+		lastHour = max(lastHour, v.LastHour.Nodes)
+		sinceStart = max(sinceStart, v.SinceStart.Nodes)
+	}
+	// Merge sums Nodes, which is only correct along the node axis. The same
+	// nodes report every target, so folding across targets must not sum;
+	// keep the widest single observation instead.
+	dst.Nodes = nodes
+	dst.LastMinute.Nodes = lastMinute
+	dst.LastHour.Nodes = lastHour
+	dst.SinceStart.Nodes = sinceStart
+	if dst.LastDay != nil {
+		// Per-segment counts cannot be recovered once the timelines are
+		// merged; nodes is an upper bound and never inflates.
+		for i := range dst.LastDay.Segments {
+			dst.LastDay.Segments[i].Nodes = nodes
+		}
 	}
 	return dst
 }
@@ -2548,6 +2586,26 @@ type ReplicationStats struct {
 }
 
 type SegmentedReplicationStats = Segmented[ReplicationStats, *ReplicationStats]
+
+// SegmentedReplicationTotal folds every time segment into a single
+// ReplicationStats.
+//
+// Add sums Nodes, which is only correct along the node axis. The same nodes
+// report every segment, so folding along the time axis must not sum; Nodes is
+// set to the widest single segment instead.
+func SegmentedReplicationTotal(s *SegmentedReplicationStats) ReplicationStats {
+	var res ReplicationStats
+	if s == nil {
+		return res
+	}
+	var nodes int
+	for i := range s.Segments {
+		res.Add(&s.Segments[i])
+		nodes = max(nodes, s.Segments[i].Nodes)
+	}
+	res.Nodes = nodes
+	return res
+}
 
 // Add 'other' to a.
 func (a *ReplicationStats) Add(other *ReplicationStats) {

--- a/metrics.go
+++ b/metrics.go
@@ -2587,12 +2587,6 @@ type ReplicationStats struct {
 
 type SegmentedReplicationStats = Segmented[ReplicationStats, *ReplicationStats]
 
-// SegmentedReplicationTotal folds every time segment into a single
-// ReplicationStats.
-//
-// Add sums Nodes, which is only correct along the node axis. The same nodes
-// report every segment, so folding along the time axis must not sum; Nodes is
-// set to the widest single segment instead.
 // ReplicationDayNodes recomputes per-segment Nodes on dst, a window built by
 // folding the per-target windows in srcs together.
 //
@@ -2625,6 +2619,12 @@ func ReplicationDayNodes(dst *SegmentedReplicationStats, srcs ...*SegmentedRepli
 	}
 }
 
+// SegmentedReplicationTotal folds every time segment into a single
+// ReplicationStats.
+//
+// Add sums Nodes, which is only correct along the node axis. The same nodes
+// report every segment, so folding along the time axis must not sum; Nodes is
+// set to the widest single segment instead.
 func SegmentedReplicationTotal(s *SegmentedReplicationStats) ReplicationStats {
 	var res ReplicationStats
 	if s == nil {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1362,6 +1362,96 @@ func TestAllTargetsNodesNeverSums(t *testing.T) {
 	}
 }
 
+// Each day segment carries its own count: a quarter hour that only some nodes
+// reported must come back with that count, not the summed one Add leaves and not
+// the whole-window figure. Two targets on a 3-node cluster, second segment
+// reported by one node each, used to yield 3 (window figure) where Add left 2.
+func TestAllTargetsDayNodesArePerSegment(t *testing.T) {
+	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	day := func() *SegmentedReplicationStats {
+		return &SegmentedReplicationStats{
+			Interval: 900, FirstTime: ft,
+			Segments: []ReplicationStats{
+				{Nodes: 3, Events: 100},
+				{Nodes: 1, Events: 10},
+			},
+		}
+	}
+	m := &ReplicationMetrics{
+		Nodes: 3,
+		Targets: map[string]ReplicationTargetStats{
+			"peer:a": {Nodes: 3, LastHour: ReplicationStats{Nodes: 3, Events: 5}, LastDay: day()},
+			"peer:b": {Nodes: 3, LastHour: ReplicationStats{Nodes: 3, Events: 5}, LastDay: day()},
+		},
+	}
+
+	all := m.AllTargets()
+	wantNodes := []int{3, 1}
+	wantEvents := []int64{200, 20} // Events really do sum across targets.
+	for i, seg := range all.LastDay.Segments {
+		if seg.Nodes != wantNodes[i] {
+			t.Errorf("LastDay.Segments[%d].Nodes = %d, want %d", i, seg.Nodes, wantNodes[i])
+		}
+		if seg.Events != wantEvents[i] {
+			t.Errorf("LastDay.Segments[%d].Events = %d, want %d", i, seg.Events, wantEvents[i])
+		}
+	}
+}
+
+// Targets need not cover the same span: Add builds a unified timeline starting
+// at the earliest FirstTime, so the per-segment maximum has to be applied at the
+// right offset. A slot no target covered stays at zero.
+func TestReplicationDayNodesAlignsOffsetWindows(t *testing.T) {
+	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	early := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: ft,
+		Segments: []ReplicationStats{{Nodes: 2, Events: 1}, {Nodes: 1, Events: 1}},
+	}
+	// Starts one interval later, so its segments land on slots 1 and 2.
+	late := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: ft.Add(15 * time.Minute),
+		Segments: []ReplicationStats{{Nodes: 3, Events: 1}, {Nodes: 1, Events: 1}},
+	}
+
+	var merged SegmentedReplicationStats
+	merged.Add(early)
+	merged.Add(late)
+	ReplicationDayNodes(&merged, early, late)
+
+	for i, want := range []int{2, 3, 1} {
+		if got := merged.Segments[i].Nodes; got != want {
+			t.Errorf("Segments[%d].Nodes = %d, want %d", i, got, want)
+		}
+	}
+}
+
+// A window whose resolution does not match is dropped by Add, so it must not
+// contribute a node count either.
+func TestReplicationDayNodesSkipsMismatchedInterval(t *testing.T) {
+	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	dst := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: ft,
+		Segments: []ReplicationStats{{Nodes: 99, Events: 1}},
+	}
+	other := &SegmentedReplicationStats{
+		Interval: 60, FirstTime: ft,
+		Segments: []ReplicationStats{{Nodes: 7, Events: 1}},
+	}
+	ReplicationDayNodes(dst, other)
+	if got := dst.Segments[0].Nodes; got != 0 {
+		t.Errorf("Nodes = %d, want 0: a mismatched resolution contributes nothing", got)
+	}
+}
+
+func TestReplicationDayNodesNilAndEmpty(t *testing.T) {
+	ReplicationDayNodes(nil) // must not panic
+	empty := &SegmentedReplicationStats{Interval: 900}
+	ReplicationDayNodes(empty, nil)
+	if len(empty.Segments) != 0 {
+		t.Errorf("Segments = %d, want 0", len(empty.Segments))
+	}
+}
+
 // The time-axis counterpart of the above, for the replication family.
 func TestSegmentedReplicationTotalNodesNeverSums(t *testing.T) {
 	const nodes, segments = 3, 96

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1362,10 +1362,10 @@ func TestAllTargetsNodesNeverSums(t *testing.T) {
 	}
 }
 
-// Each day segment carries its own count: a quarter hour that only some nodes
-// reported must come back with that count, not the summed one Add leaves and not
-// the whole-window figure. Two targets on a 3-node cluster, second segment
-// reported by one node each, used to yield 3 (window figure) where Add left 2.
+// Each day segment is bounded on its own: a quarter hour that only some nodes
+// reported must not be rounded up to the whole-window figure. Two targets on a
+// 3-node cluster, second segment reported by one node each, gives 3 for the busy
+// segment and stays under it for the quiet one.
 func TestAllTargetsDayNodesArePerSegment(t *testing.T) {
 	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
 	day := func() *SegmentedReplicationStats {
@@ -1386,7 +1386,10 @@ func TestAllTargetsDayNodesArePerSegment(t *testing.T) {
 	}
 
 	all := m.AllTargets()
-	wantNodes := []int{3, 1}
+	// Segment 1 was reported by one node per target; whether that is the same
+	// node is not knowable from counts, so the sum stands where it is under the
+	// responding-node bound.
+	wantNodes := []int{3, 2}
 	wantEvents := []int64{200, 20} // Events really do sum across targets.
 	for i, seg := range all.LastDay.Segments {
 		if seg.Nodes != wantNodes[i] {
@@ -1398,10 +1401,34 @@ func TestAllTargetsDayNodesArePerSegment(t *testing.T) {
 	}
 }
 
+// Each segment is clamped on its own: one over the bound comes down to it, one
+// under it is left alone, and a slot no target covered stays at zero.
+func TestReplicationDayNodesClampsPerSegment(t *testing.T) {
+	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	dst := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: ft,
+		Segments: []ReplicationStats{
+			{Nodes: 6, Events: 100}, // summed over two targets, above the bound
+			{Nodes: 2, Events: 20},  // already under it
+			{Events: 0},             // uncovered
+		},
+	}
+	ReplicationDayNodes(dst, 3)
+
+	for i, want := range []int{3, 2, 0} {
+		if got := dst.Segments[i].Nodes; got != want {
+			t.Errorf("Segments[%d].Nodes = %d, want %d", i, got, want)
+		}
+	}
+	// Event counters sum across targets and must be untouched.
+	if got := dst.Segments[0].Events; got != 100 {
+		t.Errorf("Segments[0].Events = %d, want 100", got)
+	}
+}
+
 // Targets need not cover the same span: Add builds a unified timeline starting
-// at the earliest FirstTime, so the per-segment maximum has to be applied at the
-// right offset. A slot no target covered stays at zero.
-func TestReplicationDayNodesAlignsOffsetWindows(t *testing.T) {
+// at the earliest FirstTime, and the clamp must apply to those slots as merged.
+func TestReplicationDayNodesOffsetWindows(t *testing.T) {
 	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
 	early := &SegmentedReplicationStats{
 		Interval: 900, FirstTime: ft,
@@ -1416,8 +1443,9 @@ func TestReplicationDayNodesAlignsOffsetWindows(t *testing.T) {
 	var merged SegmentedReplicationStats
 	merged.Add(early)
 	merged.Add(late)
-	ReplicationDayNodes(&merged, early, late)
+	ReplicationDayNodes(&merged, 3)
 
+	// Slot 1 summed to 4 across the two windows and comes down to the bound.
 	for i, want := range []int{2, 3, 1} {
 		if got := merged.Segments[i].Nodes; got != want {
 			t.Errorf("Segments[%d].Nodes = %d, want %d", i, got, want)
@@ -1425,28 +1453,10 @@ func TestReplicationDayNodesAlignsOffsetWindows(t *testing.T) {
 	}
 }
 
-// A window whose resolution does not match is dropped by Add, so it must not
-// contribute a node count either.
-func TestReplicationDayNodesSkipsMismatchedInterval(t *testing.T) {
-	ft := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
-	dst := &SegmentedReplicationStats{
-		Interval: 900, FirstTime: ft,
-		Segments: []ReplicationStats{{Nodes: 99, Events: 1}},
-	}
-	other := &SegmentedReplicationStats{
-		Interval: 60, FirstTime: ft,
-		Segments: []ReplicationStats{{Nodes: 7, Events: 1}},
-	}
-	ReplicationDayNodes(dst, other)
-	if got := dst.Segments[0].Nodes; got != 0 {
-		t.Errorf("Nodes = %d, want 0: a mismatched resolution contributes nothing", got)
-	}
-}
-
 func TestReplicationDayNodesNilAndEmpty(t *testing.T) {
-	ReplicationDayNodes(nil) // must not panic
+	ReplicationDayNodes(nil, 3) // must not panic
 	empty := &SegmentedReplicationStats{Interval: 900}
-	ReplicationDayNodes(empty, nil)
+	ReplicationDayNodes(empty, 3)
 	if len(empty.Segments) != 0 {
 		t.Errorf("Segments = %d, want 0", len(empty.Segments))
 	}
@@ -1496,6 +1506,140 @@ func TestAllTargetsIgnoresUnreportedTargets(t *testing.T) {
 	}
 	if all.LastHour.Events != 7 {
 		t.Errorf("LastHour.Events = %d, want 7", all.LastHour.Events)
+	}
+}
+
+// oneNodeReplication is one node's report: every target it knows about carries
+// Nodes == 1. The day window, when given, is shared by all of that node's
+// targets.
+func oneNodeReplication(day *SegmentedReplicationStats, arns ...string) *ReplicationMetrics {
+	m := &ReplicationMetrics{Nodes: 1, Targets: make(map[string]ReplicationTargetStats, len(arns))}
+	for _, arn := range arns {
+		t := ReplicationTargetStats{
+			Nodes:      1,
+			LastMinute: ReplicationStats{Nodes: 1, Events: 1},
+			LastHour:   ReplicationStats{Nodes: 1, Events: 100},
+			SinceStart: ReplicationStats{Nodes: 1, Events: 1000},
+		}
+		if day != nil {
+			cp := *day
+			cp.Segments = append([]ReplicationStats(nil), day.Segments...)
+			t.LastDay = &cp
+		}
+		m.Targets[arn] = t
+	}
+	return m
+}
+
+func checkAllTargetNodes(t *testing.T, all ReplicationTargetStats, want int) {
+	t.Helper()
+	for _, tc := range []struct {
+		name string
+		got  int
+	}{
+		{"Nodes", all.Nodes},
+		{"LastMinute.Nodes", all.LastMinute.Nodes},
+		{"LastHour.Nodes", all.LastHour.Nodes},
+		{"SinceStart.Nodes", all.SinceStart.Nodes},
+	} {
+		if tc.got != want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, want)
+		}
+	}
+}
+
+// A node gains a map entry for a target only once it has processed an event for
+// it, so reporter sets differ per target. Two nodes reporting one target each
+// leave every target at Nodes == 1 while two distinct nodes contributed to the
+// aggregate: the per-target maximum used to return 1.
+func TestAllTargetsDisjointReporters(t *testing.T) {
+	day := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC),
+		Segments: []ReplicationStats{{Nodes: 1, Events: 50}},
+	}
+
+	var m ReplicationMetrics
+	m.Merge(oneNodeReplication(day, "peer:a"))
+	m.Merge(oneNodeReplication(day, "peer:b"))
+
+	all := m.AllTargets()
+	checkAllTargetNodes(t, all, 2)
+	if got := all.LastDay.Segments[0].Nodes; got != 2 {
+		t.Errorf("LastDay.Segments[0].Nodes = %d, want 2", got)
+	}
+	// The per-target view is untouched: one node really did report each.
+	for _, arn := range []string{"peer:a", "peer:b"} {
+		if got := m.Targets[arn].Nodes; got != 1 {
+			t.Errorf("Targets[%s].Nodes = %d, want 1", arn, got)
+		}
+	}
+	// Event counters still sum along both axes.
+	if all.LastHour.Events != 200 {
+		t.Errorf("LastHour.Events = %d, want 200", all.LastHour.Events)
+	}
+}
+
+// Partially overlapping reporter sets. Three nodes: n1 reports both targets, n2
+// only peer:a, n3 only peer:b -- so each target has two reporters while three
+// nodes contributed. The per-target maximum used to return 2.
+func TestAllTargetsPartiallyOverlappingReporters(t *testing.T) {
+	day := &SegmentedReplicationStats{
+		Interval: 900, FirstTime: time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC),
+		Segments: []ReplicationStats{{Nodes: 1, Events: 10}, {Nodes: 1, Events: 10}},
+	}
+
+	var m ReplicationMetrics
+	m.Merge(oneNodeReplication(day, "peer:a", "peer:b"))
+	m.Merge(oneNodeReplication(day, "peer:a"))
+	m.Merge(oneNodeReplication(day, "peer:b"))
+
+	all := m.AllTargets()
+	checkAllTargetNodes(t, all, 3)
+
+	// Each slot summed to 4 across the four (node, target) windows covering it
+	// and comes down to the three nodes that responded. Events keep the sum.
+	for i, seg := range all.LastDay.Segments {
+		if seg.Nodes != 3 {
+			t.Errorf("LastDay.Segments[%d].Nodes = %d, want 3", i, seg.Nodes)
+		}
+		if seg.Events != 40 {
+			t.Errorf("LastDay.Segments[%d].Events = %d, want 40", i, seg.Events)
+		}
+	}
+}
+
+// The bound is the responding node count, so it overcounts when few nodes hold
+// many targets each: one node with three targets in a cluster where three
+// responded reports 3, not 1. Pinned deliberately -- the alternative, the
+// per-target maximum, undercounts the cases above, and counts alone cannot
+// separate the two.
+func TestAllTargetsClampOvercountsIdleNodes(t *testing.T) {
+	var m ReplicationMetrics
+	m.Merge(oneNodeReplication(nil, "peer:a", "peer:b", "peer:c"))
+	m.Merge(&ReplicationMetrics{Nodes: 1}) // responded, has processed nothing
+	m.Merge(&ReplicationMetrics{Nodes: 1})
+
+	if m.Nodes != 3 {
+		t.Fatalf("Nodes = %d, want 3: nodes without targets still responded", m.Nodes)
+	}
+	checkAllTargetNodes(t, m.AllTargets(), 3)
+}
+
+// Without a responding node count to bound the sum, fall back to the per-target
+// maximum rather than zeroing every count.
+func TestAllTargetsWithoutNodeCount(t *testing.T) {
+	m := &ReplicationMetrics{
+		Targets: map[string]ReplicationTargetStats{
+			"peer:a": {Nodes: 2, LastHour: ReplicationStats{Nodes: 2, Events: 7}},
+			"peer:b": {Nodes: 2, LastHour: ReplicationStats{Nodes: 2, Events: 7}},
+		},
+	}
+	all := m.AllTargets()
+	if all.Nodes != 2 {
+		t.Errorf("Nodes = %d, want 2", all.Nodes)
+	}
+	if all.LastHour.Events != 14 {
+		t.Errorf("LastHour.Events = %d, want 14", all.LastHour.Events)
 	}
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -900,6 +900,53 @@ func TestAPIMetricsMerge(t *testing.T) {
 	}
 }
 
+// Merge sums Nodes, which is only correct along the node axis. SegmentedAPITotal
+// folds along the time axis, where every segment carries the same nodes: a
+// 3-node cluster over 95 quarter-hour segments must still report 3, not 285.
+func TestSegmentedAPITotalNodesNeverSums(t *testing.T) {
+	const nodes, segments = 3, 95
+	seg := SegmentedAPIMetrics{
+		Interval:  900,
+		FirstTime: time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC),
+		Segments:  make([]APIStats, segments),
+	}
+	for i := range seg.Segments {
+		seg.Segments[i] = APIStats{Nodes: nodes, Requests: 100}
+	}
+
+	total := SegmentedAPITotal(seg)
+	if total.Nodes != nodes {
+		t.Errorf("Nodes = %d, want %d (summed across %d segments)", total.Nodes, nodes, segments)
+	}
+	// Requests really are a cross-segment sum and must not be reset.
+	if want := int64(segments * 100); total.Requests != want {
+		t.Errorf("Requests = %d, want %d", total.Requests, want)
+	}
+}
+
+// A node that joined or left mid-window reported only some segments, so the fold
+// keeps the widest single observation rather than the first or last.
+func TestSegmentedAPITotalNodesUsesWidestSegment(t *testing.T) {
+	seg := SegmentedAPIMetrics{
+		Interval: 900,
+		Segments: []APIStats{
+			{Nodes: 1, Requests: 10},
+			{Nodes: 3, Requests: 10},
+			{Nodes: 2, Requests: 10},
+		},
+	}
+	if got := SegmentedAPITotal(seg).Nodes; got != 3 {
+		t.Errorf("Nodes = %d, want 3", got)
+	}
+}
+
+func TestSegmentedAPITotalEmpty(t *testing.T) {
+	total := SegmentedAPITotal(SegmentedAPIMetrics{})
+	if total.Nodes != 0 || total.Requests != 0 {
+		t.Errorf("empty fold = %+v, want zero value", total)
+	}
+}
+
 // TestReplicationMetricsMerge tests ReplicationMetrics.Merge functionality
 func TestReplicationMetricsMerge(t *testing.T) {
 	now := time.Now()
@@ -1265,6 +1312,100 @@ func TestReplicationTargetStatsMerge(t *testing.T) {
 			tt.base.Merge(tt.other)
 			tt.verify(t, tt.base)
 		})
+	}
+}
+
+// AllTargets folds along the target axis, where the same nodes report every
+// target: 46 targets on a 3-node cluster must report 3, not 138.
+func TestAllTargetsNodesNeverSums(t *testing.T) {
+	const nodes, targets = 3, 46
+	m := &ReplicationMetrics{
+		Nodes:   nodes,
+		Targets: make(map[string]ReplicationTargetStats, targets),
+	}
+	for i := range targets {
+		m.Targets[fmt.Sprintf("peer:bucket-%d", i)] = ReplicationTargetStats{
+			Nodes:      nodes,
+			LastMinute: ReplicationStats{Nodes: nodes, Events: 1},
+			LastHour:   ReplicationStats{Nodes: nodes, Events: 100},
+			SinceStart: ReplicationStats{Nodes: nodes, Events: 1000},
+			LastDay: &SegmentedReplicationStats{
+				Interval: 900,
+				Segments: []ReplicationStats{{Nodes: nodes, Events: 50}},
+			},
+		}
+	}
+
+	all := m.AllTargets()
+	for _, tc := range []struct {
+		name string
+		got  int
+	}{
+		{"Nodes", all.Nodes},
+		{"LastMinute.Nodes", all.LastMinute.Nodes},
+		{"LastHour.Nodes", all.LastHour.Nodes},
+		{"SinceStart.Nodes", all.SinceStart.Nodes},
+	} {
+		if tc.got != nodes {
+			t.Errorf("%s = %d, want %d (summed across %d targets)", tc.name, tc.got, nodes, targets)
+		}
+	}
+	for i, s := range all.LastDay.Segments {
+		if s.Nodes != nodes {
+			t.Errorf("LastDay.Segments[%d].Nodes = %d, want %d", i, s.Nodes, nodes)
+		}
+	}
+
+	// Event counters are additive along the target axis and must be untouched.
+	if want := int64(targets * 100); all.LastHour.Events != want {
+		t.Errorf("LastHour.Events = %d, want %d", all.LastHour.Events, want)
+	}
+}
+
+// The time-axis counterpart of the above, for the replication family.
+func TestSegmentedReplicationTotalNodesNeverSums(t *testing.T) {
+	const nodes, segments = 3, 96
+	seg := &SegmentedReplicationStats{
+		Interval: 900,
+		Segments: make([]ReplicationStats, segments),
+	}
+	for i := range seg.Segments {
+		seg.Segments[i] = ReplicationStats{Nodes: nodes, Events: 100}
+	}
+
+	total := SegmentedReplicationTotal(seg)
+	if total.Nodes != nodes {
+		t.Errorf("Nodes = %d, want %d (summed across %d segments)", total.Nodes, nodes, segments)
+	}
+	if want := int64(segments * 100); total.Events != want {
+		t.Errorf("Events = %d, want %d", total.Events, want)
+	}
+}
+
+// A nil window is the common case for a target that has never replicated.
+func TestSegmentedReplicationTotalNil(t *testing.T) {
+	total := SegmentedReplicationTotal(nil)
+	if total.Nodes != 0 || total.Events != 0 {
+		t.Errorf("nil fold = %+v, want zero value", total)
+	}
+}
+
+// Targets that no node reported are skipped by Merge and must not drag the node
+// count down.
+func TestAllTargetsIgnoresUnreportedTargets(t *testing.T) {
+	m := &ReplicationMetrics{
+		Nodes: 3,
+		Targets: map[string]ReplicationTargetStats{
+			"peer:live": {Nodes: 3, LastHour: ReplicationStats{Nodes: 3, Events: 7}},
+			"peer:cold": {},
+		},
+	}
+	all := m.AllTargets()
+	if all.Nodes != 3 {
+		t.Errorf("Nodes = %d, want 3", all.Nodes)
+	}
+	if all.LastHour.Events != 7 {
+		t.Errorf("LastHour.Events = %d, want 7", all.LastHour.Events)
 	}
 }
 

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -728,10 +728,7 @@ func (node *APILastDayEndpointNode) GetChild(name string) (MetricNode, error) {
 	// Handle "Total" entry
 	if name == "Total" {
 		// Calculate total stats for this endpoint
-		total := madmin.APIStats{}
-		for _, segment := range node.segmented.Segments {
-			total.Merge(segment)
-		}
+		total := madmin.SegmentedAPITotal(node.segmented)
 
 		return &APIEndpointNode{
 			endpoint: node.apiName,
@@ -763,10 +760,7 @@ func (node *APILastDayEndpointNode) GetLeafData() map[string]string {
 	}
 
 	// Calculate total stats for this endpoint
-	total := madmin.APIStats{}
-	for _, segment := range node.segmented.Segments {
-		total.Merge(segment)
-	}
+	total := madmin.SegmentedAPITotal(node.segmented)
 	return generateAPIStatsDisplay(total, 1, false, nil)
 }
 

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -725,10 +725,7 @@ func (node *ReplicationLastDayNode) GetLeafData() map[string]string {
 func (node *ReplicationLastDayNode) GetChild(name string) (MetricNode, error) {
 	// Handle "Total" entry - shows aggregated stats
 	if name == "Total" {
-		var total madmin.ReplicationStats
-		if node.segmented != nil {
-			total = node.segmented.Total()
-		}
+		total := madmin.SegmentedReplicationTotal(node.segmented)
 		return &ReplicationLastDayTotalNode{
 			targetName: node.targetName,
 			total:      total,
@@ -957,7 +954,7 @@ func (node *ReplicationLastDayAggregatedNode) GetChild(name string) (MetricNode,
 	}
 
 	if name == "Total" {
-		total := seg.Total()
+		total := madmin.SegmentedReplicationTotal(seg)
 		return &ReplicationLastDayTotalNode{
 			targetName: "all targets",
 			total:      total,

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -870,18 +870,16 @@ func (node *ReplicationLastDayAggregatedNode) aggregated() *madmin.SegmentedRepl
 		return nil
 	}
 	var merged madmin.SegmentedReplicationStats
-	days := make([]*madmin.SegmentedReplicationStats, 0, len(node.replication.Targets))
 	for _, t := range node.replication.Targets {
-		if t.LastDay != nil && len(t.LastDay.Segments) > 0 {
+		if t.LastDay != nil {
 			merged.Add(t.LastDay)
-			days = append(days, t.LastDay)
 		}
 	}
-	if len(days) == 0 {
+	if len(merged.Segments) == 0 {
 		return nil
 	}
-	// Add summed Nodes along the target axis; recover the per-segment maximum.
-	madmin.ReplicationDayNodes(&merged, days...)
+	// Add summed Nodes along the target axis; clamp to the responding nodes.
+	madmin.ReplicationDayNodes(&merged, node.replication.Nodes)
 	return &merged
 }
 

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -870,16 +870,24 @@ func (node *ReplicationLastDayAggregatedNode) aggregated() *madmin.SegmentedRepl
 		return nil
 	}
 	var merged madmin.SegmentedReplicationStats
+	var maxNodes int
 	for _, t := range node.replication.Targets {
 		if t.LastDay != nil {
 			merged.Add(t.LastDay)
 		}
+		maxNodes = max(maxNodes, t.Nodes)
 	}
 	if len(merged.Segments) == 0 {
 		return nil
 	}
 	// Add summed Nodes along the target axis; clamp to the responding nodes.
-	madmin.ReplicationDayNodes(&merged, node.replication.Nodes)
+	// With no count to clamp against, fall back to the per-target maximum rather
+	// than zeroing every segment, as AllTargets does.
+	nodes := node.replication.Nodes
+	if nodes <= 0 {
+		nodes = maxNodes
+	}
+	madmin.ReplicationDayNodes(&merged, nodes)
 	return &merged
 }
 

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -870,16 +870,18 @@ func (node *ReplicationLastDayAggregatedNode) aggregated() *madmin.SegmentedRepl
 		return nil
 	}
 	var merged madmin.SegmentedReplicationStats
-	var found bool
+	days := make([]*madmin.SegmentedReplicationStats, 0, len(node.replication.Targets))
 	for _, t := range node.replication.Targets {
 		if t.LastDay != nil && len(t.LastDay.Segments) > 0 {
 			merged.Add(t.LastDay)
-			found = true
+			days = append(days, t.LastDay)
 		}
 	}
-	if !found {
+	if len(days) == 0 {
 		return nil
 	}
+	// Add summed Nodes along the target axis; recover the per-segment maximum.
+	madmin.ReplicationDayNodes(&merged, days...)
 	return &merged
 }
 

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -451,6 +451,55 @@ func TestReplicationDayTotalLeavesReportNodeCount(t *testing.T) {
 	}
 }
 
+// The all-targets day view folds every target's window onto one timeline, so a
+// segment's node count is summed along the target axis as well as reused along
+// the time axis. Two targets on a 3-node cluster reported "6" for a segment all
+// three nodes covered and "2" for one only a single node covered; both are the
+// per-target sum, and the second is not even the window's node count.
+func TestReplicationDayAggregatedNodeCountsArePerSegment(t *testing.T) {
+	day := func() *madmin.SegmentedReplicationStats {
+		return &madmin.SegmentedReplicationStats{
+			Interval: 900, FirstTime: dupFirstTime,
+			Segments: []madmin.ReplicationStats{
+				{Nodes: 3, Events: 100, PutObject: 100},
+				{Nodes: 1, Events: 10, PutObject: 10},
+			},
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Replication: &madmin.ReplicationMetrics{
+			Nodes: 3,
+			Targets: map[string]madmin.ReplicationTargetStats{
+				"peer:a": {Nodes: 3, LastHour: madmin.ReplicationStats{Nodes: 3, Events: 5}, LastDay: day()},
+				"peer:b": {Nodes: 3, LastHour: madmin.ReplicationStats{Nodes: 3, Events: 5}, LastDay: day()},
+			},
+		}},
+	})
+
+	for _, tc := range []struct {
+		path, nodes, events string
+	}{
+		// Both targets cover this slot with all three nodes.
+		{"replication/last_day/" + dupFirstTime.Format("15:04Z"), "3", "200"},
+		// One node per target covered this slot; events still sum.
+		{"replication/last_day/" + dupFirstTime.Add(15*time.Minute).Format("15:04Z"), "1", "20"},
+		// The window total takes the widest segment, not the sum.
+		{"replication/last_day/Total", "3", "220"},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		data := node.GetLeafData()
+		if got := leafValue(data, "Nodes Reporting"); got != tc.nodes {
+			t.Errorf("%s: Nodes Reporting = %q, want %q", tc.path, got, tc.nodes)
+		}
+		if got := leafValue(data, "Total Events"); got != tc.events {
+			t.Errorf("%s: Total Events = %q, want %q", tc.path, got, tc.events)
+		}
+	}
+}
+
 // Microsecond precision is what a sub-second latency needs and pure noise on a
 // figure of minutes, which is how a mean failed-wait rendered as
 // "13m19.506473s".

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -452,10 +452,10 @@ func TestReplicationDayTotalLeavesReportNodeCount(t *testing.T) {
 }
 
 // The all-targets day view folds every target's window onto one timeline, so a
-// segment's node count is summed along the target axis as well as reused along
-// the time axis. Two targets on a 3-node cluster reported "6" for a segment all
-// three nodes covered and "2" for one only a single node covered; both are the
-// per-target sum, and the second is not even the window's node count.
+// segment's node count comes out summed along the target axis. Two targets on a
+// 3-node cluster reported "6" for a segment all three nodes covered; each
+// segment is now bounded by the nodes that responded, per segment rather than
+// once for the window.
 func TestReplicationDayAggregatedNodeCountsArePerSegment(t *testing.T) {
 	day := func() *madmin.SegmentedReplicationStats {
 		return &madmin.SegmentedReplicationStats{
@@ -481,8 +481,10 @@ func TestReplicationDayAggregatedNodeCountsArePerSegment(t *testing.T) {
 	}{
 		// Both targets cover this slot with all three nodes.
 		{"replication/last_day/" + dupFirstTime.Format("15:04Z"), "3", "200"},
-		// One node per target covered this slot; events still sum.
-		{"replication/last_day/" + dupFirstTime.Add(15*time.Minute).Format("15:04Z"), "1", "20"},
+		// One node per target covered this slot. Whether that is the same node
+		// is not knowable from counts, so the sum stands under the bound of
+		// three; events still sum.
+		{"replication/last_day/" + dupFirstTime.Add(15*time.Minute).Format("15:04Z"), "2", "20"},
 		// The window total takes the widest segment, not the sum.
 		{"replication/last_day/Total", "3", "220"},
 	} {

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -18,6 +18,7 @@
 package mnav
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -299,6 +300,154 @@ func TestWindowAllLeafReportsNodeCount(t *testing.T) {
 	// The counters really are cross-segment sums, so those must NOT be divided.
 	if got, want := leafValue(d, "Acquires"), "120"; got != want {
 		t.Errorf("Acquires = %q, want %q: a counter still sums over the window", got, want)
+	}
+}
+
+// The API family reaches the same invariant by a different route: APIStats.Merge
+// sums Nodes, which is only right along the node axis. Folding a day of segments
+// into one endpoint total walks the time axis instead, where every segment
+// carries the same nodes. A 3-node cluster over 95 quarter-hour segments reported
+// "285 nodes", which reads as a fleet size and is off by the segment count.
+func TestAPIEndpointLeavesReportNodeCount(t *testing.T) {
+	const nodes, segments = 3, 95
+	segs := make([]madmin.APIStats, segments)
+	for i := range segs {
+		segs[i] = madmin.APIStats{
+			Nodes: nodes, Requests: 1000, IncomingBytes: 4096,
+			RequestTimeSecs: 4.0, RespTTFBSecsMax: 0.3,
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{API: &madmin.APIMetrics{
+			Nodes: nodes,
+			LastDayAPI: map[string]madmin.SegmentedAPIMetrics{
+				"s3.PutObject": {Interval: 900, FirstTime: dupFirstTime, Segments: segs},
+			},
+		}},
+	})
+
+	// The endpoint leaf and its Total child fold the same segments; both used to
+	// inflate, so both are pinned.
+	for _, path := range []string{
+		"api/last_day/s3.PutObject",
+		"api/last_day/s3.PutObject/Total",
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		data := node.GetLeafData()
+		if got, want := leafValue(data, "Responding Nodes"), "3 nodes"; got != want {
+			t.Errorf("%s: Responding Nodes = %q, want %q: summing Nodes over %d segments gives %d",
+				path, got, want, segments, nodes*segments)
+		}
+		// The request counters really are cross-segment sums, so those must NOT be reset.
+		if got, want := leafValue(data, "Total Requests"), "95,000"; got != want {
+			t.Errorf("%s: Total Requests = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// A single time segment is already a per-node fan-in, so it reports the node
+// count directly -- the fold is what has to be corrected, not the segment.
+func TestAPITimeSegmentLeafReportsNodeCount(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{API: &madmin.APIMetrics{
+			Nodes: 3,
+			LastDayAPI: map[string]madmin.SegmentedAPIMetrics{
+				"s3.PutObject": {
+					Interval: 900, FirstTime: dupFirstTime,
+					Segments: []madmin.APIStats{{Nodes: 3, Requests: 1000, RequestTimeSecs: 4.0}},
+				},
+			},
+		}},
+	})
+	node, err := nav.Navigate("api/last_day/s3.PutObject/" + dupFirstTime.Format("15:04Z"))
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	if got, want := leafValue(node.GetLeafData(), "Responding Nodes"), "3 nodes"; got != want {
+		t.Errorf("Responding Nodes = %q, want %q", got, want)
+	}
+}
+
+// Replication folds along the target axis rather than time, but the invariant is
+// the same: every target is reported by the same nodes, so 46 targets on a 3-node
+// cluster reported "138".
+func TestReplicationLastHourLeafReportsNodeCount(t *testing.T) {
+	const nodes, targets = 3, 46
+	rm := &madmin.ReplicationMetrics{
+		Nodes:   nodes,
+		Targets: make(map[string]madmin.ReplicationTargetStats, targets),
+	}
+	for i := range targets {
+		rm.Targets[fmt.Sprintf("peer%d:bucket-%d", i, i)] = madmin.ReplicationTargetStats{
+			Nodes:      nodes,
+			LastHour:   madmin.ReplicationStats{Nodes: nodes, Events: 7000, PutObject: 7000},
+			SinceStart: madmin.ReplicationStats{Nodes: nodes, Events: 90000},
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Replication: rm},
+	})
+
+	node, err := nav.Navigate("replication/last_hour")
+	if err != nil {
+		t.Fatalf("navigate replication/last_hour: %v", err)
+	}
+	data := node.GetLeafData()
+	if got, want := leafValue(data, "Nodes Reporting"), "3"; got != want {
+		t.Errorf("Nodes Reporting = %q, want %q: summing Nodes over %d targets gives %d",
+			got, want, targets, nodes*targets)
+	}
+	// Events are additive across targets and must survive the reset.
+	if got, want := leafValue(data, "Total Events"), "322,000"; got != want {
+		t.Errorf("Total Events = %q, want %q", got, want)
+	}
+}
+
+// Replication's last-day Total nodes fold via the generic Segmented.Total,
+// which cannot correct a node count because T is opaque to it. Both the
+// per-target and the all-targets path reported "288" for 96 quarter-hour
+// segments on a 3-node cluster.
+func TestReplicationDayTotalLeavesReportNodeCount(t *testing.T) {
+	const nodes, segments = 3, 96
+	segs := make([]madmin.ReplicationStats, segments)
+	for i := range segs {
+		segs[i] = madmin.ReplicationStats{Nodes: nodes, Events: 100, PutObject: 100}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Replication: &madmin.ReplicationMetrics{
+			Nodes: nodes,
+			Targets: map[string]madmin.ReplicationTargetStats{
+				"peer:bucket": {
+					Nodes:    nodes,
+					LastHour: madmin.ReplicationStats{Nodes: nodes, Events: 10},
+					LastDay: &madmin.SegmentedReplicationStats{
+						Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+					},
+				},
+			},
+		}},
+	})
+
+	for _, path := range []string{
+		"replication/last_day/Total",
+		"replication/peer:bucket/last_day/Total",
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		data := node.GetLeafData()
+		if got, want := leafValue(data, "Nodes Reporting"), "3"; got != want {
+			t.Errorf("%s: Nodes Reporting = %q, want %q: summing Nodes over %d segments gives %d",
+				path, got, want, segments, nodes*segments)
+		}
+		// Events are a real cross-segment sum and must not be reset.
+		if got, want := leafValue(data, "Total Events"), "9,600"; got != want {
+			t.Errorf("%s: Total Events = %q, want %q", path, got, want)
+		}
 	}
 }
 

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -451,6 +451,43 @@ func TestReplicationDayTotalLeavesReportNodeCount(t *testing.T) {
 	}
 }
 
+// A capture whose top-level node count never got filled in still has per-target
+// counts, and clamping to zero would drop "Nodes Reporting" from every segment
+// and from the total. The per-target maximum stands in instead.
+func TestReplicationDayAggregatedWithoutNodeCount(t *testing.T) {
+	day := func() *madmin.SegmentedReplicationStats {
+		return &madmin.SegmentedReplicationStats{
+			Interval: 900, FirstTime: dupFirstTime,
+			Segments: []madmin.ReplicationStats{{Nodes: 2, Events: 100, PutObject: 100}},
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Replication: &madmin.ReplicationMetrics{
+			Targets: map[string]madmin.ReplicationTargetStats{
+				"peer:a": {Nodes: 2, LastDay: day()},
+				"peer:b": {Nodes: 2, LastDay: day()},
+			},
+		}},
+	})
+
+	for _, path := range []string{
+		"replication/last_day/" + dupFirstTime.Format("15:04Z"),
+		"replication/last_day/Total",
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		data := node.GetLeafData()
+		if got, want := leafValue(data, "Nodes Reporting"), "2"; got != want {
+			t.Errorf("%s: Nodes Reporting = %q, want %q", path, got, want)
+		}
+		if got, want := leafValue(data, "Total Events"), "200"; got != want {
+			t.Errorf("%s: Total Events = %q, want %q", path, got, want)
+		}
+	}
+}
+
 // The all-targets day view folds every target's window onto one timeline, so a
 // segment's node count comes out summed along the target axis. Two targets on a
 // 3-node cluster reported "6" for a segment all three nodes covered; each


### PR DESCRIPTION
When merging within a node the node count should be preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API and replication metrics so node counts are no longer inflated when combining time periods or targets.
  * Preserved additive totals for request and event counters while reporting accurate node counts.
  * Updated last-day, last-hour, and overall metric views to display correct counts across targets and time segments.
  * Improved handling of empty, missing, partially reported, and overlapping metric data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->