### PR TITLE
feat: add AlertTypeBucketQuota for per-bucket quota alerts

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -53,6 +53,9 @@ const (
 	// AlertTypeLicensedCapacity represents cluster usage approaching the
 	// licensed (org-wide) storage capacity
 	AlertTypeLicensedCapacity AlertType = "licensed-capacity"
+	// AlertTypeBucketQuota represents a bucket's usage approaching its
+	// configured hard quota
+	AlertTypeBucketQuota AlertType = "bucket-quota"
 	// AlertTypeScannerExcessFolders represents alerts for prefixes with excessive sub-folders
 	AlertTypeScannerExcessFolders AlertType = "scanner-excess-folders"
 	// AlertTypeScannerExcessVersions represents alerts for objects with excessive versions


### PR DESCRIPTION
Adds a bucket-quota alert type so AIStor can emit an alert as a bucket approaches its configured hard quota.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bucket quota alerts.
  * Alerts can now indicate when bucket usage is approaching its configured hard quota.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->