### PR TITLE
feat: report warehouse buckets in AccountInfo BucketDetails

### DIFF
--- a/user-commands.go
+++ b/user-commands.go
@@ -62,6 +62,11 @@ type BucketDetails struct {
 	// CompressionILM reports that the bucket has at least one lifecycle rule
 	// carrying a compression action.
 	CompressionILM bool `json:"compressionILM,omitempty"`
+	// IsWarehouse reports that the bucket is an AIStor Tables warehouse.
+	// Warehouses are configured through the Tables API rather than the S3
+	// bucket-configuration APIs, so a caller listing buckets needs to tell them
+	// apart to know which configuration applies.
+	IsWarehouse bool `json:"isWarehouse,omitempty"`
 }
 
 // BucketAccessInfo represents bucket usage of a bucket, and its relevant


### PR DESCRIPTION
Adds `IsWarehouse` to `BucketDetails` so a caller listing buckets can tell AIStor Tables warehouses apart from regular buckets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bucket details can now indicate whether a bucket is an AIStor Tables warehouse.
  * Added documentation for the new warehouse status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->