### PR TITLE
nmav: Improve process/cpu/mem stats

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1981,6 +1981,18 @@ type RuntimeMetrics struct {
 	// N tracks the number of merged entries.
 	N int `json:"n"`
 
+	// UptimeSecs is the accumulated process uptime of the nodes that reported
+	// one, in seconds. The mean is what a rate over these cumulative counters
+	// needs as its denominator.
+	UptimeSecs float64 `json:"uptimeSecs,omitempty"`
+
+	// UptimeNodes is how many nodes contributed to UptimeSecs.
+	//
+	// Deliberately not N: a mixed-version cluster has nodes that do not report
+	// an uptime yet, and dividing by N would scale the mean down by whatever
+	// share of the fleet stayed silent. Zero means nobody reported one.
+	UptimeNodes int `json:"uptimeNodes,omitempty"`
+
 	LastDay *SegmentedRuntimeMetrics `json:"lastDay,omitempty"`
 
 	// Last hour statistics (1-min segments).
@@ -2022,6 +2034,8 @@ func (m *RuntimeMetrics) Merge(other *RuntimeMetrics) {
 		}
 	}
 	m.N += other.N
+	m.UptimeSecs += other.UptimeSecs
+	m.UptimeNodes += other.UptimeNodes
 	if other.LastDay != nil {
 		if m.LastDay == nil {
 			m.LastDay = new(SegmentedRuntimeMetrics)

--- a/metrics_gen.go
+++ b/metrics_gen.go
@@ -33617,7 +33617,7 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -33720,6 +33720,20 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "N")
 				return
 			}
+		case "uptimeSecs":
+			z.UptimeSecs, err = dc.ReadFloat64()
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeSecs")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "uptimeNodes":
+			z.UptimeNodes, err = dc.ReadInt()
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeNodes")
+				return
+			}
+			zb0001Mask |= 0x10
 		case "lastDay":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -33738,7 +33752,7 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x20
 		case "lastHour":
 			if dc.IsNil() {
 				err = dc.ReadNil()
@@ -33757,7 +33771,7 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x40
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -33767,7 +33781,7 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.UintMetrics = nil
 		}
@@ -33778,9 +33792,15 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.HistMetrics = nil
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.LastDay = nil
+			z.UptimeSecs = 0
 		}
 		if (zb0001Mask & 0x10) == 0 {
+			z.UptimeNodes = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
 			z.LastHour = nil
 		}
 	}
@@ -33790,8 +33810,8 @@ func (z *RuntimeMetrics) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *RuntimeMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.UintMetrics == nil {
 		zb0001Len--
@@ -33805,13 +33825,21 @@ func (z *RuntimeMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.LastDay == nil {
+	if z.UptimeSecs == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.LastHour == nil {
+	if z.UptimeNodes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -33904,6 +33932,30 @@ func (z *RuntimeMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "uptimeSecs"
+			err = en.Append(0xaa, 0x75, 0x70, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteFloat64(z.UptimeSecs)
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeSecs")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "uptimeNodes"
+			err = en.Append(0xab, 0x75, 0x70, 0x74, 0x69, 0x6d, 0x65, 0x4e, 0x6f, 0x64, 0x65, 0x73)
+			if err != nil {
+				return
+			}
+			err = en.WriteInt(z.UptimeNodes)
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeNodes")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// write "lastDay"
 			err = en.Append(0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
 			if err != nil {
@@ -33922,7 +33974,7 @@ func (z *RuntimeMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// write "lastHour"
 			err = en.Append(0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
 			if err != nil {
@@ -33949,8 +34001,8 @@ func (z *RuntimeMetrics) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *RuntimeMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(6)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.UintMetrics == nil {
 		zb0001Len--
@@ -33964,13 +34016,21 @@ func (z *RuntimeMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.LastDay == nil {
+	if z.UptimeSecs == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if z.LastHour == nil {
+	if z.UptimeNodes == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if z.LastDay == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.LastHour == nil {
+		zb0001Len--
+		zb0001Mask |= 0x80
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -34012,6 +34072,16 @@ func (z *RuntimeMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 		o = append(o, 0xa1, 0x6e)
 		o = msgp.AppendInt(o, z.N)
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "uptimeSecs"
+			o = append(o, 0xaa, 0x75, 0x70, 0x74, 0x69, 0x6d, 0x65, 0x53, 0x65, 0x63, 0x73)
+			o = msgp.AppendFloat64(o, z.UptimeSecs)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "uptimeNodes"
+			o = append(o, 0xab, 0x75, 0x70, 0x74, 0x69, 0x6d, 0x65, 0x4e, 0x6f, 0x64, 0x65, 0x73)
+			o = msgp.AppendInt(o, z.UptimeNodes)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// string "lastDay"
 			o = append(o, 0xa7, 0x6c, 0x61, 0x73, 0x74, 0x44, 0x61, 0x79)
 			if z.LastDay == nil {
@@ -34024,7 +34094,7 @@ func (z *RuntimeMetrics) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// string "lastHour"
 			o = append(o, 0xa8, 0x6c, 0x61, 0x73, 0x74, 0x48, 0x6f, 0x75, 0x72)
 			if z.LastHour == nil {
@@ -34051,7 +34121,7 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -34154,6 +34224,20 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "N")
 				return
 			}
+		case "uptimeSecs":
+			z.UptimeSecs, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeSecs")
+				return
+			}
+			zb0001Mask |= 0x8
+		case "uptimeNodes":
+			z.UptimeNodes, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "UptimeNodes")
+				return
+			}
+			zb0001Mask |= 0x10
 		case "lastDay":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -34171,7 +34255,7 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x20
 		case "lastHour":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -34189,7 +34273,7 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x40
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -34199,7 +34283,7 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.UintMetrics = nil
 		}
@@ -34210,9 +34294,15 @@ func (z *RuntimeMetrics) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.HistMetrics = nil
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.LastDay = nil
+			z.UptimeSecs = 0
 		}
 		if (zb0001Mask & 0x10) == 0 {
+			z.UptimeNodes = 0
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LastDay = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
 			z.LastHour = nil
 		}
 	}
@@ -34243,7 +34333,7 @@ func (z *RuntimeMetrics) Msgsize() (s int) {
 			s += msgp.StringPrefixSize + len(za0005) + (*localF64H)(&za0006).Msgsize()
 		}
 	}
-	s += 2 + msgp.IntSize + 8
+	s += 2 + msgp.IntSize + 11 + msgp.Float64Size + 12 + msgp.IntSize + 8
 	if z.LastDay == nil {
 		s += msgp.NilSize
 	} else {

--- a/mnav/apistats.go
+++ b/mnav/apistats.go
@@ -28,6 +28,20 @@ import (
 	"github.com/minio/madmin-go/v4"
 )
 
+// lastMinuteSecs is the window the last_minute views cover.
+const lastMinuteSecs = 60
+
+// lastDayWindowSecs is the wall-clock span the last-day segments cover. Every
+// endpoint shares one timeline, so the widest series gives the window.
+func lastDayWindowSecs(day map[string]madmin.SegmentedAPIMetrics) float64 {
+	var interval, segments int
+	for _, s := range day {
+		interval = max(interval, s.Interval)
+		segments = max(segments, len(s.Segments))
+	}
+	return float64(interval * segments)
+}
+
 // formatAPISegmentDesc formats a description for an API endpoint across all segments.
 func formatAPISegmentDesc(stats madmin.APIStats, intervalSecs int, numSegments int) string {
 	totalSecs := float64(intervalSecs * numSegments)
@@ -202,8 +216,9 @@ func (node *APILastMinuteNode) GetChildren() []MetricChild {
 	return children
 }
 
-// generateAPIStatsDisplay creates a consistent API statistics display
-func generateAPIStatsDisplay(stats madmin.APIStats, endpointsCount int, showTopEndpoints bool, endpoints map[string]madmin.APIStats) map[string]string {
+// generateAPIStatsDisplay creates a consistent API statistics display.
+// window is the wall-clock seconds stats covers, 0 if the view does not fix it.
+func generateAPIStatsDisplay(stats madmin.APIStats, window float64, endpointsCount int, showTopEndpoints bool, endpoints map[string]madmin.APIStats) map[string]string {
 	if stats.Requests == 0 {
 		data := make(map[string]string)
 		data["Status"] = "No API requests recorded"
@@ -217,8 +232,8 @@ func generateAPIStatsDisplay(stats madmin.APIStats, endpointsCount int, showTopE
 	entries = append(entries, struct{ key, value string }{"Total Requests", humanize.Comma(stats.Requests)})
 
 	// Calculate RPS if we have wall time
-	if stats.WallTimeSecs > 0 {
-		rps := float64(stats.Requests) / stats.WallTimeSecs
+	if secs := windowSecs(window, stats.WallTimeSecs, stats.Nodes); secs > 0 {
+		rps := float64(stats.Requests) / secs
 		entries = append(entries, struct{ key, value string }{"Request Rate", fmt.Sprintf("%.1f req/sec", rps)})
 	}
 
@@ -435,7 +450,7 @@ func (node *APILastMinuteNode) GetLeafData() map[string]string {
 	}
 
 	total := node.api.LastMinuteTotal()
-	return generateAPIStatsDisplay(total, len(node.api.LastMinuteAPI), true, node.api.LastMinuteAPI)
+	return generateAPIStatsDisplay(total, lastMinuteSecs, len(node.api.LastMinuteAPI), true, node.api.LastMinuteAPI)
 }
 
 func (node *APILastMinuteNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -449,10 +464,11 @@ func (node *APILastMinuteNode) GetChild(name string) (MetricNode, error) {
 
 	if stats, exists := node.api.LastMinuteAPI[name]; exists {
 		return &APIEndpointNode{
-			endpoint: name,
-			stats:    stats,
-			parent:   node,
-			path:     node.path + "/" + name,
+			endpoint:   name,
+			stats:      stats,
+			windowSecs: lastMinuteSecs,
+			parent:     node,
+			path:       node.path + "/" + name,
 		}, nil
 	}
 
@@ -473,10 +489,10 @@ func apiView(ops map[string]madmin.SegmentedAPIMetrics) segView[madmin.APIStats,
 			return formatAPISegmentDesc(s, interval, 1)
 		},
 		opLeaf: func(op string, s madmin.APIStats, segTime time.Time, interval int, parent MetricNode, path string) MetricNode {
-			return &APIEndpointNode{endpoint: op, stats: s, segmentTime: segTime, interval: interval, parent: parent, path: path}
+			return &APIEndpointNode{endpoint: op, stats: s, segmentTime: segTime, interval: interval, windowSecs: float64(interval), parent: parent, path: path}
 		},
-		sumLeaf: func(s madmin.APIStats, segTime time.Time, _, _ int, parent MetricNode, path string) MetricNode {
-			return &APITimeSegmentAllNode{segment: s, segmentTime: segTime, parent: parent, path: path}
+		sumLeaf: func(s madmin.APIStats, segTime time.Time, interval, _ int, parent MetricNode, path string) MetricNode {
+			return &APITimeSegmentAllNode{segment: s, segmentTime: segTime, interval: interval, parent: parent, path: path}
 		},
 	}
 }
@@ -540,7 +556,7 @@ func (node *APILastDayNode) GetLeafData() map[string]string {
 	}
 
 	total := node.api.LastDayTotal()
-	return generateAPIStatsDisplay(total, len(node.api.LastDayAPI), false, nil)
+	return generateAPIStatsDisplay(total, lastDayWindowSecs(node.api.LastDayAPI), len(node.api.LastDayAPI), false, nil)
 }
 
 func (node *APILastDayNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -649,6 +665,7 @@ func (node *APILastDayAllNode) GetChild(name string) (MetricNode, error) {
 		return &APITimeSegmentAllNode{
 			segment:     segmented.Segments[i],
 			segmentTime: segmentStart(segmented.FirstTime, segmented.Interval, i),
+			interval:    segmented.Interval,
 			parent:      node,
 			path:        node.path + "/" + name,
 		}, nil
@@ -663,7 +680,7 @@ func (node *APILastDayAllNode) GetLeafData() map[string]string {
 	}
 
 	total := node.api.LastDayTotal()
-	return generateAPIStatsDisplay(total, len(node.api.LastDayAPI), false, nil)
+	return generateAPIStatsDisplay(total, lastDayWindowSecs(node.api.LastDayAPI), len(node.api.LastDayAPI), false, nil)
 }
 
 func (node *APILastDayAllNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -731,10 +748,11 @@ func (node *APILastDayEndpointNode) GetChild(name string) (MetricNode, error) {
 		total := madmin.SegmentedAPITotal(node.segmented)
 
 		return &APIEndpointNode{
-			endpoint: node.apiName,
-			stats:    total,
-			parent:   node,
-			path:     node.path + "/" + name,
+			endpoint:   node.apiName,
+			stats:      total,
+			windowSecs: segmentedWindowSecs(&node.segmented),
+			parent:     node,
+			path:       node.path + "/" + name,
 		}, nil
 	}
 
@@ -746,6 +764,7 @@ func (node *APILastDayEndpointNode) GetChild(name string) (MetricNode, error) {
 			stats:       node.segmented.Segments[i],
 			segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
 			interval:    node.segmented.Interval,
+			windowSecs:  float64(node.segmented.Interval),
 			parent:      node,
 			path:        node.path + "/" + name,
 		}, nil
@@ -761,7 +780,7 @@ func (node *APILastDayEndpointNode) GetLeafData() map[string]string {
 
 	// Calculate total stats for this endpoint
 	total := madmin.SegmentedAPITotal(node.segmented)
-	return generateAPIStatsDisplay(total, 1, false, nil)
+	return generateAPIStatsDisplay(total, segmentedWindowSecs(&node.segmented), 1, false, nil)
 }
 
 func (node *APILastDayEndpointNode) GetMetricType() madmin.MetricType { return madmin.MetricsAPI }
@@ -794,7 +813,8 @@ func (node *APISinceStartNode) GetLeafData() map[string]string {
 		return map[string]string{"Status": "No API metrics available"}
 	}
 
-	return generateAPIStatsDisplay(node.api.SinceStart, 0, false, nil)
+	// No window is known for since-start: the nodes' uptimes are all it covers.
+	return generateAPIStatsDisplay(node.api.SinceStart, 0, 0, false, nil)
 }
 
 func (node *APISinceStartNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -831,7 +851,7 @@ func (node *APILastDayTotalNode) GetLeafData() map[string]string {
 	}
 
 	total := node.api.LastDayTotal()
-	return generateAPIStatsDisplay(total, len(node.api.LastDayAPI), false, nil)
+	return generateAPIStatsDisplay(total, lastDayWindowSecs(node.api.LastDayAPI), len(node.api.LastDayAPI), false, nil)
 }
 
 func (node *APILastDayTotalNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -851,6 +871,7 @@ func (node *APILastDayTotalNode) GetChild(_ string) (MetricNode, error) {
 type APITimeSegmentAllNode struct {
 	segment     madmin.APIStats
 	segmentTime time.Time
+	interval    int
 	parent      MetricNode
 	path        string
 }
@@ -868,7 +889,7 @@ func (node *APITimeSegmentAllNode) GetChild(_ string) (MetricNode, error) {
 }
 
 func (node *APITimeSegmentAllNode) GetLeafData() map[string]string {
-	return generateAPIStatsDisplay(node.segment, 1, false, nil)
+	return generateAPIStatsDisplay(node.segment, float64(node.interval), 1, false, nil)
 }
 
 func (node *APITimeSegmentAllNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
@@ -880,66 +901,13 @@ func (node *APITimeSegmentAllNode) ShouldPauseRefresh() bool {
 	return true
 }
 
-type APITimeSegmentNode struct {
-	segment     madmin.APIStats
-	segmentTime time.Time
-	parent      MetricNode
-	path        string
-}
-
-func (node *APITimeSegmentNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *APITimeSegmentNode) ShouldPauseRefresh() bool {
-	return true
-}
-
-func (node *APITimeSegmentNode) GetChildren() []MetricChild {
-	// Check if we have individual API data for this time segment
-	// For now, we'll show "All" as the only option since we have aggregated data
-	return []MetricChild{
-		{
-			Name:        "All",
-			Description: fmt.Sprintf("All API endpoints combined for %s time segment", node.segmentTime.Local().Format("15:04")),
-		},
-	}
-}
-
-func (node *APITimeSegmentNode) GetLeafData() map[string]string {
-	// This node now has children, so it should just show navigation info
-	data := make(map[string]string)
-	endTime := node.segmentTime.Add(time.Duration(15) * time.Minute) // Assume 15-minute intervals for now
-	data["Time Range"] = fmt.Sprintf("%s -> %s",
-		node.segmentTime.Local().Format("15:04"),
-		endTime.Local().Format("15:04"))
-	data["Total Requests"] = humanize.Comma(node.segment.Requests)
-	data["Available APIs"] = "Select 'All' to view combined statistics"
-	return data
-}
-
-func (node *APITimeSegmentNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
-func (node *APITimeSegmentNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
-func (node *APITimeSegmentNode) GetParent() MetricNode              { return node.parent }
-func (node *APITimeSegmentNode) GetPath() string                    { return node.path }
-func (node *APITimeSegmentNode) GetChild(name string) (MetricNode, error) {
-	if name == "All" {
-		return &APITimeSegmentAllNode{
-			segment:     node.segment,
-			segmentTime: node.segmentTime,
-			parent:      node,
-			path:        node.path + "/" + name,
-		}, nil
-	}
-	return nil, fmt.Errorf("API selection not found: %s", name)
-}
-
 // APIEndpointNode shows detailed statistics for a specific endpoint
 type APIEndpointNode struct {
 	endpoint    string
 	stats       madmin.APIStats
 	segmentTime time.Time
 	interval    int
+	windowSecs  float64 // wall-clock seconds stats covers
 	parent      MetricNode
 	path        string
 }
@@ -982,8 +950,8 @@ func (node *APIEndpointNode) GetLeafData() map[string]string {
 	entries = append(entries, struct{ key, value string }{"Total Requests", humanize.Comma(node.stats.Requests)})
 
 	// Calculate RPS if we have wall time
-	if node.stats.WallTimeSecs > 0 {
-		rps := float64(node.stats.Requests) / node.stats.WallTimeSecs
+	if secs := windowSecs(node.windowSecs, node.stats.WallTimeSecs, node.stats.Nodes); secs > 0 {
+		rps := float64(node.stats.Requests) / secs
 		entries = append(entries, struct{ key, value string }{"Request Rate", fmt.Sprintf("%.1f req/sec", rps)})
 	}
 
@@ -1152,82 +1120,6 @@ func (node *APIEndpointNode) GetParent() MetricNode              { return node.p
 func (node *APIEndpointNode) GetPath() string                    { return node.path }
 func (node *APIEndpointNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children available for endpoint node")
-}
-
-// APISegmentedNode shows segmented statistics for a specific endpoint over the last day
-type APISegmentedNode struct {
-	segmented madmin.SegmentedAPIMetrics
-	parent    MetricNode
-	path      string
-}
-
-func (node *APISegmentedNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *APISegmentedNode) GetChildren() []MetricChild {
-	children := make([]MetricChild, 0, len(node.segmented.Segments))
-	for i := range node.segmented.Segments {
-		children = append(children, MetricChild{
-			Name:        fmt.Sprintf("segment_%d", i),
-			Description: fmt.Sprintf("Time segment %d statistics", i),
-		})
-	}
-	return children
-}
-
-func (node *APISegmentedNode) GetLeafData() map[string]string {
-	data := make(map[string]string)
-
-	data["Segment Count"] = fmt.Sprintf("%d segments", len(node.segmented.Segments))
-	data["Interval"] = fmt.Sprintf("%d seconds", node.segmented.Interval)
-
-	// Aggregate statistics
-	var totalRequests int64
-	var totalErrors int
-	var totalBytes int64
-	var totalLatency float64
-
-	for _, segment := range node.segmented.Segments {
-		totalRequests += segment.Requests
-		totalErrors += segment.Errors4xx + segment.Errors5xx
-		totalBytes += segment.IncomingBytes + segment.OutgoingBytes
-		totalLatency += segment.RequestTimeSecs
-	}
-
-	if totalRequests > 0 {
-		avgLatency := (totalLatency / float64(totalRequests)) * 1000
-		data["Total Requests"] = humanize.Comma(totalRequests)
-		data["Average Latency"] = fmt.Sprintf("%.1f ms", avgLatency)
-
-		if totalErrors > 0 {
-			errorRate := float64(totalErrors) / float64(totalRequests) * 100
-			data["Error Rate"] = fmt.Sprintf("%.2f%% (%d errors)", errorRate, totalErrors)
-		}
-
-		if totalBytes > 0 {
-			data["Total Throughput"] = humanize.Bytes(uint64(totalBytes))
-		}
-
-		// Calculate request rate per segment
-		avgReqPerSegment := float64(totalRequests) / float64(len(node.segmented.Segments))
-		data["Avg Requests/Segment"] = fmt.Sprintf("%.1f", avgReqPerSegment)
-	}
-
-	return data
-}
-
-func (node *APISegmentedNode) GetMetricType() madmin.MetricType   { return madmin.MetricsAPI }
-func (node *APISegmentedNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
-func (node *APISegmentedNode) GetParent() MetricNode              { return node.parent }
-func (node *APISegmentedNode) GetPath() string                    { return node.path }
-
-func (node *APISegmentedNode) ShouldPauseRefresh() bool {
-	return true
-}
-
-func (node *APISegmentedNode) GetChild(name string) (MetricNode, error) {
-	return nil, fmt.Errorf("segmented endpoint children not yet implemented: %s", name)
 }
 
 // generateAPIOverviewDashboard creates a clean API performance dashboard

--- a/mnav/mem.go
+++ b/mnav/mem.go
@@ -117,7 +117,7 @@ func (r *memRows) total(label string, v, whole uint64) {
 	if v == 0 {
 		return
 	}
-	r.add(label, fmtBytes(float64(v))+qualify(r.nodes, float64(v), float64(whole), fmtBytes))
+	r.add(label, fmtBytes(float64(v))+qualify(r.nodes, "node", float64(v), float64(whole), fmtBytes))
 }
 
 func (node *MemMetricsNavigator) GetLeafData() map[string]string {
@@ -333,7 +333,7 @@ func (node *MemSwapNode) GetLeafData() map[string]string {
 	// Rendered even at zero: "none in use" is the reassurance being looked for,
 	// and hiding it makes a healthy cluster look unreported.
 	used := info.SwapSpaceTotal - info.SwapSpaceFree
-	r.add("Used", fmtBytes(float64(used))+qualify(r.nodes, float64(used), float64(info.SwapSpaceTotal), fmtBytes))
+	r.add("Used", fmtBytes(float64(used))+qualify(r.nodes, "node", float64(used), float64(info.SwapSpaceTotal), fmtBytes))
 	r.total("Free", info.SwapSpaceFree, info.SwapSpaceTotal)
 	if info.Total > 0 {
 		r.add("Swap : RAM", fmt.Sprintf("%.2f : 1", float64(info.SwapSpaceTotal)/float64(info.Total)))

--- a/mnav/mem.go
+++ b/mnav/mem.go
@@ -444,8 +444,10 @@ var memWindowRows = []memWindowRow{
 // Every field is summed over the samples folded in -- N of them, one per node per
 // segment -- so the quotient is a mean per sample and one sample covers one
 // interval. That makes interval the divisor for every rate here even when the
-// whole window is rendered; segments is what turns N back into a node count and
-// scales a counter's total to one node's share of the window.
+// whole window is rendered; segments is how many slots carried a sample -- not
+// how many the window holds, since nothing accrued in the empty ones -- and is
+// what turns N back into a node count and scales a counter's total to one node's
+// share.
 func memSegmentRows(seg madmin.MemSegment, interval, segments int, coverage string) map[string]string {
 	if seg.N == 0 {
 		return map[string]string{"Status": "no node reported this time segment"}
@@ -545,6 +547,19 @@ func (node *MemLastDayNode) hasSegments() bool {
 	return node.segmented != nil && node.segmented.Interval > 0 && len(node.segmented.Segments) > 0
 }
 
+// reportedSegments counts the slots that carry a sample. A window's slots are not
+// all populated -- a restart, a startup or a node joining late leaves gaps -- and
+// nothing accrued in those.
+func (node *MemLastDayNode) reportedSegments() int {
+	var n int
+	for i := range node.segmented.Segments {
+		if node.segmented.Segments[i].N > 0 {
+			n++
+		}
+	}
+	return n
+}
+
 func (node *MemLastDayNode) wholeSecs() int {
 	return node.segmented.Interval * len(node.segmented.Segments)
 }
@@ -587,7 +602,7 @@ func (node *MemLastDayNode) GetChild(name string) (MetricNode, error) {
 		return &MemTimeSegmentNode{
 			segment:  node.segmented.Total(),
 			interval: node.segmented.Interval,
-			segments: len(node.segmented.Segments),
+			segments: node.reportedSegments(),
 			coverage: windowCoverage(node.segmented.FirstTime, node.wholeSecs()),
 			flags:    node.flags, parent: node, path: node.path + "/" + name,
 		}, nil
@@ -613,7 +628,7 @@ func (node *MemLastDayNode) GetLeafData() map[string]string {
 	// The aggregate only: each segment states its own figures in the description
 	// of the child that opens it.
 	return memSegmentRows(node.segmented.Total(), node.segmented.Interval,
-		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
+		node.reportedSegments(), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
 }
 
 // MemTimeSegmentNode is one segment of a memory window, or the whole window.

--- a/mnav/mem.go
+++ b/mnav/mem.go
@@ -20,7 +20,7 @@ package mnav
 import (
 	"fmt"
 	"strconv"
-	"time"
+	"strings"
 
 	"github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v4"
@@ -66,7 +66,8 @@ func (node *MemMetricsNavigator) GetChildren() []MetricChild {
 		MetricChild{Name: "system", Description: "System memory details (cache, buffers, shared)"},
 		MetricChild{Name: "swap", Description: "Swap space information and utilization"},
 		MetricChild{Name: "limits", Description: "Memory limits and cgroup configuration"},
-		MetricChild{Name: "last_day", Description: "Last 24h memory statistics"},
+		MetricChild{Name: "last_hour", Description: "Memory levels and kernel reclaim over the last hour, by time segment"},
+		MetricChild{Name: "last_day", Description: "Memory levels and kernel reclaim over the last day, by time segment"},
 	)
 	if node.mem.VMStat != nil {
 		children = append(children,
@@ -87,56 +88,60 @@ func (node *MemMetricsNavigator) GetChildren() []MetricChild {
 	return children
 }
 
+// memRows builds leaf data in display order, dividing every summed value back
+// down to one node.
+//
+// MemInfo.Merge sums every field, so a 17-node cluster reports 2.2 TB of RAM and
+// nothing an operator can compare against a machine. nodes is what makes a row
+// per-node; the share of the cluster total is the same number either way, so both
+// are stated.
+type memRows struct {
+	data  map[string]string
+	n     int
+	nodes int
+}
+
+func newMemRows(nodes int) *memRows {
+	return &memRows{data: make(map[string]string), nodes: max(nodes, 1)}
+}
+
+func (r *memRows) add(label, value string) {
+	r.data[fmt.Sprintf("%02d:%s", r.n, label)] = value
+	r.n++
+}
+
+// total states a summed value as the cluster figure with the per-node mean, and
+// its share of whole where there is one. A value nobody reported is skipped
+// rather than rendered as a measured zero.
+func (r *memRows) total(label string, v, whole uint64) {
+	if v == 0 {
+		return
+	}
+	r.add(label, fmtBytes(float64(v))+qualify(r.nodes, float64(v), float64(whole), fmtBytes))
+}
+
 func (node *MemMetricsNavigator) GetLeafData() map[string]string {
 	if node.mem == nil {
 		return map[string]string{"Status": "Memory metrics not available"}
 	}
-
-	data := map[string]string{
-		"Collected At": node.mem.CollectedAt.Format("2006-01-02 15:04:05"),
-	}
+	info := node.mem.Info
+	r := newMemRows(node.mem.Nodes)
+	r.add("Collected At", node.mem.CollectedAt.Format("2006-01-02 15:04:05"))
 	if node.mem.Nodes > 0 {
-		data["Nodes"] = strconv.Itoa(node.mem.Nodes)
+		r.add("Nodes", formatNodeCount(node.mem.Nodes, 1))
 	}
-	// Add high-level memory summary with averages
-	if node.mem.Info.Total > 0 {
-		data["Total Memory"] = fmt.Sprintf("%s across %d nodes",
-			formatMemoryBytes(node.mem.Info.Total), node.mem.Nodes)
-
-		if node.mem.Nodes > 0 {
-			avgTotal := node.mem.Info.Total / uint64(node.mem.Nodes)
-			data["Avg per Node"] = formatMemoryBytes(avgTotal)
-
-			if node.mem.Info.Used > 0 {
-				avgUsed := node.mem.Info.Used / uint64(node.mem.Nodes)
-				data["Avg Used"] = fmt.Sprintf("%s (%s)",
-					formatMemoryBytes(avgUsed),
-					calculatePercentage(node.mem.Info.Used, node.mem.Info.Total))
-			}
-
-			if node.mem.Info.Available > 0 {
-				avgAvailable := node.mem.Info.Available / uint64(node.mem.Nodes)
-				data["Avg Available"] = fmt.Sprintf("%s (%s)",
-					formatMemoryBytes(avgAvailable),
-					calculatePercentage(node.mem.Info.Available, node.mem.Info.Total))
-			}
-		} else {
-			// Fallback if node count is not available
-			if node.mem.Info.Used > 0 {
-				data["Used"] = fmt.Sprintf("%s (%s)",
-					formatMemoryBytes(node.mem.Info.Used),
-					calculatePercentage(node.mem.Info.Used, node.mem.Info.Total))
-			}
-
-			if node.mem.Info.Available > 0 {
-				data["Available"] = fmt.Sprintf("%s (%s)",
-					formatMemoryBytes(node.mem.Info.Available),
-					calculatePercentage(node.mem.Info.Available, node.mem.Info.Total))
-			}
-		}
+	r.total("Total", info.Total, 0)
+	// Available, not Free, is the number that says whether a host is about to
+	// run out: Linux lends everything it is not using to the page cache, so Free
+	// reads alarmingly low on a perfectly healthy machine.
+	r.total("Used", info.Used, info.Total)
+	r.total("Available", info.Available, info.Total)
+	r.total("Free", info.Free, info.Total)
+	r.total("Cache", info.Cache, info.Total)
+	if info.SwapSpaceTotal > 0 {
+		r.total("Swap Used", info.SwapSpaceTotal-info.SwapSpaceFree, info.SwapSpaceTotal)
 	}
-
-	return data
+	return r.data
 }
 
 func (node *MemMetricsNavigator) GetMetricType() madmin.MetricType {
@@ -173,6 +178,11 @@ func (node *MemMetricsNavigator) GetChild(name string) (MetricNode, error) {
 		return NewMemSwapNode(node.mem, node, fmt.Sprintf("%s/swap", node.path)), nil
 	case "limits":
 		return NewMemLimitsNode(node.mem, node, fmt.Sprintf("%s/limits", node.path)), nil
+	case "last_hour":
+		return &MemLastDayNode{
+			segmented: node.mem.LastHour, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/last_hour", node.path),
+		}, nil
 	case "last_day":
 		return NewMemLastDayNode(node.mem.LastDay, node, fmt.Sprintf("%s/last_day", node.path)), nil
 	case "vmstat":
@@ -211,61 +221,21 @@ func (node *MemUsageNode) GetLeafData() map[string]string {
 	if node.mem == nil {
 		return map[string]string{"Status": "Memory usage metrics not available"}
 	}
-
-	data := map[string]string{}
 	info := node.mem.Info
-
-	if info.Total > 0 {
-		data["Total"] = fmt.Sprintf("%s across cluster", formatMemoryBytes(info.Total))
-
-		if node.mem.Nodes > 0 {
-			avgPerNode := info.Total / uint64(node.mem.Nodes)
-			data["Avg per Node"] = fmt.Sprintf("%s per node", formatMemoryBytes(avgPerNode))
-		}
+	if info.Total == 0 {
+		return map[string]string{"Status": "No memory usage reported"}
 	}
-
-	if info.Used > 0 {
-		usedPercent := calculatePercentage(info.Used, info.Total)
-		data["Used"] = fmt.Sprintf("%s (%s)", formatMemoryBytes(info.Used), usedPercent)
-	}
-
-	if info.Free > 0 {
-		freePercent := calculatePercentage(info.Free, info.Total)
-		data["Free"] = fmt.Sprintf("%s (%s)", formatMemoryBytes(info.Free), freePercent)
-	}
-
-	if info.Available > 0 {
-		availPercent := calculatePercentage(info.Available, info.Total)
-		data["Available"] = fmt.Sprintf("%s (%s)", formatMemoryBytes(info.Available), availPercent)
-
-		if info.Total > 0 {
-			availableRatio := float64(info.Available) / float64(info.Total)
-			var pressureStatus string
-			if availableRatio > 0.5 {
-				pressureStatus = "Low pressure"
-			} else if availableRatio > 0.2 {
-				pressureStatus = "Moderate pressure"
-			} else {
-				pressureStatus = "High pressure"
-			}
-			data["Pressure"] = pressureStatus
-		}
-	}
-
-	if info.Used > 0 && info.Total > 0 {
-		utilizationRatio := float64(info.Used) / float64(info.Total)
-		var efficiencyNote string
-		if utilizationRatio > 0.8 {
-			efficiencyNote = "High utilization"
-		} else if utilizationRatio > 0.6 {
-			efficiencyNote = "Good utilization"
-		} else {
-			efficiencyNote = "Low utilization"
-		}
-		data["Efficiency"] = efficiencyNote
-	}
-
-	return data
+	r := newMemRows(node.mem.Nodes)
+	r.total("Total", info.Total, 0)
+	r.total("Used", info.Used, info.Total)
+	// Available is what an allocation can actually get: it counts the reclaimable
+	// page cache that Free does not.
+	r.total("Available", info.Available, info.Total)
+	r.total("Free", info.Free, info.Total)
+	r.total("Cache", info.Cache, info.Total)
+	r.total("Buffers", info.Buffers, info.Total)
+	r.total("Shared", info.Shared, info.Total)
+	return r.data
 }
 
 func (node *MemUsageNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
@@ -304,64 +274,18 @@ func (node *MemSystemNode) GetLeafData() map[string]string {
 	if node.mem == nil {
 		return map[string]string{"Status": "System memory metrics not available"}
 	}
-
-	data := map[string]string{}
 	info := node.mem.Info
-
-	// Cache memory
-	if info.Cache > 0 {
-		cachePercent := calculatePercentage(info.Cache, info.Total)
-		data["Cache"] = fmt.Sprintf("%s (%s)",
-			formatMemoryBytes(info.Cache), cachePercent)
+	if info.Cache == 0 && info.Buffers == 0 && info.Shared == 0 {
+		return map[string]string{"Status": "No cache, buffer or shared memory reported"}
 	}
-
-	// Buffer memory
-	if info.Buffers > 0 {
-		bufferPercent := calculatePercentage(info.Buffers, info.Total)
-		data["Buffers"] = fmt.Sprintf("%s (%s)",
-			formatMemoryBytes(info.Buffers), bufferPercent)
-	}
-
-	// Shared memory
-	if info.Shared > 0 {
-		sharedPercent := calculatePercentage(info.Shared, info.Total)
-		data["Shared"] = fmt.Sprintf("%s (%s)",
-			formatMemoryBytes(info.Shared), sharedPercent)
-	}
-
-	// System memory efficiency
-	if info.Cache > 0 || info.Buffers > 0 {
-		systemMemory := info.Cache + info.Buffers
-		if info.Total > 0 {
-			systemPercent := calculatePercentage(systemMemory, info.Total)
-			data["System Total"] = fmt.Sprintf("%s (%s)",
-				formatMemoryBytes(systemMemory), systemPercent)
-
-			if info.Cache > 0 && info.Buffers > 0 {
-				cacheRatio := float64(info.Cache) / float64(systemMemory) * 100
-				data["Cache/Buffer"] = fmt.Sprintf("%.1f%% / %.1f%%",
-					cacheRatio, 100-cacheRatio)
-			}
-		}
-	}
-
-	// Analysis of system memory health
-	if info.Total > 0 && (info.Cache > 0 || info.Buffers > 0) {
-		systemTotal := info.Cache + info.Buffers
-		systemRatio := float64(systemTotal) / float64(info.Total)
-
-		var healthNote string
-		if systemRatio > 0.3 {
-			healthNote = "High usage - good I/O performance"
-		} else if systemRatio > 0.1 {
-			healthNote = "Moderate usage - balanced"
-		} else {
-			healthNote = "Low usage - cache available"
-		}
-		data["Health"] = healthNote
-	}
-
-	return data
+	r := newMemRows(node.mem.Nodes)
+	r.total("Cache", info.Cache, info.Total)
+	r.total("Buffers", info.Buffers, info.Total)
+	r.total("Shared", info.Shared, info.Total)
+	// Cache plus buffers is the memory the kernel will hand back under pressure,
+	// which is why it is worth a line of its own next to the total.
+	r.total("Reclaimable", info.Cache+info.Buffers, info.Total)
+	return r.data
 }
 
 func (node *MemSystemNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
@@ -400,76 +324,21 @@ func (node *MemSwapNode) GetLeafData() map[string]string {
 	if node.mem == nil {
 		return map[string]string{"Status": "Swap space metrics not available"}
 	}
-
-	data := map[string]string{}
 	info := node.mem.Info
-
-	// Total swap space
-	if info.SwapSpaceTotal > 0 {
-		data["Total Swap"] = fmt.Sprintf("%s across cluster",
-			formatMemoryBytes(info.SwapSpaceTotal))
-
-		if node.mem.Nodes > 0 {
-			avgSwapPerNode := info.SwapSpaceTotal / uint64(node.mem.Nodes)
-			data["Avg per Node"] = fmt.Sprintf("%s per node",
-				formatMemoryBytes(avgSwapPerNode))
-		}
+	if info.SwapSpaceTotal == 0 {
+		return map[string]string{"Status": "no swap configured on any node"}
 	}
-
-	// Free swap space
-	if info.SwapSpaceFree > 0 {
-		freeSwapPercent := calculatePercentage(info.SwapSpaceFree, info.SwapSpaceTotal)
-		data["Free Swap"] = fmt.Sprintf("%s (%s)",
-			formatMemoryBytes(info.SwapSpaceFree), freeSwapPercent)
+	r := newMemRows(node.mem.Nodes)
+	r.total("Total", info.SwapSpaceTotal, 0)
+	// Rendered even at zero: "none in use" is the reassurance being looked for,
+	// and hiding it makes a healthy cluster look unreported.
+	used := info.SwapSpaceTotal - info.SwapSpaceFree
+	r.add("Used", fmtBytes(float64(used))+qualify(r.nodes, float64(used), float64(info.SwapSpaceTotal), fmtBytes))
+	r.total("Free", info.SwapSpaceFree, info.SwapSpaceTotal)
+	if info.Total > 0 {
+		r.add("Swap : RAM", fmt.Sprintf("%.2f : 1", float64(info.SwapSpaceTotal)/float64(info.Total)))
 	}
-
-	// Used swap calculation and analysis
-	if info.SwapSpaceTotal > 0 && info.SwapSpaceFree > 0 {
-		swapUsed := info.SwapSpaceTotal - info.SwapSpaceFree
-		if swapUsed > 0 {
-			usedSwapPercent := calculatePercentage(swapUsed, info.SwapSpaceTotal)
-			data["Used Swap"] = fmt.Sprintf("%s (%s)",
-				formatMemoryBytes(swapUsed), usedSwapPercent)
-
-			// Swap usage health indicator
-			swapUsageRatio := float64(swapUsed) / float64(info.SwapSpaceTotal)
-			var swapHealth string
-			if swapUsageRatio < 0.1 {
-				swapHealth = "Minimal usage - sufficient RAM"
-			} else if swapUsageRatio < 0.5 {
-				swapHealth = "Moderate usage - monitor pressure"
-			} else {
-				swapHealth = "High usage - consider more RAM"
-			}
-			data["Health"] = swapHealth
-		} else {
-			data["Used Swap"] = "0 bytes - no swap in use"
-			data["Health"] = "Optimal - all in RAM"
-		}
-	} else if info.SwapSpaceTotal == 0 {
-		data["Config"] = "No swap configured"
-		data["Note"] = "Consider swap for overflow protection"
-	}
-
-	// Memory vs Swap ratio analysis
-	if info.Total > 0 && info.SwapSpaceTotal > 0 {
-		swapRatio := float64(info.SwapSpaceTotal) / float64(info.Total)
-		data["Swap:RAM"] = fmt.Sprintf("%.1f:1", swapRatio)
-
-		var ratioAnalysis string
-		if swapRatio > 2.0 {
-			ratioAnalysis = "Excellent protection"
-		} else if swapRatio > 1.0 {
-			ratioAnalysis = "Good protection"
-		} else if swapRatio > 0.5 {
-			ratioAnalysis = "Basic protection"
-		} else {
-			ratioAnalysis = "Limited protection"
-		}
-		data["Protection"] = ratioAnalysis
-	}
-
-	return data
+	return r.data
 }
 
 func (node *MemSwapNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
@@ -508,73 +377,27 @@ func (node *MemLimitsNode) GetLeafData() map[string]string {
 	if node.mem == nil {
 		return map[string]string{"Status": "Memory limits metrics not available"}
 	}
-
-	data := map[string]string{}
 	info := node.mem.Info
-
-	// Cgroup memory limit analysis
-	if info.Limit > 0 {
-		data["Limit"] = formatMemoryBytes(info.Limit)
-
-		// Compare limit to physical memory
-		if info.Total > 0 {
-			if info.Limit == info.Total {
-				data["Type"] = "No cgroup limit - full memory"
-			} else if info.Limit < info.Total {
-				limitPercent := calculatePercentage(info.Limit, info.Total)
-				data["Type"] = fmt.Sprintf("Limited to %s of physical", limitPercent)
-
-				// Headroom analysis
-				if info.Used > 0 {
-					limitHeadroom := info.Limit - info.Used
-					headroomPercent := calculatePercentage(limitHeadroom, info.Limit)
-					data["Headroom"] = fmt.Sprintf("%s (%s)",
-						formatMemoryBytes(limitHeadroom), headroomPercent)
-
-					// Limit pressure indicator
-					usageRatio := float64(info.Used) / float64(info.Limit)
-					var pressureStatus string
-					if usageRatio > 0.9 {
-						pressureStatus = "Critical - very close to limit"
-					} else if usageRatio > 0.8 {
-						pressureStatus = "High - approaching limit"
-					} else if usageRatio > 0.6 {
-						pressureStatus = "Moderate - comfortable distance"
-					} else {
-						pressureStatus = "Low - plenty of headroom"
-					}
-					data["Pressure"] = pressureStatus
-				}
-			} else {
-				data["Type"] = "Limit exceeds physical memory (misconfigured)"
-			}
-		}
-	} else if info.Total > 0 {
-		data["Limit"] = "No cgroup limit configured"
-		data["Type"] = "Full memory without restrictions"
-		data["Note"] = "Consider limits for resource management"
+	// Limit is set to Total where no cgroup limit applies, so the two being equal
+	// is how "unlimited" arrives on the wire rather than a zero.
+	if info.Limit == 0 || info.Limit == info.Total {
+		return map[string]string{"Status": "no cgroup memory limit configured"}
 	}
-
-	// Memory governance analysis
-	if info.Limit > 0 && info.Total > 0 && info.Used > 0 {
-		effectiveLimit := info.Limit
-		if info.Limit > info.Total {
-			effectiveLimit = info.Total
-		}
-
-		utilizationAgainstLimit := float64(info.Used) / float64(effectiveLimit)
-		var governanceNote string
-		if utilizationAgainstLimit < 0.5 {
-			governanceNote = "Conservative - good margin"
-		} else if utilizationAgainstLimit < 0.8 {
-			governanceNote = "Healthy - approaching optimal"
+	r := newMemRows(node.mem.Nodes)
+	r.total("Limit", info.Limit, info.Total)
+	r.total("Physical", info.Total, 0)
+	if info.Used > 0 {
+		r.total("Used", info.Used, info.Limit)
+		if info.Limit > info.Used {
+			r.total("Headroom", info.Limit-info.Used, info.Limit)
 		} else {
-			governanceNote = "High - monitor for violations"
+			r.add("Headroom", "none: usage is at or above the limit")
 		}
-		data["Status"] = governanceNote
 	}
-
-	return data
+	if info.Limit > info.Total {
+		r.add("Note", "the limit exceeds physical memory, so it cannot bind")
+	}
+	return r.data
 }
 
 func (node *MemLimitsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
@@ -590,61 +413,234 @@ func (node *MemLimitsNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("memory limits node has no children")
 }
 
-// MemLastDayNode shows last 24h memory statistics
+// memWindowRow is a value worth a row in a memory window. A gauge reads as a
+// level; a counter is a per-segment delta on the wire and earns a rate.
+type memWindowRow struct {
+	label   string
+	counter bool
+	brief   bool
+	unit    string
+	render  func(float64) string
+	value   func(madmin.MemSegment) uint64
+}
+
+var memWindowRows = []memWindowRow{
+	{"Used", false, true, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.Used }},
+	{"Available", false, true, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.Available }},
+	{"Free", false, false, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.Free }},
+	{"Limit", false, false, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.Limit }},
+	// The kernel's own account of what the pressure cost. Every one of these is
+	// a delta over the segment, so a segment is comparable to its neighbours.
+	{"Swap In", true, true, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.SwapInBytes }},
+	{"Swap Out", true, true, "", fmtBytes, func(m madmin.MemSegment) uint64 { return m.SwapOutBytes }},
+	{"Major Faults", true, true, "", fmtCount, func(m madmin.MemSegment) uint64 { return m.MajorFaults }},
+	{"Workingset Refault", true, false, "", fmtCount, func(m madmin.MemSegment) uint64 { return m.WorkingsetRefault }},
+	{"Compaction Stalls", true, false, "", fmtCount, func(m madmin.MemSegment) uint64 { return m.CompactStall }},
+	{"OOM Kills", true, true, "", fmtCount, func(m madmin.MemSegment) uint64 { return m.OOMKill }},
+}
+
+// memSegmentRows renders one segment, or a whole window, as leaf data.
+//
+// Every field is summed over the samples folded in -- N of them, one per node per
+// segment -- so the quotient is a mean per sample and one sample covers one
+// interval. That makes interval the divisor for every rate here even when the
+// whole window is rendered; segments is what turns N back into a node count and
+// scales a counter's total to one node's share of the window.
+func memSegmentRows(seg madmin.MemSegment, interval, segments int, coverage string) map[string]string {
+	if seg.N == 0 {
+		return map[string]string{"Status": "no node reported this time segment"}
+	}
+	n := float64(seg.N)
+	r := newMemRows(1)
+	r.add("Coverage", coverage)
+	r.add("Nodes", formatNodeCount(seg.N, segments)+" reporting")
+
+	total := float64(seg.Used+seg.Free) / n
+	for _, row := range memWindowRows {
+		v := float64(row.value(seg))
+		if v == 0 {
+			continue
+		}
+		if !row.counter {
+			r.add(row.label, fmtBytes(v/n)+" per node"+percentOf(v/n, total))
+			continue
+		}
+		// A counter's window total is one node's share of every segment folded
+		// in; its rate is that spread over the segments it accrued across.
+		value := row.render(v*float64(max(segments, 1))/n) + " per node"
+		if interval > 0 {
+			value += ", " + fmtRate(v/n/float64(interval), row.render, row.unit)
+		}
+		r.add(row.label, value)
+	}
+
+	// Fragmentation carries its own divisor: buddyinfo can be unreadable on a
+	// host whose meminfo is fine, so dividing by N would under-report by the
+	// share of hosts without it.
+	if seg.FragN > 0 && seg.FragFreeBytes > 0 {
+		f := float64(seg.FragN)
+		r.add("Free (Fragmented)", fmtBytes(float64(seg.FragFreeBytes)/f)+" per node, "+
+			fmtPct(float64(seg.FragFreeBytes-seg.FragFreeBytesLarge), float64(seg.FragFreeBytes))+" unusable")
+	}
+	return r.data
+}
+
+// percentOf is the parenthesised share a level carries next to its value.
+func percentOf(v, whole float64) string {
+	if whole <= 0 {
+		return ""
+	}
+	return " (" + fmtPct(v, whole) + ")"
+}
+
+// describeMemSegment renders one segment on a single line, per node.
+func describeMemSegment(seg madmin.MemSegment) string {
+	n := float64(seg.N)
+	var parts []string
+	for _, row := range memWindowRows {
+		v := float64(row.value(seg))
+		if !row.brief || v == 0 {
+			continue
+		}
+		if row.counter {
+			parts = append(parts, row.label+" +"+row.render(v/n))
+			continue
+		}
+		parts = append(parts, row.label+" "+row.render(v/n))
+	}
+	if len(parts) == 0 {
+		return formatNodeCount(seg.N, 1) + ", nothing recorded"
+	}
+	return strings.Join(parts, ", ") + " per node"
+}
+
+// MemLastDayNode is one persisted memory window -- the hour or the day -- as a
+// navigable child per time segment plus an _ALL entry over the whole span.
 type MemLastDayNode struct {
 	segmented *madmin.SegmentedMemMetrics
+	flags     madmin.MetricFlags
+	window    string
 	parent    MetricNode
 	path      string
 }
 
+// NewMemLastDayNode creates a navigator for the last-day memory window.
 func NewMemLastDayNode(segmented *madmin.SegmentedMemMetrics, parent MetricNode, path string) *MemLastDayNode {
-	return &MemLastDayNode{segmented: segmented, parent: parent, path: path}
+	return &MemLastDayNode{
+		segmented: segmented, flags: madmin.MetricsDayStats, window: "day",
+		parent: parent, path: path,
+	}
 }
 
 func (node *MemLastDayNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
 func (node *MemLastDayNode) GetPath() string                    { return node.path }
 func (node *MemLastDayNode) GetParent() MetricNode              { return node.parent }
 func (node *MemLastDayNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
-func (node *MemLastDayNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
+func (node *MemLastDayNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
 func (node *MemLastDayNode) ShouldPauseRefresh() bool           { return true }
-func (node *MemLastDayNode) GetChildren() []MetricChild         { return nil }
 
-func (node *MemLastDayNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("no children")
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *MemLastDayNode) hasSegments() bool {
+	return node.segmented != nil && node.segmented.Interval > 0 && len(node.segmented.Segments) > 0
 }
 
-func (node *MemLastDayNode) GetLeafData() map[string]string {
-	if node.segmented == nil || len(node.segmented.Segments) == 0 {
-		return nil
+func (node *MemLastDayNode) wholeSecs() int {
+	return node.segmented.Interval * len(node.segmented.Segments)
+}
+
+func (node *MemLastDayNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
 	}
-	data := make(map[string]string)
-	idx := 0
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.segmented.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	withDate := windowCrossesDay(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	// Newest first, as every other family lists a window.
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
 		seg := node.segmented.Segments[i]
 		if seg.N == 0 {
 			continue
 		}
-		idx++
-		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := segmentRowKey(idx, startTime, endTime)
-
-		n := uint64(seg.N)
-		perNodeUsed := seg.Used / n
-		perNodeFree := seg.Free / n
-		perNodeTotal := perNodeUsed + perNodeFree
-		pct := float64(0)
-		if perNodeTotal > 0 {
-			pct = float64(perNodeUsed) / float64(perNodeTotal) * 100
+		start := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
 		}
-
-		data[name] = fmt.Sprintf("%s, %d nodes, Used: %s (%.1f%%), Free: %s/node",
-			startTime.Local().Format("15:04"),
-			seg.N,
-			formatMemoryBytes(perNodeUsed), pct,
-			formatMemoryBytes(perNodeFree))
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeMemSegment(seg),
+		})
 	}
-	return data
+	return children
+}
+
+func (node *MemLastDayNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s memory segments available", node.window)
+	}
+	if name == "_ALL" {
+		return &MemTimeSegmentNode{
+			segment:  node.segmented.Total(),
+			interval: node.segmented.Interval,
+			segments: len(node.segmented.Segments),
+			coverage: windowCoverage(node.segmented.FirstTime, node.wholeSecs()),
+			flags:    node.flags, parent: node, path: node.path + "/" + name,
+		}, nil
+	}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	if i, ok := owners[name]; ok {
+		start := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
+		return &MemTimeSegmentNode{
+			segment:  node.segmented.Segments[i],
+			interval: node.segmented.Interval,
+			segments: 1,
+			coverage: windowCoverage(start, node.segmented.Interval),
+			flags:    node.flags, parent: node, path: node.path + "/" + name,
+		}, nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *MemLastDayNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.segmented, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	// The aggregate only: each segment states its own figures in the description
+	// of the child that opens it.
+	return memSegmentRows(node.segmented.Total(), node.segmented.Interval,
+		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
+}
+
+// MemTimeSegmentNode is one segment of a memory window, or the whole window.
+type MemTimeSegmentNode struct {
+	segment  madmin.MemSegment
+	interval int
+	segments int
+	coverage string
+	flags    madmin.MetricFlags
+	parent   MetricNode
+	path     string
+}
+
+func (node *MemTimeSegmentNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *MemTimeSegmentNode) GetPath() string                    { return node.path }
+func (node *MemTimeSegmentNode) GetParent() MetricNode              { return node.parent }
+func (node *MemTimeSegmentNode) GetMetricType() madmin.MetricType   { return madmin.MetricsMem }
+func (node *MemTimeSegmentNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *MemTimeSegmentNode) ShouldPauseRefresh() bool           { return true }
+func (node *MemTimeSegmentNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *MemTimeSegmentNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *MemTimeSegmentNode) GetLeafData() map[string]string {
+	return memSegmentRows(node.segment, node.interval, node.segments, node.coverage)
 }
 
 // MemVMStatNode shows the kernel memory-management counters.

--- a/mnav/os.go
+++ b/mnav/os.go
@@ -153,41 +153,6 @@ func (node *OSMetricsNavigator) GetChild(name string) (MetricNode, error) {
 	}
 }
 
-type OSMetricsNode struct {
-	parent MetricNode
-	path   string
-}
-
-func (node *OSMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *OSMetricsNode) ShouldPauseUpdates() bool {
-	// Legacy method - not used in interface, return false for default behavior
-	return false
-}
-
-func (node *OSMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{
-		{Name: "lifetime_ops", Description: "Accumulated operations since server start"},
-		{Name: "last_minute", Description: "Last minute operation statistics"},
-		{Name: "sensors", Description: "Temperature sensor metrics"},
-	}
-}
-func (node *OSMetricsNode) GetLeafData() map[string]string     { return nil }
-func (node *OSMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsOS }
-func (node *OSMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *OSMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *OSMetricsNode) GetPath() string                    { return node.path }
-
-func (node *OSMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *OSMetricsNode) GetChild(name string) (MetricNode, error) {
-	return nil, fmt.Errorf("os metric sub-navigation not yet implemented for: %s", name)
-}
-
 // OSLifetimeOpsNode handles navigation for OS lifetime operations
 type OSLifetimeOpsNode struct {
 	ops    map[string]uint64

--- a/mnav/process.go
+++ b/mnav/process.go
@@ -60,71 +60,118 @@ func (node *ProcessMetricsNode) GetChildren() []MetricChild {
 	return children
 }
 
+// procUptime is the mean per-process uptime: TotalRunningSecs is now minus each
+// process's start, summed, so Count is what turns it back into one process's.
+//
+// It is the window every cumulative counter in this family is measured over --
+// I/O, faults and switches are all since process start -- and being a mean, it
+// hides a node that restarted while the others stayed up.
+func procUptime(p *madmin.ProcessMetrics) (time.Duration, bool) {
+	if p == nil || p.Count <= 0 || p.TotalRunningSecs <= 0 {
+		return 0, false
+	}
+	return time.Duration(p.TotalRunningSecs / float64(p.Count) * float64(time.Second)), true
+}
+
+// procAncestor walks up to the node holding the whole sample, so a subsection can
+// reach the uptime and process count that its own struct does not carry.
+func procAncestor(n MetricNode) *madmin.ProcessMetrics {
+	for ; n != nil; n = n.GetParent() {
+		if p, ok := n.(*ProcessMetricsNode); ok {
+			return p.process
+		}
+	}
+	return nil
+}
+
+// procRows builds leaf data in display order, dividing every summed value back
+// down to one process.
+//
+// Everything on this wire is a sum over the processes that reported: a 17-node
+// cluster's file-descriptor count is the fleet total, and a bare total answers no
+// question an operator has. count is what makes it per-process, and each
+// subsection carries its own because a node can report memory but not I/O.
+type procRows struct {
+	data  map[string]string
+	n     int
+	count int
+	up    time.Duration
+}
+
+func newProcRows(count int, up time.Duration) *procRows {
+	return &procRows{data: make(map[string]string), count: max(count, 1), up: up}
+}
+
+func (r *procRows) add(label, value string) {
+	r.data[fmt.Sprintf("%02d:%s", r.n, label)] = value
+	r.n++
+}
+
+// total states a summed value as the cluster figure with the per-process mean
+// behind it, and skips a value nobody reported.
+func (r *procRows) total(label string, v float64, render func(float64) string) {
+	if v == 0 {
+		return
+	}
+	r.add(label, render(v)+qualify(r.count, v, 0, render))
+}
+
+// share is total with the value's percentage of a whole, for the breakdowns whose
+// point is the split.
+func (r *procRows) share(label string, v, whole float64, render func(float64) string) {
+	if v == 0 {
+		return
+	}
+	r.add(label, render(v)+qualify(r.count, v, whole, render))
+}
+
+// counter is total with the per-process rate over the uptime, which is the window
+// a value cumulative since process start was accrued over.
+func (r *procRows) counter(label string, v float64, render func(float64) string, unit string) {
+	if v == 0 {
+		return
+	}
+	value := render(v) + qualify(r.count, v, 0, render)
+	if r.up > 0 {
+		value += ", " + fmtRate(v/float64(r.count)/r.up.Seconds(), render, unit)
+	}
+	r.add(label, value)
+}
+
 func (node *ProcessMetricsNode) GetLeafData() map[string]string {
 	if node.process == nil {
 		return map[string]string{"Status": "No process metrics available"}
 	}
+	p := node.process
+	up, hasUp := procUptime(p)
+	r := newProcRows(p.Count, up)
 
-	data := make(map[string]string)
-
-	// Overview
-	data["00:Process Overview"] = fmt.Sprintf("Collected at %s",
-		node.process.CollectedAt.Format("2006-01-02 15:04:05"))
-
-	// Cluster information
-	if node.process.Nodes > 0 {
-		data["Cluster Status"] = fmt.Sprintf("%s nodes reporting", humanize.Comma(int64(node.process.Nodes)))
-		if node.process.Count > 0 {
-			data["Total Processes"] = fmt.Sprintf("%s MinIO processes", humanize.Comma(int64(node.process.Count)))
-		}
+	r.add("Collected At", p.CollectedAt.Format("2006-01-02 15:04:05"))
+	if p.Nodes > 0 {
+		r.add("Nodes", formatNodeCount(p.Nodes, 1))
+	}
+	if p.Count > 0 && p.Count != p.Nodes {
+		r.add("Processes", humanize.Comma(int64(p.Count)))
+	}
+	if hasUp {
+		r.add("Uptime", coverDuration(up)+" (mean per process)")
+	}
+	if p.RunningProcesses > 0 || p.BackgroundProcesses > 0 {
+		r.add("Running / Background", fmt.Sprintf("%d / %d", p.RunningProcesses, p.BackgroundProcesses))
 	}
 
-	// Process status
-	if node.process.RunningProcesses > 0 || node.process.BackgroundProcesses > 0 {
-		data["Running Processes"] = humanize.Comma(int64(node.process.RunningProcesses))
-		data["Background Processes"] = humanize.Comma(int64(node.process.BackgroundProcesses))
-	}
-
-	// Key performance metrics
-	if node.process.TotalCPUPercent > 0 {
-		data["Total CPU Usage"] = fmt.Sprintf("%.2f%% across cluster", node.process.TotalCPUPercent)
-	}
-
-	if node.process.TotalRunningSecs > 0 {
-		uptime := time.Duration(node.process.TotalRunningSecs) * time.Second
-		data["Cumulative Uptime"] = formatDuration(uptime)
-	}
-
-	// Resource utilization
-	if node.process.TotalNumConnections > 0 {
-		data["Network Connections"] = humanize.Comma(int64(node.process.TotalNumConnections))
-	}
-
-	if node.process.TotalNumFDs > 0 {
-		data["File Descriptors"] = humanize.Comma(node.process.TotalNumFDs)
-	}
-
-	if node.process.TotalNumThreads > 0 {
-		data["Total Threads"] = humanize.Comma(node.process.TotalNumThreads)
-	}
-
-	// Memory summary
-	if node.process.MemInfo.RSS > 0 {
-		data["Resident Memory"] = humanize.Bytes(node.process.MemInfo.RSS)
-		if node.process.MemInfo.VMS > 0 {
-			data["Virtual Memory"] = humanize.Bytes(node.process.MemInfo.VMS)
-		}
-	}
-
-	// I/O summary
-	if node.process.IOCounters.ReadBytes > 0 || node.process.IOCounters.WriteBytes > 0 {
-		data["Total Read I/O"] = humanize.Bytes(node.process.IOCounters.ReadBytes)
-		data["Total Write I/O"] = humanize.Bytes(node.process.IOCounters.WriteBytes)
-	}
+	r.total("CPU", p.TotalCPUPercent, func(v float64) string { return fmt.Sprintf("%.1f%%", v) })
+	r.total("Threads", float64(p.TotalNumThreads), fmtCount)
+	r.total("File Descriptors", float64(p.TotalNumFDs), fmtCount)
+	r.total("Connections", float64(p.TotalNumConnections), fmtCount)
+	r.total("Resident", float64(p.MemInfo.RSS), fmtBytes)
+	r.total("Virtual", float64(p.MemInfo.VMS), fmtBytes)
+	r.counter("Read", float64(p.IOCounters.ReadBytes), fmtBytes, "")
+	r.counter("Written", float64(p.IOCounters.WriteBytes), fmtBytes, "")
 
 	// Kernel thread states, busiest first.
-	if len(node.process.ThreadStates) > 0 {
-		data["Thread States"] = formatCountMap(node.process.ThreadStates, 8)
+	if len(p.ThreadStates) > 0 {
+		r.add("Thread States", formatCountMap(p.ThreadStates, 8))
 	}
 
 	// PSI: mean stall across the reporting nodes, with the worst node, so a
@@ -136,8 +183,8 @@ func (node *ProcessMetricsNode) GetLeafData() map[string]string {
 	for _, line := range psiLineOrder {
 		known[line] = true
 	}
-	extra := make([]string, 0, len(node.process.Pressure))
-	for line := range node.process.Pressure {
+	extra := make([]string, 0, len(p.Pressure))
+	for line := range p.Pressure {
 		if !known[line] {
 			extra = append(extra, line)
 		}
@@ -145,7 +192,7 @@ func (node *ProcessMetricsNode) GetLeafData() map[string]string {
 	sort.Strings(extra)
 
 	for _, line := range append(append([]string{}, psiLineOrder...), extra...) {
-		stall, ok := node.process.Pressure[line]
+		stall, ok := p.Pressure[line]
 		if !ok || stall.N == 0 {
 			continue
 		}
@@ -153,21 +200,21 @@ func (node *ProcessMetricsNode) GetLeafData() map[string]string {
 		if !ok {
 			label = line
 		}
-		data["Pressure "+label] = fmt.Sprintf("%.2f%% avg10 (max %.2f%%), %s stalled",
+		r.add("Pressure "+label, fmt.Sprintf("%.2f%% avg10 (max %.2f%%), %s stalled",
 			stall.Avg10Sum/float64(stall.N), stall.Avg10Max,
-			formatDuration(time.Duration(stall.StallUS)*time.Microsecond))
+			fmtSecs(float64(stall.StallUS)/1e6)))
 	}
 
-	if d := node.process.DState; d != nil {
+	if d := p.DState; d != nil {
 		if len(d.DwellBuckets) > 0 {
-			data["Uninterruptible Dwell"] = formatDwellBuckets(d.DwellBuckets, d.WindowSecs)
+			r.add("Uninterruptible Dwell", formatDwellBuckets(d.DwellBuckets, d.WindowSecs))
 		}
 		if len(d.ByWchan) > 0 {
-			data["Uninterruptible By Wchan"] = formatCountMap(d.ByWchan, 5)
+			r.add("Uninterruptible By Wchan", formatCountMap(d.ByWchan, 5))
 		}
 	}
 
-	return data
+	return r.data
 }
 
 // psiLineOrder fixes the display order of PSI lines; psiLineLabels gives each
@@ -296,61 +343,40 @@ func (node *ProcessCPUTimesNode) GetLeafData() map[string]string {
 	if node.cpuTimes == nil {
 		return map[string]string{"Status": "No CPU timing data available"}
 	}
+	c := node.cpuTimes
+	up, _ := procUptime(procAncestor(node))
+	r := newProcRows(c.Count, up)
 
-	data := make(map[string]string)
-
-	if node.cpuTimes.Count > 0 {
-		data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.cpuTimes.Count)
+	total := c.User + c.System + c.Idle + c.Nice + c.Iowait + c.Irq +
+		c.Softirq + c.Steal + c.Guest + c.GuestNice
+	if total == 0 {
+		return map[string]string{"Status": "No CPU time recorded"}
 	}
-
-	// Calculate total time for percentages
-	totalTime := node.cpuTimes.User + node.cpuTimes.System + node.cpuTimes.Idle +
-		node.cpuTimes.Nice + node.cpuTimes.Iowait + node.cpuTimes.Irq +
-		node.cpuTimes.Softirq + node.cpuTimes.Steal + node.cpuTimes.Guest +
-		node.cpuTimes.GuestNice
-
-	if totalTime > 0 {
-		data["00:CPU"] = "Cumulative CPU time across all processes"
-
-		data["User Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-			node.cpuTimes.User, (node.cpuTimes.User/totalTime)*100)
-		data["System Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-			node.cpuTimes.System, (node.cpuTimes.System/totalTime)*100)
-		data["Idle Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-			node.cpuTimes.Idle, (node.cpuTimes.Idle/totalTime)*100)
-
-		// Only show non-zero times
-		if node.cpuTimes.Nice > 0 {
-			data["Nice Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Nice, (node.cpuTimes.Nice/totalTime)*100)
-		}
-		if node.cpuTimes.Iowait > 0 {
-			data["IO Wait Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Iowait, (node.cpuTimes.Iowait/totalTime)*100)
-		}
-		if node.cpuTimes.Irq > 0 {
-			data["IRQ Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Irq, (node.cpuTimes.Irq/totalTime)*100)
-		}
-		if node.cpuTimes.Softirq > 0 {
-			data["Soft IRQ Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Softirq, (node.cpuTimes.Softirq/totalTime)*100)
-		}
-		if node.cpuTimes.Steal > 0 {
-			data["Steal Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Steal, (node.cpuTimes.Steal/totalTime)*100)
-		}
-		if node.cpuTimes.Guest > 0 {
-			data["Guest Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.Guest, (node.cpuTimes.Guest/totalTime)*100)
-		}
-		if node.cpuTimes.GuestNice > 0 {
-			data["Guest Nice Time"] = fmt.Sprintf("%.2f seconds (%.1f%%)",
-				node.cpuTimes.GuestNice, (node.cpuTimes.GuestNice/totalTime)*100)
-		}
+	r.add("Processes", humanize.Comma(int64(max(c.Count, 1))))
+	// Cumulative since process start, so the share of the uptime is what says
+	// how busy a process was; the seconds alone only say how long it has run.
+	if up > 0 {
+		r.add("Busy", fmtPct(total-c.Idle, up.Seconds()*float64(max(c.Count, 1)))+" of one core, per process")
 	}
-
-	return data
+	r.share("Total", total, 0, fmtSecs)
+	for _, row := range []struct {
+		label string
+		v     float64
+	}{
+		{"User", c.User},
+		{"System", c.System},
+		{"Idle", c.Idle},
+		{"Nice", c.Nice},
+		{"IO Wait", c.Iowait},
+		{"IRQ", c.Irq},
+		{"Soft IRQ", c.Softirq},
+		{"Steal", c.Steal},
+		{"Guest", c.Guest},
+		{"Guest Nice", c.GuestNice},
+	} {
+		r.share(row.label, row.v, total, fmtSecs)
+	}
+	return r.data
 }
 
 func (node *ProcessCPUTimesNode) GetChild(_ string) (MetricNode, error) {
@@ -389,44 +415,30 @@ func (node *ProcessMemoryInfoNode) GetLeafData() map[string]string {
 	if node.memInfo == nil {
 		return map[string]string{"Status": "No memory information available"}
 	}
-
-	data := make(map[string]string)
-
-	if node.memInfo.Count > 0 {
-		data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.memInfo.Count)
+	m := node.memInfo
+	r := newProcRows(m.Count, 0)
+	r.add("Processes", humanize.Comma(int64(max(m.Count, 1))))
+	// Resident first: it is the number that decides whether a host is about to
+	// run out. Virtual and the segment breakdown explain its shape.
+	for _, row := range []struct {
+		label string
+		v     uint64
+	}{
+		{"Resident", m.RSS},
+		{"Peak Resident", m.HWM},
+		{"Virtual", m.VMS},
+		{"Data", m.Data},
+		{"Stack", m.Stack},
+		{"Shared", m.Shared},
+		{"Locked", m.Locked},
+		{"Swap", m.Swap},
+	} {
+		r.total(row.label, float64(row.v), fmtBytes)
 	}
-
-	data["00:Memory usage"] = "Cumulative memory usage across all processes"
-
-	// Primary memory metrics
-	if node.memInfo.RSS > 0 {
-		data["Resident Set Size"] = humanize.Bytes(node.memInfo.RSS)
+	if r.n == 1 {
+		return map[string]string{"Status": "No memory usage recorded"}
 	}
-	if node.memInfo.VMS > 0 {
-		data["Virtual Memory Size"] = humanize.Bytes(node.memInfo.VMS)
-	}
-	if node.memInfo.HWM > 0 {
-		data["High Water Mark"] = humanize.Bytes(node.memInfo.HWM)
-	}
-
-	// Detailed memory breakdown
-	if node.memInfo.Data > 0 {
-		data["Data Segment"] = humanize.Bytes(node.memInfo.Data)
-	}
-	if node.memInfo.Stack > 0 {
-		data["Stack Memory"] = humanize.Bytes(node.memInfo.Stack)
-	}
-	if node.memInfo.Shared > 0 {
-		data["Shared Memory"] = humanize.Bytes(node.memInfo.Shared)
-	}
-	if node.memInfo.Locked > 0 {
-		data["Locked Memory"] = humanize.Bytes(node.memInfo.Locked)
-	}
-	if node.memInfo.Swap > 0 {
-		data["Swap Memory"] = humanize.Bytes(node.memInfo.Swap)
-	}
-
-	return data
+	return r.data
 }
 
 func (node *ProcessMemoryInfoNode) GetChild(_ string) (MetricNode, error) {
@@ -465,42 +477,26 @@ func (node *ProcessIOCountersNode) GetLeafData() map[string]string {
 	if node.ioCounters == nil {
 		return map[string]string{"Status": "No I/O statistics available"}
 	}
-
-	data := make(map[string]string)
-
-	if node.ioCounters.Count > 0 {
-		data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.ioCounters.Count)
+	io := node.ioCounters
+	up, _ := procUptime(procAncestor(node))
+	r := newProcRows(io.Count, up)
+	r.add("Processes", humanize.Comma(int64(max(io.Count, 1))))
+	r.counter("Read", float64(io.ReadBytes), fmtBytes, "")
+	r.counter("Written", float64(io.WriteBytes), fmtBytes, "")
+	r.counter("Reads", float64(io.ReadCount), fmtCount, "ops")
+	r.counter("Writes", float64(io.WriteCount), fmtCount, "ops")
+	// Mean request size says whether the load is streaming or metadata-shaped,
+	// which the byte and operation counts only imply separately.
+	if io.ReadCount > 0 && io.ReadBytes > 0 {
+		r.add("Mean Read", fmtBytes(float64(io.ReadBytes)/float64(io.ReadCount)))
 	}
-
-	data["00:I/O"] = "Cumulative I/O operations across all processes"
-
-	// Operation counts
-	if node.ioCounters.ReadCount > 0 {
-		data["Read Operations"] = humanize.Comma(int64(node.ioCounters.ReadCount))
+	if io.WriteCount > 0 && io.WriteBytes > 0 {
+		r.add("Mean Write", fmtBytes(float64(io.WriteBytes)/float64(io.WriteCount)))
 	}
-	if node.ioCounters.WriteCount > 0 {
-		data["Write Operations"] = humanize.Comma(int64(node.ioCounters.WriteCount))
+	if r.n == 1 {
+		return map[string]string{"Status": "No I/O recorded"}
 	}
-
-	// Data transferred
-	if node.ioCounters.ReadBytes > 0 {
-		data["Bytes Read"] = humanize.Bytes(node.ioCounters.ReadBytes)
-	}
-	if node.ioCounters.WriteBytes > 0 {
-		data["Bytes Written"] = humanize.Bytes(node.ioCounters.WriteBytes)
-	}
-
-	// Calculate averages if we have both counts and bytes
-	if node.ioCounters.ReadCount > 0 && node.ioCounters.ReadBytes > 0 {
-		avgReadSize := float64(node.ioCounters.ReadBytes) / float64(node.ioCounters.ReadCount)
-		data["Average Read Size"] = humanize.Bytes(uint64(avgReadSize))
-	}
-	if node.ioCounters.WriteCount > 0 && node.ioCounters.WriteBytes > 0 {
-		avgWriteSize := float64(node.ioCounters.WriteBytes) / float64(node.ioCounters.WriteCount)
-		data["Average Write Size"] = humanize.Bytes(uint64(avgWriteSize))
-	}
-
-	return data
+	return r.data
 }
 
 func (node *ProcessIOCountersNode) GetChild(_ string) (MetricNode, error) {
@@ -539,34 +535,21 @@ func (node *ProcessCtxSwitchesNode) GetLeafData() map[string]string {
 	if node.ctxSwitches == nil {
 		return map[string]string{"Status": "No context switch data available"}
 	}
-
-	data := make(map[string]string)
-
-	if node.ctxSwitches.Count > 0 {
-		data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.ctxSwitches.Count)
+	c := node.ctxSwitches
+	total := c.Voluntary + c.Involuntary
+	if total == 0 {
+		return map[string]string{"Status": "No context switches recorded"}
 	}
-
-	data["00:Context Switches"] = "Cumulative context switches across all processes"
-
-	totalSwitches := node.ctxSwitches.Voluntary + node.ctxSwitches.Involuntary
-
-	if totalSwitches > 0 {
-		data["Total Context Switches"] = humanize.Comma(totalSwitches)
-
-		if node.ctxSwitches.Voluntary > 0 {
-			voluntaryPercent := float64(node.ctxSwitches.Voluntary) / float64(totalSwitches) * 100
-			data["Voluntary Switches"] = fmt.Sprintf("%s (%.1f%%)",
-				humanize.Comma(node.ctxSwitches.Voluntary), voluntaryPercent)
-		}
-
-		if node.ctxSwitches.Involuntary > 0 {
-			involuntaryPercent := float64(node.ctxSwitches.Involuntary) / float64(totalSwitches) * 100
-			data["Involuntary Switches"] = fmt.Sprintf("%s (%.1f%%)",
-				humanize.Comma(node.ctxSwitches.Involuntary), involuntaryPercent)
-		}
-	}
-
-	return data
+	up, _ := procUptime(procAncestor(node))
+	r := newProcRows(c.Count, up)
+	r.add("Processes", humanize.Comma(int64(max(c.Count, 1))))
+	r.counter("Total", float64(total), fmtCount, "")
+	// Voluntary means the thread blocked and gave the CPU up; involuntary means
+	// the scheduler took it away, which is the one that says the box is
+	// oversubscribed.
+	r.share("Voluntary", float64(c.Voluntary), float64(total), fmtCount)
+	r.share("Involuntary", float64(c.Involuntary), float64(total), fmtCount)
+	return r.data
 }
 
 func (node *ProcessCtxSwitchesNode) GetChild(_ string) (MetricNode, error) {
@@ -605,47 +588,23 @@ func (node *ProcessPageFaultsNode) GetLeafData() map[string]string {
 	if node.pageFaults == nil {
 		return map[string]string{"Status": "No page fault data available"}
 	}
-
-	data := make(map[string]string)
-
-	if node.pageFaults.Count > 0 {
-		data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.pageFaults.Count)
+	f := node.pageFaults
+	total := f.MinorFaults + f.MajorFaults
+	if total == 0 {
+		return map[string]string{"Status": "No page faults recorded"}
 	}
-
-	data["00:Page Faults"] = "Cumulative page faults across all processes"
-
-	totalFaults := node.pageFaults.MinorFaults + node.pageFaults.MajorFaults
-	totalChildFaults := node.pageFaults.ChildMinorFaults + node.pageFaults.ChildMajorFaults
-
-	if totalFaults > 0 {
-		data["Total Page Faults"] = humanize.Comma(int64(totalFaults))
-
-		if node.pageFaults.MinorFaults > 0 {
-			minorPercent := float64(node.pageFaults.MinorFaults) / float64(totalFaults) * 100
-			data["Minor Faults"] = fmt.Sprintf("%s (%.1f%%)",
-				humanize.Comma(int64(node.pageFaults.MinorFaults)), minorPercent)
-		}
-
-		if node.pageFaults.MajorFaults > 0 {
-			majorPercent := float64(node.pageFaults.MajorFaults) / float64(totalFaults) * 100
-			data["Major Faults"] = fmt.Sprintf("%s (%.1f%%)",
-				humanize.Comma(int64(node.pageFaults.MajorFaults)), majorPercent)
-		}
+	up, _ := procUptime(procAncestor(node))
+	r := newProcRows(f.Count, up)
+	r.add("Processes", humanize.Comma(int64(max(f.Count, 1))))
+	r.counter("Total", float64(total), fmtCount, "")
+	// A minor fault found the page already in memory; a major one went to disk,
+	// and its rate is what says the host is thrashing.
+	r.share("Minor", float64(f.MinorFaults), float64(total), fmtCount)
+	r.counter("Major", float64(f.MajorFaults), fmtCount, "")
+	if child := f.ChildMinorFaults + f.ChildMajorFaults; child > 0 {
+		r.total("Child Processes", float64(child), fmtCount)
 	}
-
-	if totalChildFaults > 0 {
-		data["Child Process Faults"] = humanize.Comma(int64(totalChildFaults))
-
-		if node.pageFaults.ChildMinorFaults > 0 {
-			data["Child Minor Faults"] = humanize.Comma(int64(node.pageFaults.ChildMinorFaults))
-		}
-
-		if node.pageFaults.ChildMajorFaults > 0 {
-			data["Child Major Faults"] = humanize.Comma(int64(node.pageFaults.ChildMajorFaults))
-		}
-	}
-
-	return data
+	return r.data
 }
 
 func (node *ProcessPageFaultsNode) GetChild(_ string) (MetricNode, error) {
@@ -687,50 +646,29 @@ func (node *ProcessMemoryMapsNode) GetLeafData() map[string]string {
 			"Note":   "Memory mapping details are platform-specific",
 		}
 	}
-
-	data := make(map[string]string)
-	data["Data Sources"] = fmt.Sprintf("%d processes reporting", node.memMaps.Count)
-	data["00:Memory Maps"] = "Memory mapping details (platform-specific)"
-
-	// Total mapping sizes
-	if node.memMaps.TotalSize > 0 {
-		data["Total Map Size"] = humanize.Bytes(node.memMaps.TotalSize)
+	m := node.memMaps
+	r := newProcRows(m.Count, 0)
+	r.add("Processes", humanize.Comma(int64(max(m.Count, 1))))
+	r.total("Mapped", float64(m.TotalSize), fmtBytes)
+	// Against the mapped total, so a row says what share of the address space is
+	// actually backed rather than only how large it is.
+	for _, row := range []struct {
+		label string
+		v     uint64
+	}{
+		{"Resident", m.TotalRSS},
+		{"Proportional", m.TotalPSS},
+		{"Shared Clean", m.TotalSharedClean},
+		{"Shared Dirty", m.TotalSharedDirty},
+		{"Private Clean", m.TotalPrivateClean},
+		{"Private Dirty", m.TotalPrivateDirty},
+		{"Referenced", m.TotalReferenced},
+		{"Anonymous", m.TotalAnonymous},
+		{"Swapped", m.TotalSwap},
+	} {
+		r.share(row.label, float64(row.v), float64(m.TotalSize), fmtBytes)
 	}
-	if node.memMaps.TotalRSS > 0 {
-		data["Total RSS"] = humanize.Bytes(node.memMaps.TotalRSS)
-	}
-	if node.memMaps.TotalPSS > 0 {
-		data["Total PSS"] = humanize.Bytes(node.memMaps.TotalPSS)
-	}
-
-	// Shared memory
-	if node.memMaps.TotalSharedClean > 0 {
-		data["Shared Clean"] = humanize.Bytes(node.memMaps.TotalSharedClean)
-	}
-	if node.memMaps.TotalSharedDirty > 0 {
-		data["Shared Dirty"] = humanize.Bytes(node.memMaps.TotalSharedDirty)
-	}
-
-	// Private memory
-	if node.memMaps.TotalPrivateClean > 0 {
-		data["Private Clean"] = humanize.Bytes(node.memMaps.TotalPrivateClean)
-	}
-	if node.memMaps.TotalPrivateDirty > 0 {
-		data["Private Dirty"] = humanize.Bytes(node.memMaps.TotalPrivateDirty)
-	}
-
-	// Other memory details
-	if node.memMaps.TotalReferenced > 0 {
-		data["Referenced Memory"] = humanize.Bytes(node.memMaps.TotalReferenced)
-	}
-	if node.memMaps.TotalAnonymous > 0 {
-		data["Anonymous Memory"] = humanize.Bytes(node.memMaps.TotalAnonymous)
-	}
-	if node.memMaps.TotalSwap > 0 {
-		data["Swap Memory"] = humanize.Bytes(node.memMaps.TotalSwap)
-	}
-
-	return data
+	return r.data
 }
 
 func (node *ProcessMemoryMapsNode) GetChild(_ string) (MetricNode, error) {
@@ -756,7 +694,8 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%d days, %.1f hours", days, hours)
 }
 
-// ProcessLastDayNode shows last 24h process statistics with time segment navigation
+// ProcessLastDayNode shows the last-day process window: a navigable child per
+// time segment, and an _ALL entry over the whole span.
 type ProcessLastDayNode struct {
 	segmented *madmin.SegmentedProcessMetrics
 	parent    MetricNode
@@ -773,79 +712,72 @@ func (node *ProcessLastDayNode) GetParent() MetricNode              { return nod
 func (node *ProcessLastDayNode) GetMetricType() madmin.MetricType   { return madmin.MetricsProcess }
 func (node *ProcessLastDayNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
 func (node *ProcessLastDayNode) ShouldPauseRefresh() bool           { return true }
-func (node *ProcessLastDayNode) GetLeafData() map[string]string     { return nil }
 
-// segmentOwners maps this node's navigation keys -- segment end instants -- to the
-// slot that owns each.
-func (node *ProcessLastDayNode) segmentOwners() map[string]int {
-	step := time.Duration(node.segmented.Interval) * time.Second
-	return segmentOwners(node.segmented.FirstTime.Add(step), step, len(node.segmented.Segments))
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *ProcessLastDayNode) hasSegments() bool {
+	return node.segmented != nil && node.segmented.Interval > 0 && len(node.segmented.Segments) > 0
+}
+
+// wholeSecs is the span the whole window covers.
+func (node *ProcessLastDayNode) wholeSecs() int {
+	return node.segmented.Interval * len(node.segmented.Segments)
+}
+
+func (node *ProcessLastDayNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.segmented, "day"); status != "" {
+		return map[string]string{"Status": status}
+	}
+	// The aggregate only: each segment states its own figures in the
+	// description of the child that opens it.
+	return processSegmentRows(node.segmented.Total(), node.segmented.Interval,
+		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
 }
 
 func (node *ProcessLastDayNode) GetChildren() []MetricChild {
-	if node.segmented == nil || len(node.segmented.Segments) == 0 {
-		return nil
+	if !node.hasSegments() {
+		return []MetricChild{}
 	}
-
-	var children []MetricChild
-	children = append(children, MetricChild{
-		Name:        "Total",
-		Description: "Aggregated process statistics across all time segments",
-	})
-
-	// A segment is named by the instant it ends here, so the owner map starts one
-	// interval later than the window does.
-	owners := node.segmentOwners()
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.segmented.FirstTime, node.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	withDate := windowCrossesDay(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	// Newest first, as every other family lists a window: the reader is here to
+	// see what just happened, not to read a day from the beginning.
 	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
 		seg := node.segmented.Segments[i]
 		if seg.N == 0 {
 			continue
 		}
-
-		segmentTime := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
-		endTime := segmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		segmentName := segmentKey(endTime)
-		if owners[segmentName] != i {
+		start := segmentStart(node.segmented.FirstTime, node.segmented.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
 			continue
 		}
-
-		avgCPU := seg.CPUPercent / float64(seg.N)
-		avgRSS := seg.RSS / uint64(seg.N)
-		throughput := seg.ReadBytes + seg.WriteBytes
-
-		day := "Today "
-		if segmentTime.Local().Day() != time.Now().Day() {
-			day = "Yesterday "
-		}
-
 		children = append(children, MetricChild{
-			Name: segmentName,
-			Description: fmt.Sprintf("%s%s -> %s: CPU %.1f%%, RSS %s, I/O %s",
-				day,
-				segmentTime.Local().Format("15:04"),
-				endTime.Local().Format("15:04"),
-				avgCPU,
-				humanize.Bytes(avgRSS),
-				humanize.Bytes(throughput)),
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeProcessSegment(seg, node.segmented.Interval),
 		})
 	}
 	return children
 }
 
 func (node *ProcessLastDayNode) GetChild(name string) (MetricNode, error) {
-	if node.segmented == nil {
-		return nil, fmt.Errorf("no segmented data")
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-day process segments available")
 	}
-
-	if name == "Total" {
+	if name == "_ALL" {
 		return &ProcessSegmentTotalNode{
 			segmented: node.segmented,
 			parent:    node,
-			path:      node.path + "/Total",
+			path:      node.path + "/" + name,
 		}, nil
 	}
-
-	if i, ok := node.segmentOwners()[name]; ok {
+	owners := segmentSecOwners(node.segmented.FirstTime, node.segmented.Interval, len(node.segmented.Segments))
+	if i, ok := owners[name]; ok {
 		return &ProcessTimeSegmentNode{
 			segment:     node.segmented.Segments[i],
 			segmentTime: segmentStart(node.segmented.FirstTime, node.segmented.Interval, i),
@@ -854,142 +786,172 @@ func (node *ProcessLastDayNode) GetChild(name string) (MetricNode, error) {
 			path:        node.path + "/" + name,
 		}, nil
 	}
-
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }
 
-// ProcessSegmentTotalNode shows aggregated process statistics across all time segments
+// describeProcessSegment renders one segment on a single line, per process.
+func describeProcessSegment(seg madmin.ProcessSegment, interval int) string {
+	n := float64(seg.N)
+	parts := []string{fmt.Sprintf("CPU %.1f%%", seg.CPUPercent/n)}
+	if seg.RSS > 0 {
+		parts = append(parts, "RSS "+fmtBytes(float64(seg.RSS)/n))
+	}
+	if seg.NumThreads > 0 {
+		parts = append(parts, "threads "+fmtCount(float64(seg.NumThreads)/n))
+	}
+	// I/O is a within-segment sum, not a level, so it earns a rate.
+	if io := seg.ReadBytes + seg.WriteBytes; io > 0 && interval > 0 {
+		parts = append(parts, "I/O "+fmtRate(float64(io)/n/float64(interval), fmtBytes, ""))
+	}
+	return strings.Join(parts, ", ") + " per process"
+}
+
+// processSegmentRows renders one segment, or a whole window, as leaf data.
+//
+// Every field is summed over the samples folded in -- N of them, one per process
+// per sample -- so nothing here is read without dividing by N first.
+//
+// That quotient is a mean over samples, and one sample covers one interval, so
+// interval is the divisor for every rate and utilisation here even when the whole
+// window is being rendered. Handing it the window span instead understated a
+// day's CPU and I/O by the number of segments in it: a 14-segment window read
+// 136% of a core where the segments it was built from each read ~1900%.
+//
+// segments is how many were folded in, so N can be turned back into a count of
+// the processes reporting rather than a count of samples.
+func processSegmentRows(seg madmin.ProcessSegment, interval, segments int, coverage string) map[string]string {
+	if seg.N == 0 {
+		return map[string]string{"Status": "no process reported this time segment"}
+	}
+	n := float64(seg.N)
+	r := newProcRows(1, 0)
+	r.add("Coverage", coverage)
+	r.add("Processes", formatNodeCount(seg.N, segments)+" reporting")
+	r.add("CPU", fmt.Sprintf("%.2f%% per process", seg.CPUPercent/n))
+
+	// CPU seconds, per process per interval, as a share of that interval: one
+	// full core is 100%. The old form divided the cluster-wide sum by the
+	// window, scaling every figure by the number of processes reporting.
+	cpuRow := func(label string, v float64) {
+		if v <= 0 {
+			return
+		}
+		perProc := v / n
+		if interval > 0 {
+			r.add(label, fmt.Sprintf("%s (%s of one core)", fmtSecs(perProc), fmtPct(perProc, float64(interval))))
+			return
+		}
+		r.add(label, fmtSecs(perProc))
+	}
+	for _, row := range []struct {
+		label string
+		v     float64
+	}{
+		{"CPU User", seg.CPUUser},
+		{"CPU System", seg.CPUSystem},
+		{"CPU IO Wait", seg.CPUIowait},
+		{"CPU Nice", seg.CPUNice},
+		{"CPU IRQ", seg.CPUIrq},
+		{"CPU Soft IRQ", seg.CPUSoftirq},
+		{"CPU Steal", seg.CPUSteal},
+		{"CPU Guest", seg.CPUGuest},
+		{"CPU Guest Nice", seg.CPUGuestNice},
+		{"CPU Idle", seg.CPUIdle},
+	} {
+		cpuRow(row.label, row.v)
+	}
+
+	r.add("Resident", fmtBytes(float64(seg.RSS)/n)+" per process")
+	if seg.VMS > 0 {
+		r.add("Virtual", fmtBytes(float64(seg.VMS)/n)+" per process")
+	}
+	r.add("Threads", fmtCount(float64(seg.NumThreads)/n)+" per process")
+	r.add("File Descriptors", fmtCount(float64(seg.NumFDs)/n)+" per process")
+	r.add("Connections", fmtCount(float64(seg.NumConnections)/n)+" per process")
+	if seg.ThreadsD > 0 {
+		r.add("Uninterruptible", fmtCount(float64(seg.ThreadsD)/n)+" threads per process")
+	}
+
+	// I/O and the fault and switch counters accrue inside the window, so they
+	// carry a rate rather than a level.
+	ioRow := func(label string, v float64, render func(float64) string, unit string) {
+		if v <= 0 {
+			return
+		}
+		perProc := v / n
+		value := render(perProc) + " per process"
+		if interval > 0 {
+			value += ", " + fmtRate(perProc/float64(interval), render, unit)
+		}
+		r.add(label, value)
+	}
+	ioRow("Read", float64(seg.ReadBytes), fmtBytes, "")
+	ioRow("Written", float64(seg.WriteBytes), fmtBytes, "")
+	ioRow("Reads", float64(seg.ReadCount), fmtCount, "ops")
+	ioRow("Writes", float64(seg.WriteCount), fmtCount, "ops")
+	ioRow("Ctx Switches (vol)", float64(seg.CtxSwitchesVoluntary), fmtCount, "")
+	ioRow("Ctx Switches (invol)", float64(seg.CtxSwitchesInvoluntary), fmtCount, "")
+	ioRow("Minor Faults", float64(seg.MinorFaults), fmtCount, "")
+	ioRow("Major Faults", float64(seg.MajorFaults), fmtCount, "")
+
+	// PSI is Linux-only and can be missing on a host whose process sample is
+	// present, so it has its own count; dividing by N would under-report by the
+	// share of hosts without it.
+	if seg.PSIN > 0 {
+		psi := float64(seg.PSIN)
+		for _, row := range []struct {
+			label string
+			v     float64
+		}{
+			{"Pressure CPU (some)", seg.PSICPUSome10},
+			{"Pressure I/O (some)", seg.PSIIOSome10},
+			{"Pressure I/O (all)", seg.PSIIOFull10},
+			{"Pressure Memory (some)", seg.PSIMemSome10},
+			{"Pressure Memory (all)", seg.PSIMemFull10},
+		} {
+			if row.v > 0 {
+				r.add(row.label, fmt.Sprintf("%.2f%% avg10", row.v/psi))
+			}
+		}
+	}
+	return r.data
+}
+
+// ProcessSegmentTotalNode is the _ALL entry: the whole window rather than one
+// slot of it.
 type ProcessSegmentTotalNode struct {
 	segmented *madmin.SegmentedProcessMetrics
 	parent    MetricNode
 	path      string
 }
 
-func (node *ProcessSegmentTotalNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *ProcessSegmentTotalNode) GetPath() string                    { return node.path }
-func (node *ProcessSegmentTotalNode) GetParent() MetricNode              { return node.parent }
-func (node *ProcessSegmentTotalNode) GetMetricType() madmin.MetricType   { return madmin.MetricsProcess }
-func (node *ProcessSegmentTotalNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *ProcessSegmentTotalNode) ShouldPauseRefresh() bool           { return false }
-func (node *ProcessSegmentTotalNode) GetChildren() []MetricChild         { return nil }
+func (node *ProcessSegmentTotalNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *ProcessSegmentTotalNode) GetPath() string                  { return node.path }
+func (node *ProcessSegmentTotalNode) GetParent() MetricNode            { return node.parent }
+func (node *ProcessSegmentTotalNode) GetMetricType() madmin.MetricType { return madmin.MetricsProcess }
+
+// GetMetricFlags keeps the day window on the refresh request: without it a tick
+// would drop the very segments this node renders.
+func (node *ProcessSegmentTotalNode) GetMetricFlags() madmin.MetricFlags {
+	return madmin.MetricsDayStats
+}
+func (node *ProcessSegmentTotalNode) ShouldPauseRefresh() bool   { return true }
+func (node *ProcessSegmentTotalNode) GetChildren() []MetricChild { return []MetricChild{} }
 
 func (node *ProcessSegmentTotalNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("total is a leaf node")
+	return nil, fmt.Errorf("no children")
 }
 
 func (node *ProcessSegmentTotalNode) GetLeafData() map[string]string {
 	if node.segmented == nil || len(node.segmented.Segments) == 0 {
-		return nil
+		return map[string]string{"Status": "no last-day process segments available"}
 	}
-
-	total := node.segmented.Total()
-	if total.N == 0 {
-		return map[string]string{"Status": "No data collected"}
-	}
-
-	data := make(map[string]string)
-	n := float64(total.N)
-
-	// Time range
-	firstTime := node.segmented.FirstTime
-	lastSegmentTime := node.segmented.FirstTime.Add(time.Duration((len(node.segmented.Segments)-1)*node.segmented.Interval) * time.Second)
-	endTime := lastSegmentTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-	data["00:Time Range"] = fmt.Sprintf("%s -> %s", firstTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
-
-	// CPU
-	wallTime := float64(len(node.segmented.Segments) * node.segmented.Interval)
-	data["01:CPU Usage"] = fmt.Sprintf("%.2f%% average", total.CPUPercent/n)
-	if total.CPUUser > 0 {
-		data["01a:CPU User"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUUser, (total.CPUUser/wallTime)*100)
-	}
-	if total.CPUSystem > 0 {
-		data["01b:CPU System"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUSystem, (total.CPUSystem/wallTime)*100)
-	}
-	if total.CPUIdle > 0 {
-		data["01c:CPU Idle"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUIdle, (total.CPUIdle/wallTime)*100)
-	}
-	if total.CPUNice > 0 {
-		data["01d:CPU Nice"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUNice, (total.CPUNice/wallTime)*100)
-	}
-	if total.CPUIowait > 0 {
-		data["01e:CPU IOwait"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUIowait, (total.CPUIowait/wallTime)*100)
-	}
-	if total.CPUIrq > 0 {
-		data["01f:CPU IRQ"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUIrq, (total.CPUIrq/wallTime)*100)
-	}
-	if total.CPUSoftirq > 0 {
-		data["01g:CPU SoftIRQ"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUSoftirq, (total.CPUSoftirq/wallTime)*100)
-	}
-	if total.CPUSteal > 0 {
-		data["01h:CPU Steal"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUSteal, (total.CPUSteal/wallTime)*100)
-	}
-	if total.CPUGuest > 0 {
-		data["01i:CPU Guest"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUGuest, (total.CPUGuest/wallTime)*100)
-	}
-	if total.CPUGuestNice > 0 {
-		data["01j:CPU GuestNice"] = fmt.Sprintf("%.1fs (%.1f%% wall)", total.CPUGuestNice, (total.CPUGuestNice/wallTime)*100)
-	}
-
-	// Memory
-	data["02:RSS"] = humanize.Bytes(total.RSS/uint64(total.N)) + " average"
-	data["03:VMS"] = humanize.Bytes(total.VMS/uint64(total.N)) + " average"
-
-	// Threads/FDs/Connections
-	data["04:Threads"] = humanize.Comma(total.NumThreads/int64(total.N)) + " average"
-	data["05:FDs"] = humanize.Comma(total.NumFDs/int64(total.N)) + " average"
-	data["06:Connections"] = humanize.Comma(int64(total.NumConnections/total.N)) + " average"
-
-	// I/O totals
-	data["07:Read Ops"] = humanize.Comma(int64(total.ReadCount))
-	data["08:Write Ops"] = humanize.Comma(int64(total.WriteCount))
-	data["09:Bytes Read"] = humanize.Bytes(total.ReadBytes)
-	data["10:Bytes Written"] = humanize.Bytes(total.WriteBytes)
-
-	// Context switches
-	data["11:Voln Ctx Sw"] = humanize.Comma(total.CtxSwitchesVoluntary)
-	data["12:Involn Ctx Sw"] = humanize.Comma(total.CtxSwitchesInvoluntary)
-
-	// Page faults
-	data["13:Minor Faults"] = humanize.Comma(int64(total.MinorFaults))
-	data["14:Major Faults"] = humanize.Comma(int64(total.MajorFaults))
-
-	// CPU time breakdown (show as percentages of total CPU time)
-	totalCPUTime := total.CPUUser + total.CPUSystem + total.CPUIdle + total.CPUNice +
-		total.CPUIowait + total.CPUIrq + total.CPUSoftirq + total.CPUSteal +
-		total.CPUGuest + total.CPUGuestNice
-	if totalCPUTime > 0 {
-		data["15a:CPU User %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUUser/totalCPUTime)*100)
-		data["15b:CPU System %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUSystem/totalCPUTime)*100)
-		if total.CPUIdle > 0 {
-			data["15c:CPU Idle %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUIdle/totalCPUTime)*100)
-		}
-		if total.CPUNice > 0 {
-			data["15d:CPU Nice %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUNice/totalCPUTime)*100)
-		}
-		if total.CPUIowait > 0 {
-			data["15e:CPU IOwait %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUIowait/totalCPUTime)*100)
-		}
-		if total.CPUIrq > 0 {
-			data["15f:CPU IRQ %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUIrq/totalCPUTime)*100)
-		}
-		if total.CPUSoftirq > 0 {
-			data["15g:CPU SoftIRQ %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUSoftirq/totalCPUTime)*100)
-		}
-		if total.CPUSteal > 0 {
-			data["15h:CPU Steal %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUSteal/totalCPUTime)*100)
-		}
-		if total.CPUGuest > 0 {
-			data["15i:CPU Guest %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUGuest/totalCPUTime)*100)
-		}
-		if total.CPUGuestNice > 0 {
-			data["15j:CPU GuestNice %"] = fmt.Sprintf("%.1f%% of cpu", (total.CPUGuestNice/totalCPUTime)*100)
-		}
-	}
-
-	return data
+	secs := node.segmented.Interval * len(node.segmented.Segments)
+	return processSegmentRows(node.segmented.Total(), node.segmented.Interval,
+		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, secs))
 }
 
-// ProcessTimeSegmentNode shows process statistics for a specific time segment
+// ProcessTimeSegmentNode is one time segment of the window.
 type ProcessTimeSegmentNode struct {
 	segment     madmin.ProcessSegment
 	segmentTime time.Time
@@ -998,120 +960,24 @@ type ProcessTimeSegmentNode struct {
 	path        string
 }
 
-func (node *ProcessTimeSegmentNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *ProcessTimeSegmentNode) GetPath() string                    { return node.path }
-func (node *ProcessTimeSegmentNode) GetParent() MetricNode              { return node.parent }
-func (node *ProcessTimeSegmentNode) GetMetricType() madmin.MetricType   { return madmin.MetricsProcess }
-func (node *ProcessTimeSegmentNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *ProcessTimeSegmentNode) ShouldPauseRefresh() bool           { return false }
-func (node *ProcessTimeSegmentNode) GetChildren() []MetricChild         { return nil }
+func (node *ProcessTimeSegmentNode) GetOpts() madmin.MetricsOptions   { return getNodeOpts(node) }
+func (node *ProcessTimeSegmentNode) GetPath() string                  { return node.path }
+func (node *ProcessTimeSegmentNode) GetParent() MetricNode            { return node.parent }
+func (node *ProcessTimeSegmentNode) GetMetricType() madmin.MetricType { return madmin.MetricsProcess }
+
+// GetMetricFlags keeps the day window on the refresh request, as for the _ALL
+// node above.
+func (node *ProcessTimeSegmentNode) GetMetricFlags() madmin.MetricFlags {
+	return madmin.MetricsDayStats
+}
+func (node *ProcessTimeSegmentNode) ShouldPauseRefresh() bool   { return true }
+func (node *ProcessTimeSegmentNode) GetChildren() []MetricChild { return []MetricChild{} }
 
 func (node *ProcessTimeSegmentNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("time segment is a leaf node")
+	return nil, fmt.Errorf("no children")
 }
 
 func (node *ProcessTimeSegmentNode) GetLeafData() map[string]string {
-	seg := node.segment
-	if seg.N == 0 {
-		return map[string]string{"Status": "No data for this segment"}
-	}
-
-	data := make(map[string]string)
-	n := float64(seg.N)
-
-	// Time range
-	endTime := node.segmentTime.Add(time.Duration(node.interval) * time.Second)
-	data["00:Time Range"] = fmt.Sprintf("%s -> %s", node.segmentTime.Local().Format("15:04"), endTime.Local().Format("15:04"))
-
-	// CPU
-	wallTime := float64(node.interval)
-	data["01:CPU Usage"] = fmt.Sprintf("%.2f%% average", seg.CPUPercent/n)
-	if seg.CPUUser > 0 {
-		data["01a:CPU User"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUUser, (seg.CPUUser/wallTime)*100)
-	}
-	if seg.CPUSystem > 0 {
-		data["01b:CPU System"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUSystem, (seg.CPUSystem/wallTime)*100)
-	}
-	if seg.CPUIdle > 0 {
-		data["01c:CPU Idle"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUIdle, (seg.CPUIdle/wallTime)*100)
-	}
-	if seg.CPUNice > 0 {
-		data["01d:CPU Nice"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUNice, (seg.CPUNice/wallTime)*100)
-	}
-	if seg.CPUIowait > 0 {
-		data["01e:CPU IOwait"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUIowait, (seg.CPUIowait/wallTime)*100)
-	}
-	if seg.CPUIrq > 0 {
-		data["01f:CPU IRQ"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUIrq, (seg.CPUIrq/wallTime)*100)
-	}
-	if seg.CPUSoftirq > 0 {
-		data["01g:CPU SoftIRQ"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUSoftirq, (seg.CPUSoftirq/wallTime)*100)
-	}
-	if seg.CPUSteal > 0 {
-		data["01h:CPU Steal"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUSteal, (seg.CPUSteal/wallTime)*100)
-	}
-	if seg.CPUGuest > 0 {
-		data["01i:CPU Guest"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUGuest, (seg.CPUGuest/wallTime)*100)
-	}
-	if seg.CPUGuestNice > 0 {
-		data["01j:CPU GuestNice"] = fmt.Sprintf("%.1fs (%.1f%% wall)", seg.CPUGuestNice, (seg.CPUGuestNice/wallTime)*100)
-	}
-
-	// Memory
-	data["02:RSS"] = humanize.Bytes(seg.RSS/uint64(seg.N)) + " average"
-	data["03:VMS"] = humanize.Bytes(seg.VMS/uint64(seg.N)) + " average"
-
-	// Threads/FDs/Connections
-	data["04:Threads"] = humanize.Comma(seg.NumThreads/int64(seg.N)) + " average"
-	data["05:FDs"] = humanize.Comma(seg.NumFDs/int64(seg.N)) + " average"
-	data["06:Connections"] = humanize.Comma(int64(seg.NumConnections/seg.N)) + " average"
-
-	// I/O
-	data["07:Read Ops"] = humanize.Comma(int64(seg.ReadCount))
-	data["08:Write Ops"] = humanize.Comma(int64(seg.WriteCount))
-	data["09:Bytes Read"] = humanize.Bytes(seg.ReadBytes)
-	data["10:Bytes Written"] = humanize.Bytes(seg.WriteBytes)
-
-	// Context switches
-	data["11:Voln Ctx Sw"] = humanize.Comma(seg.CtxSwitchesVoluntary)
-	data["12:Involn Ctx Sw"] = humanize.Comma(seg.CtxSwitchesInvoluntary)
-
-	// Page faults
-	data["13:Minor Faults"] = humanize.Comma(int64(seg.MinorFaults))
-	data["14:Major Faults"] = humanize.Comma(int64(seg.MajorFaults))
-
-	// CPU time breakdown
-	totalCPUTime := seg.CPUUser + seg.CPUSystem + seg.CPUIdle + seg.CPUNice +
-		seg.CPUIowait + seg.CPUIrq + seg.CPUSoftirq + seg.CPUSteal +
-		seg.CPUGuest + seg.CPUGuestNice
-	if totalCPUTime > 0 {
-		data["15a:CPU User %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUUser/totalCPUTime)*100)
-		data["15b:CPU System %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUSystem/totalCPUTime)*100)
-		if seg.CPUIdle > 0 {
-			data["15c:CPU Idle %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUIdle/totalCPUTime)*100)
-		}
-		if seg.CPUNice > 0 {
-			data["15d:CPU Nice %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUNice/totalCPUTime)*100)
-		}
-		if seg.CPUIowait > 0 {
-			data["15e:CPU IOwait %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUIowait/totalCPUTime)*100)
-		}
-		if seg.CPUIrq > 0 {
-			data["15f:CPU IRQ %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUIrq/totalCPUTime)*100)
-		}
-		if seg.CPUSoftirq > 0 {
-			data["15g:CPU SoftIRQ %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUSoftirq/totalCPUTime)*100)
-		}
-		if seg.CPUSteal > 0 {
-			data["15h:CPU Steal %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUSteal/totalCPUTime)*100)
-		}
-		if seg.CPUGuest > 0 {
-			data["15i:CPU Guest %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUGuest/totalCPUTime)*100)
-		}
-		if seg.CPUGuestNice > 0 {
-			data["15j:CPU GuestNice %"] = fmt.Sprintf("%.1f%% of cpu", (seg.CPUGuestNice/totalCPUTime)*100)
-		}
-	}
-
-	return data
+	return processSegmentRows(node.segment, node.interval, 1,
+		windowCoverage(node.segmentTime, node.interval))
 }

--- a/mnav/process.go
+++ b/mnav/process.go
@@ -731,7 +731,7 @@ func (node *ProcessLastDayNode) GetLeafData() map[string]string {
 	// The aggregate only: each segment states its own figures in the
 	// description of the child that opens it.
 	return processSegmentRows(node.segmented.Total(), node.segmented.Interval,
-		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
+		reportedProcessSegments(node.segmented), windowCoverage(node.segmented.FirstTime, node.wholeSecs()))
 }
 
 func (node *ProcessLastDayNode) GetChildren() []MetricChild {
@@ -806,6 +806,19 @@ func describeProcessSegment(seg madmin.ProcessSegment, interval int) string {
 	return strings.Join(parts, ", ") + " per process"
 }
 
+// reportedProcessSegments counts the slots that carry a sample. A window's slots
+// are not all populated -- a restart, a startup or a node joining late leaves
+// gaps -- and nothing accrued in those.
+func reportedProcessSegments(s *madmin.SegmentedProcessMetrics) int {
+	var n int
+	for i := range s.Segments {
+		if s.Segments[i].N > 0 {
+			n++
+		}
+	}
+	return n
+}
+
 // processSegmentRows renders one segment, or a whole window, as leaf data.
 //
 // Every field is summed over the samples folded in -- N of them, one per process
@@ -817,8 +830,10 @@ func describeProcessSegment(seg madmin.ProcessSegment, interval int) string {
 // day's CPU and I/O by the number of segments in it: a 14-segment window read
 // 136% of a core where the segments it was built from each read ~1900%.
 //
-// segments is how many were folded in, so N can be turned back into a count of
-// the processes reporting rather than a count of samples.
+// segments is how many of them carried a sample, not how many slots the window
+// holds: counters only accrue where something reported, so scaling by the empty
+// slots too would invent activity for a restart or a startup gap. It is also what
+// turns N back into a count of the processes reporting rather than of samples.
 func processSegmentRows(seg madmin.ProcessSegment, interval, segments int, coverage string) map[string]string {
 	if seg.N == 0 {
 		return map[string]string{"Status": "no process reported this time segment"}
@@ -952,7 +967,7 @@ func (node *ProcessSegmentTotalNode) GetLeafData() map[string]string {
 	}
 	secs := node.segmented.Interval * len(node.segmented.Segments)
 	return processSegmentRows(node.segmented.Total(), node.segmented.Interval,
-		len(node.segmented.Segments), windowCoverage(node.segmented.FirstTime, secs))
+		reportedProcessSegments(node.segmented), windowCoverage(node.segmented.FirstTime, secs))
 }
 
 // ProcessTimeSegmentNode is one time segment of the window.

--- a/mnav/process.go
+++ b/mnav/process.go
@@ -113,7 +113,7 @@ func (r *procRows) total(label string, v float64, render func(float64) string) {
 	if v == 0 {
 		return
 	}
-	r.add(label, render(v)+qualify(r.count, v, 0, render))
+	r.add(label, render(v)+qualify(r.count, "process", v, 0, render))
 }
 
 // share is total with the value's percentage of a whole, for the breakdowns whose
@@ -122,7 +122,7 @@ func (r *procRows) share(label string, v, whole float64, render func(float64) st
 	if v == 0 {
 		return
 	}
-	r.add(label, render(v)+qualify(r.count, v, whole, render))
+	r.add(label, render(v)+qualify(r.count, "process", v, whole, render))
 }
 
 // counter is total with the per-process rate over the uptime, which is the window
@@ -131,7 +131,7 @@ func (r *procRows) counter(label string, v float64, render func(float64) string,
 	if v == 0 {
 		return
 	}
-	value := render(v) + qualify(r.count, v, 0, render)
+	value := render(v) + qualify(r.count, "process", v, 0, render)
 	if r.up > 0 {
 		value += ", " + fmtRate(v/float64(r.count)/r.up.Seconds(), render, unit)
 	}

--- a/mnav/process.go
+++ b/mnav/process.go
@@ -836,12 +836,16 @@ func processSegmentRows(seg madmin.ProcessSegment, interval, segments int, cover
 		if v <= 0 {
 			return
 		}
+		// v/n is one process's figure for one segment; the window's is that
+		// times the segments folded in. The share is the same either way, since
+		// both sides scale together.
 		perProc := v / n
 		if interval > 0 {
-			r.add(label, fmt.Sprintf("%s (%s of one core)", fmtSecs(perProc), fmtPct(perProc, float64(interval))))
+			r.add(label, fmt.Sprintf("%s (%s of one core)",
+				fmtSecs(perProc*float64(segments)), fmtPct(perProc, float64(interval))))
 			return
 		}
-		r.add(label, fmtSecs(perProc))
+		r.add(label, fmtSecs(perProc*float64(segments)))
 	}
 	for _, row := range []struct {
 		label string
@@ -879,7 +883,7 @@ func processSegmentRows(seg madmin.ProcessSegment, interval, segments int, cover
 			return
 		}
 		perProc := v / n
-		value := render(perProc) + " per process"
+		value := render(perProc*float64(segments)) + " per process"
 		if interval > 0 {
 			value += ", " + fmtRate(perProc/float64(interval), render, unit)
 		}

--- a/mnav/process_test.go
+++ b/mnav/process_test.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// Every process value on the wire is a sum over the processes that reported, so
+// the fleet figure alone answers nothing: "File Descriptors 38,102" across 17
+// nodes is 2,241 each, and only the second number is comparable to a limit.
+func TestProcessValuesCarryPerNodeMean(t *testing.T) {
+	const nodes = 17
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+			Nodes: nodes, Count: nodes,
+			// An hour of uptime each: the window every counter below is over.
+			TotalRunningSecs: 3600 * nodes,
+			TotalCPUPercent:  8.4 * nodes,
+			TotalNumThreads:  248 * nodes,
+			TotalNumFDs:      2241 * nodes,
+			MemInfo:          madmin.ProcessMemoryInfo{RSS: 2 << 30 * nodes, Count: nodes},
+			IOCounters: madmin.ProcessIOCounters{
+				ReadBytes: 3_600_000_000 * nodes, Count: nodes,
+			},
+		}},
+	})
+	node, err := nav.Navigate("process")
+	if err != nil {
+		t.Fatalf("navigate process: %v", err)
+	}
+	data := node.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"Nodes", "17 node(s)"},
+		{"Uptime", "1h (mean per process)"},
+		{"CPU", "142.8% (8.4%/node)"},
+		{"Threads", "4,216 (248/node)"},
+		{"File Descriptors", "38,097 (2,241/node)"},
+		{"Resident", "36 GB (2.1 GB/node)"},
+		// Cumulative since process start, so it carries the rate over the uptime.
+		{"Read", "61 GB (3.6 GB/node), 1.0 MB/s"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+
+	// The old rows either stated a cluster sum as if it were one process's, or
+	// said nothing at all.
+	for _, gone := range []string{"Cumulative Uptime", "Total Read I/O", "Cluster Status", "Process Overview"} {
+		if got := leafValue(data, gone); got != "" {
+			t.Errorf("%s = %q, want it dropped", gone, got)
+		}
+	}
+}
+
+// A subsection reaches the uptime through its parent, since its own struct does
+// not carry one, and without it a cumulative counter has no window to divide by.
+func TestProcessSubsectionRatesUseParentUptime(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+			Nodes: 4, Count: 4, TotalRunningSecs: 3600 * 4,
+			IOCounters: madmin.ProcessIOCounters{
+				ReadBytes: 3_600_000_000 * 4, ReadCount: 36000 * 4, Count: 4,
+			},
+		}},
+	})
+	node, err := nav.Navigate("process/io")
+	if err != nil {
+		t.Fatalf("navigate io: %v", err)
+	}
+	data := node.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"Read", "14 GB (3.6 GB/node), 1.0 MB/s"},
+		{"Reads", "144,000 (36,000/node), 10 ops/s"},
+		{"Mean Read", "100 kB"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+}
+
+// A segment's CPU seconds are summed over its samples -- one per process per
+// tick -- so the utilisation is the per-process figure over the wall clock. The
+// old form divided the whole sum by the window, scaling every percentage by the
+// number of processes reporting.
+func TestProcessSegmentCPUShareIsPerProcess(t *testing.T) {
+	seg := madmin.ProcessSegment{
+		N: 4, CPUPercent: 4 * 25, CPUUser: 200, RSS: 4 << 30,
+		NumThreads: 4 * 100, ReadBytes: 4 * 900_000_000,
+	}
+	data := processSegmentRows(seg, 900, 1, "Covering 15m, until X.")
+	for _, want := range []struct{ label, value string }{
+		{"CPU", "25.00% per process"},
+		// 200s over four processes is 50s each, and 50s of a 900s segment is
+		// 5.56% of one core -- not the 22.2% the whole sum would give.
+		{"CPU User", "50s (5.56% of one core)"},
+		{"Resident", "1.1 GB per process"},
+		{"Threads", "100 per process"},
+		{"Read", "900 MB per process, 1.0 MB/s"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+}
+
+// The window lists an _ALL summary and a navigable child per segment, newest
+// first and keyed by segment start like every other family, and every node in it keeps asking for
+// the day window -- without the flag a refresh drops what it renders.
+func TestProcessWindowNavigation(t *testing.T) {
+	segs := make([]madmin.ProcessSegment, 3)
+	for i := range segs {
+		segs[i] = madmin.ProcessSegment{
+			N: 2, CPUPercent: 2 * float64(10+i*5), RSS: 2 << 30, NumThreads: 2 * 90,
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+			Nodes: 2, Count: 2,
+			LastDay: &madmin.SegmentedProcessMetrics{
+				Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+			},
+		}},
+	})
+
+	day, err := nav.Navigate("process/last_day")
+	if err != nil {
+		t.Fatalf("navigate last_day: %v", err)
+	}
+	// Newest first, behind _ALL, the way every family lists a window.
+	got := childNames(day.GetChildren())
+	want := []string{"_ALL", "10:30Z", "10:15Z", "10:00Z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	if desc := childDesc(day.GetChildren(), "10:15Z"); !strings.Contains(desc, "CPU 15.0%") {
+		t.Errorf("segment description = %q, want the segment's own CPU in it", desc)
+	}
+
+	for _, path := range []string{"process/last_day", "process/last_day/_ALL", "process/last_day/10:30Z"} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		if flags := node.GetMetricFlags(); flags != madmin.MetricsDayStats {
+			t.Errorf("%s flags = %v, want MetricsDayStats", path, flags)
+		}
+		if !node.ShouldPauseRefresh() {
+			t.Errorf("%s refreshes while being read, want it paused", path)
+		}
+		if got := leafValue(node.GetLeafData(), "Coverage"); !strings.HasPrefix(got, "Covering ") {
+			t.Errorf("%s Coverage = %q, want a coverage statement", path, got)
+		}
+	}
+
+	// The whole window averages its segments rather than summing them.
+	all, err := nav.Navigate("process/last_day/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	if got, want := leafValue(all.GetLeafData(), "CPU"), "15.00% per process"; got != want {
+		t.Errorf("_ALL CPU = %q, want %q", got, want)
+	}
+}
+
+// Every value here is a mean over samples, and one sample covers one interval,
+// so a window summary must land on the same figures as the segments it was built
+// from -- not on those divided by the number of segments.
+//
+// The window used to be handed its whole span as the divisor, which read a
+// 14-segment day at 136% of a core where every segment in it read 1900%.
+func TestProcessWindowAgreesWithItsSegments(t *testing.T) {
+	const nodes, count = 17, 14
+	segs := make([]madmin.ProcessSegment, count)
+	for i := range segs {
+		segs[i] = madmin.ProcessSegment{
+			N: nodes, CPUPercent: nodes * 1900, RSS: nodes * (2 << 30),
+			CPUUser: nodes * 200, ReadBytes: nodes * 900_000_000,
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+			Nodes: nodes, Count: nodes,
+			LastDay: &madmin.SegmentedProcessMetrics{
+				Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+			},
+		}},
+	})
+
+	all, err := nav.Navigate("process/last_day/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	one, err := nav.Navigate("process/last_day/" + dupKey)
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	allData, oneData := all.GetLeafData(), one.GetLeafData()
+	for _, label := range []string{"CPU", "CPU User", "Resident", "Read"} {
+		got, want := leafValue(allData, label), leafValue(oneData, label)
+		if want == "" {
+			t.Fatalf("segment has no %s row to compare against", label)
+		}
+		if got != want {
+			t.Errorf("_ALL %s = %q, want %q -- the same as every segment it folded",
+				label, got, want)
+		}
+	}
+	// 200 CPU-seconds of a 900-second interval is 22.22% of one core, and the
+	// window covers the same ground however many segments it holds.
+	if got, want := leafValue(allData, "CPU User"), "3m20s (22.2% of one core)"; got != want {
+		t.Errorf("CPU User = %q, want %q", got, want)
+	}
+	// N counts samples, so the whole window carries one per process per segment;
+	// only dividing that back down gives a process count.
+	if got, want := leafValue(allData, "Processes"), "17 node(s) reporting"; got != want {
+		t.Errorf("Processes = %q, want %q: N over the window is %d", got, want, nodes*count)
+	}
+}
+
+// memNav builds a navigator over one merged memory sample. Values are given per
+// node and summed here, the way MemInfo.Merge leaves them.
+func memNav(nodes int, info madmin.MemInfo, day *madmin.SegmentedMemMetrics) MetricNavigator {
+	scaled := madmin.MemInfo{
+		Total: info.Total * uint64(nodes), Used: info.Used * uint64(nodes),
+		Free: info.Free * uint64(nodes), Available: info.Available * uint64(nodes),
+		Cache: info.Cache * uint64(nodes), Buffers: info.Buffers * uint64(nodes),
+		Shared: info.Shared * uint64(nodes), Limit: info.Limit * uint64(nodes),
+		SwapSpaceTotal: info.SwapSpaceTotal * uint64(nodes),
+		SwapSpaceFree:  info.SwapSpaceFree * uint64(nodes),
+	}
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Mem: &madmin.MemMetrics{
+			Nodes: nodes, Info: scaled, LastDay: day,
+		}},
+	})
+}
+
+// MemInfo.Merge sums every field, so the top page used to report a cluster's
+// worth of RAM with one "Avg per Node" row bolted on and nothing per-node on any
+// of the others.
+func TestMemValuesCarryPerNodeMean(t *testing.T) {
+	nav := memNav(17, madmin.MemInfo{
+		Total: 128 << 30, Used: 94 << 30, Free: 6 << 30, Available: 34 << 30,
+		Cache: 28 << 30, SwapSpaceTotal: 2 << 30, SwapSpaceFree: 2 << 30,
+	}, nil)
+	node, err := nav.Navigate("mem")
+	if err != nil {
+		t.Fatalf("navigate mem: %v", err)
+	}
+	data := node.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"Nodes", "17 node(s)"},
+		{"Total", "2.3 TB (137 GB/node)"},
+		{"Used", "1.7 TB (101 GB/node, 73.4%)"},
+		{"Available", "621 GB (36 GB/node, 26.6%)"},
+		{"Cache", "511 GB (30 GB/node, 21.9%)"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+	// Rows that restated the node count, or offered advice instead of a
+	// measurement.
+	for _, gone := range []string{"Total Memory", "Avg per Node", "Avg Used", "Efficiency", "Pressure"} {
+		if got := leafValue(data, gone); got != "" {
+			t.Errorf("%s = %q, want it dropped", gone, got)
+		}
+	}
+}
+
+// The window was a flat list of rows with nothing to open, and never surfaced the
+// vmstat deltas the wire already carries per segment.
+func TestMemWindowNavigation(t *testing.T) {
+	const nodes, count = 4, 3
+	segs := make([]madmin.MemSegment, count)
+	for i := range segs {
+		segs[i] = madmin.MemSegment{
+			N: nodes, Used: nodes * (90 << 30), Free: nodes * (10 << 30),
+			Available: nodes * (30 << 30),
+			// 1800 major faults a segment, per node: 2/s over 900s.
+			MajorFaults: nodes * 1800, OOMKill: nodes * 1,
+		}
+	}
+	nav := memNav(nodes, madmin.MemInfo{Total: 100 << 30}, &madmin.SegmentedMemMetrics{
+		Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+	})
+
+	day, err := nav.Navigate("mem/last_day")
+	if err != nil {
+		t.Fatalf("navigate last_day: %v", err)
+	}
+	got := childNames(day.GetChildren())
+	want := []string{"_ALL", "10:30Z", "10:15Z", "10:00Z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("children = %v, want %v", got, want)
+	}
+	if desc := childDesc(day.GetChildren(), "10:15Z"); !strings.Contains(desc, "Major Faults +1,800") {
+		t.Errorf("segment description = %q, want the segment's own faults in it", desc)
+	}
+
+	// A gauge is a level, so the window mean equals each identical segment's.
+	// A counter is a per-segment delta, so its window total is the sum while its
+	// rate stays the segments' own.
+	all, err := nav.Navigate("mem/last_day/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	one, err := nav.Navigate("mem/last_day/" + dupKey)
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	allData, oneData := all.GetLeafData(), one.GetLeafData()
+	if got, want := leafValue(allData, "Used"), leafValue(oneData, "Used"); got != want {
+		t.Errorf("_ALL Used = %q, want %q -- a level, not a sum", got, want)
+	}
+	if got, want := leafValue(allData, "Nodes"), "4 node(s) reporting"; got != want {
+		t.Errorf("_ALL Nodes = %q, want %q: N over the window is %d", got, want, nodes*count)
+	}
+	if got, want := leafValue(oneData, "Major Faults"), "1,800 per node, 2.0/s"; got != want {
+		t.Errorf("segment Major Faults = %q, want %q", got, want)
+	}
+	if got, want := leafValue(allData, "Major Faults"), "5,400 per node, 2.0/s"; got != want {
+		t.Errorf("_ALL Major Faults = %q, want %q: three segments of 1,800 at the same rate", got, want)
+	}
+}

--- a/mnav/process_test.go
+++ b/mnav/process_test.go
@@ -27,8 +27,12 @@ import (
 
 // Every process value on the wire is a sum over the processes that reported, so
 // the fleet figure alone answers nothing: "File Descriptors 38,102" across 17
-// nodes is 2,241 each, and only the second number is comparable to a limit.
-func TestProcessValuesCarryPerNodeMean(t *testing.T) {
+// processes is 2,241 each, and only the second number is comparable to a limit.
+//
+// The divisor is Count, so the mean is labelled per process rather than per node.
+// The two are equal on a normal deployment and the section states both, but a
+// host running more than one server would make "/node" a lie.
+func TestProcessValuesCarryPerProcessMean(t *testing.T) {
 	const nodes = 17
 	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
 		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
@@ -52,12 +56,12 @@ func TestProcessValuesCarryPerNodeMean(t *testing.T) {
 	for _, want := range []struct{ label, value string }{
 		{"Nodes", "17 node(s)"},
 		{"Uptime", "1h (mean per process)"},
-		{"CPU", "142.8% (8.4%/node)"},
-		{"Threads", "4,216 (248/node)"},
-		{"File Descriptors", "38,097 (2,241/node)"},
-		{"Resident", "36 GB (2.1 GB/node)"},
+		{"CPU", "142.8% (8.4%/process)"},
+		{"Threads", "4,216 (248/process)"},
+		{"File Descriptors", "38,097 (2,241/process)"},
+		{"Resident", "36 GB (2.1 GB/process)"},
 		// Cumulative since process start, so it carries the rate over the uptime.
-		{"Read", "61 GB (3.6 GB/node), 1.0 MB/s"},
+		{"Read", "61 GB (3.6 GB/process), 1.0 MB/s"},
 	} {
 		if got := leafValue(data, want.label); got != want.value {
 			t.Errorf("%s = %q, want %q", want.label, got, want.value)
@@ -90,8 +94,8 @@ func TestProcessSubsectionRatesUseParentUptime(t *testing.T) {
 	}
 	data := node.GetLeafData()
 	for _, want := range []struct{ label, value string }{
-		{"Read", "14 GB (3.6 GB/node), 1.0 MB/s"},
-		{"Reads", "144,000 (36,000/node), 10 ops/s"},
+		{"Read", "14 GB (3.6 GB/process), 1.0 MB/s"},
+		{"Reads", "144,000 (36,000/process), 10 ops/s"},
 		{"Mean Read", "100 kB"},
 	} {
 		if got := leafValue(data, want.label); got != want.value {

--- a/mnav/process_test.go
+++ b/mnav/process_test.go
@@ -188,13 +188,14 @@ func TestProcessWindowNavigation(t *testing.T) {
 	}
 }
 
-// Every value here is a mean over samples, and one sample covers one interval,
-// so a window summary must land on the same figures as the segments it was built
-// from -- not on those divided by the number of segments.
+// A gauge is a level, so a window summary equals the segments it folded. A
+// counter is each segment's own increase, so its window total is their sum while
+// its rate stays the segments' own -- one sample covers one interval however many
+// were folded in.
 //
-// The window used to be handed its whole span as the divisor, which read a
+// The window used to be handed its whole span as the rate divisor, reading a
 // 14-segment day at 136% of a core where every segment in it read 1900%.
-func TestProcessWindowAgreesWithItsSegments(t *testing.T) {
+func TestProcessWindowFoldsGaugesAndCountersApart(t *testing.T) {
 	const nodes, count = 17, 14
 	segs := make([]madmin.ProcessSegment, count)
 	for i := range segs {
@@ -221,21 +222,32 @@ func TestProcessWindowAgreesWithItsSegments(t *testing.T) {
 		t.Fatalf("navigate segment: %v", err)
 	}
 	allData, oneData := all.GetLeafData(), one.GetLeafData()
-	for _, label := range []string{"CPU", "CPU User", "Resident", "Read"} {
+
+	for _, label := range []string{"CPU", "Resident", "Threads"} {
 		got, want := leafValue(allData, label), leafValue(oneData, label)
 		if want == "" {
 			t.Fatalf("segment has no %s row to compare against", label)
 		}
 		if got != want {
-			t.Errorf("_ALL %s = %q, want %q -- the same as every segment it folded",
-				label, got, want)
+			t.Errorf("_ALL %s = %q, want %q -- a level, not a sum", label, got, want)
 		}
 	}
-	// 200 CPU-seconds of a 900-second interval is 22.22% of one core, and the
-	// window covers the same ground however many segments it holds.
-	if got, want := leafValue(allData, "CPU User"), "3m20s (22.2% of one core)"; got != want {
-		t.Errorf("CPU User = %q, want %q", got, want)
+
+	// 200 CPU-seconds of a 900-second interval is 22.2% of one core, and
+	// fourteen of them are 46m40s across the window.
+	for _, w := range []struct{ label, seg, all string }{
+		{"CPU User", "3m20s (22.2% of one core)", "46m40s (22.2% of one core)"},
+		{"Read", "900 MB per process, 1.0 MB/s", "13 GB per process, 1.0 MB/s"},
+	} {
+		if got := leafValue(oneData, w.label); got != w.seg {
+			t.Errorf("segment %s = %q, want %q", w.label, got, w.seg)
+		}
+		if got := leafValue(allData, w.label); got != w.all {
+			t.Errorf("_ALL %s = %q, want %q -- the sum of %d segments at the segments' own rate",
+				w.label, got, w.all, count)
+		}
 	}
+
 	// N counts samples, so the whole window carries one per process per segment;
 	// only dividing that back down gives a process count.
 	if got, want := leafValue(allData, "Processes"), "17 node(s) reporting"; got != want {
@@ -347,5 +359,82 @@ func TestMemWindowNavigation(t *testing.T) {
 	}
 	if got, want := leafValue(allData, "Major Faults"), "5,400 per node, 2.0/s"; got != want {
 		t.Errorf("_ALL Major Faults = %q, want %q: three segments of 1,800 at the same rate", got, want)
+	}
+}
+
+// The five process subsections and the four memory ones that no test reached.
+// The CPU busy share, the mapped-memory breakdown, the voluntary/involuntary
+// split, the swap ratio and the cgroup headroom are all derived here and nowhere
+// else.
+func TestProcessSubsectionsRenderDerivedRows(t *testing.T) {
+	const n = 4
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+			Nodes: n, Count: n, TotalRunningSecs: 3600 * n,
+			CPUTimes: madmin.ProcessCPUTimes{
+				Count: n, User: 720 * n, System: 180 * n, Idle: 100 * n,
+			},
+			MemInfo: madmin.ProcessMemoryInfo{
+				Count: n, RSS: 2 << 30 * n, VMS: 8 << 30 * n, HWM: 3 << 30 * n,
+			},
+			NumCtxSwitches: madmin.ProcessCtxSwitches{
+				Count: n, Voluntary: 7500 * n, Involuntary: 2500 * n,
+			},
+			PageFaults: madmin.ProcessPageFaults{
+				Count: n, MinorFaults: 99000 * n, MajorFaults: 1000 * n,
+			},
+			MemMaps: madmin.ProcessMemoryMaps{
+				Count: n, TotalSize: 10 << 30 * n, TotalRSS: 2 << 30 * n,
+				TotalPrivateDirty: 1 << 30 * n,
+			},
+		}},
+	})
+	for _, tc := range []struct{ path, label, want string }{
+		// 900 CPU-seconds of the 3600 the process has been up, per process.
+		{"process/cpu", "Busy", "25.0% of one core, per process"},
+		{"process/cpu", "User", "48m0s (12m0s/process, 72.0%)"},
+		{"process/memory", "Resident", "8.6 GB (2.1 GB/process)"},
+		{"process/memory", "Peak Resident", "13 GB (3.2 GB/process)"},
+		{"process/context_switches", "Voluntary", "30,000 (7,500/process, 75.0%)"},
+		{"process/context_switches", "Involuntary", "10,000 (2,500/process, 25.0%)"},
+		{"process/page_faults", "Minor", "396,000 (99,000/process, 99.0%)"},
+		{"process/page_faults", "Major", "4,000 (1,000/process), 16/min"},
+		{"process/mem_maps", "Mapped", "43 GB (11 GB/process)"},
+		{"process/mem_maps", "Resident", "8.6 GB (2.1 GB/process, 20.0%)"},
+		{"process/mem_maps", "Private Dirty", "4.3 GB (1.1 GB/process, 10.0%)"},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := leafValue(node.GetLeafData(), tc.label); got != tc.want {
+			t.Errorf("%s %s = %q, want %q", tc.path, tc.label, got, tc.want)
+		}
+	}
+}
+
+func TestMemSubsectionsRenderDerivedRows(t *testing.T) {
+	nav := memNav(8, madmin.MemInfo{
+		Total: 100 << 30, Used: 70 << 30, Free: 10 << 30, Available: 30 << 30,
+		Cache: 18 << 30, Buffers: 2 << 30, Shared: 1 << 30,
+		Limit: 80 << 30, SwapSpaceTotal: 50 << 30, SwapSpaceFree: 40 << 30,
+	}, nil)
+	for _, tc := range []struct{ path, label, want string }{
+		{"mem/usage", "Available", "258 GB (32 GB/node, 30.0%)"},
+		{"mem/usage", "Cache", "155 GB (19 GB/node, 18.0%)"},
+		// Cache plus buffers is what the kernel hands back under pressure.
+		{"mem/system", "Reclaimable", "172 GB (22 GB/node, 20.0%)"},
+		{"mem/swap", "Used", "86 GB (11 GB/node, 20.0%)"},
+		{"mem/swap", "Swap : RAM", "0.50 : 1"},
+		{"mem/limits", "Limit", "687 GB (86 GB/node, 80.0%)"},
+		{"mem/limits", "Headroom", "86 GB (11 GB/node, 12.5%)"},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := leafValue(node.GetLeafData(), tc.label); got != tc.want {
+			t.Errorf("%s %s = %q, want %q", tc.path, tc.label, got, tc.want)
+		}
 	}
 }

--- a/mnav/process_test.go
+++ b/mnav/process_test.go
@@ -438,3 +438,66 @@ func TestMemSubsectionsRenderDerivedRows(t *testing.T) {
 		}
 	}
 }
+
+// A window's slots are not all populated -- a restart, a startup or a node
+// joining late leaves gaps -- and nothing accrued in the empty ones. Scaling the
+// combined average by every slot invents activity that was never observed, and
+// dividing N by every slot under-reports who was there.
+func TestWindowTotalsSkipUnreportedSegments(t *testing.T) {
+	const nodes = 2
+
+	t.Run("process", func(t *testing.T) {
+		// Two slots, one sample: 900 MB read and 200 CPU-seconds per process.
+		segs := []madmin.ProcessSegment{
+			{N: nodes, CPUPercent: nodes * 25, CPUUser: nodes * 200, ReadBytes: nodes * 900_000_000},
+			{},
+		}
+		nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+			Aggregated: madmin.Metrics{Process: &madmin.ProcessMetrics{
+				Nodes: nodes, Count: nodes,
+				LastDay: &madmin.SegmentedProcessMetrics{
+					Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+				},
+			}},
+		})
+		all, err := nav.Navigate("process/last_day/_ALL")
+		if err != nil {
+			t.Fatalf("navigate _ALL: %v", err)
+		}
+		data := all.GetLeafData()
+		for _, w := range []struct{ label, want string }{
+			{"Read", "900 MB per process, 1.0 MB/s"},
+			{"CPU User", "3m20s (22.2% of one core)"},
+			{"Processes", "2 node(s) reporting"},
+		} {
+			if got := leafValue(data, w.label); got != w.want {
+				t.Errorf("%s = %q, want %q: only one of the two slots reported",
+					w.label, got, w.want)
+			}
+		}
+	})
+
+	t.Run("mem", func(t *testing.T) {
+		segs := []madmin.MemSegment{
+			{N: nodes, Used: nodes * (90 << 30), Free: nodes * (10 << 30), MajorFaults: nodes * 1800},
+			{},
+		}
+		nav := memNav(nodes, madmin.MemInfo{Total: 100 << 30}, &madmin.SegmentedMemMetrics{
+			Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+		})
+		all, err := nav.Navigate("mem/last_day/_ALL")
+		if err != nil {
+			t.Fatalf("navigate _ALL: %v", err)
+		}
+		data := all.GetLeafData()
+		for _, w := range []struct{ label, want string }{
+			{"Major Faults", "1,800 per node, 2.0/s"},
+			{"Nodes", "2 node(s) reporting"},
+		} {
+			if got := leafValue(data, w.label); got != w.want {
+				t.Errorf("%s = %q, want %q: only one of the two slots reported",
+					w.label, got, w.want)
+			}
+		}
+	})
+}

--- a/mnav/replication.go
+++ b/mnav/replication.go
@@ -87,8 +87,12 @@ func prependEntry(data map[string]string, key, value string) {
 	data[fmt.Sprintf("00:%s", key)] = value
 }
 
-// generateReplicationStatsDisplay formats ReplicationStats for display
-func generateReplicationStatsDisplay(stats madmin.ReplicationStats, includeTimeInfo bool) map[string]string {
+// lastHourSecs is the window the last_hour views cover.
+const lastHourSecs = 3600
+
+// generateReplicationStatsDisplay formats ReplicationStats for display.
+// window is the wall-clock seconds stats covers, 0 if the view does not fix it.
+func generateReplicationStatsDisplay(stats madmin.ReplicationStats, window float64, includeTimeInfo bool) map[string]string {
 	data := make(map[string]string)
 
 	if stats.Nodes == 0 && stats.Events == 0 {
@@ -96,6 +100,7 @@ func generateReplicationStatsDisplay(stats madmin.ReplicationStats, includeTimeI
 		return data
 	}
 
+	covered := windowSecs(window, stats.WallTimeSecs, stats.Nodes)
 	idx := 0
 	add := func(key, value string) {
 		data[fmt.Sprintf("%02d:%s", idx, key)] = value
@@ -107,8 +112,8 @@ func generateReplicationStatsDisplay(stats madmin.ReplicationStats, includeTimeI
 		add("Time Range", fmt.Sprintf("%s → %s",
 			stats.StartTime.Local().Format("15:04:05"),
 			stats.EndTime.Local().Format("15:04:05")))
-		if stats.WallTimeSecs > 0 {
-			add("Duration", fmt.Sprintf("%.1f seconds", stats.WallTimeSecs))
+		if covered > 0 {
+			add("Duration", fmt.Sprintf("%.1f seconds", covered))
 		}
 	}
 
@@ -121,8 +126,8 @@ func generateReplicationStatsDisplay(stats madmin.ReplicationStats, includeTimeI
 	if stats.EventTimeSecs > 0 {
 		add("Event Rate", fmt.Sprintf("%.1f events/s", float64(stats.Events)/stats.EventTimeSecs))
 	}
-	if stats.WallTimeSecs > 0 {
-		add("Throughput", fmt.Sprintf("%s/s", humanize.Bytes(uint64(float64(stats.Bytes)/stats.WallTimeSecs))))
+	if covered > 0 {
+		add("Throughput", fmt.Sprintf("%s/s", humanize.Bytes(uint64(float64(stats.Bytes)/covered))))
 	}
 
 	// Latency metrics
@@ -381,7 +386,7 @@ func (node *ReplicationLastHourNode) GetLeafData() map[string]string {
 	// Aggregate last hour stats across all targets
 	allTargets := node.replication.AllTargets()
 
-	data := generateReplicationStatsDisplay(allTargets.LastHour, true)
+	data := generateReplicationStatsDisplay(allTargets.LastHour, lastHourSecs, true)
 	targetCount := len(node.replication.Targets)
 	if targetCount > 0 {
 		prependEntry(data, "Aggregation", fmt.Sprintf("Combined from %d targets", targetCount))
@@ -513,7 +518,7 @@ func (node *ReplicationTargetLastHourNode) GetLeafData() map[string]string {
 		return map[string]string{"Status": "No target data available"}
 	}
 
-	data := generateReplicationStatsDisplay(node.target.LastHour, true)
+	data := generateReplicationStatsDisplay(node.target.LastHour, lastHourSecs, true)
 	prependEntry(data, "Target", shortARN(node.targetName))
 	return data
 }
@@ -558,7 +563,8 @@ func (node *ReplicationSinceStartNode) GetLeafData() map[string]string {
 		return map[string]string{"Status": "No target data available"}
 	}
 
-	data := generateReplicationStatsDisplay(node.target.SinceStart, true)
+	// No window is known for since-start: the nodes' uptimes are all it covers.
+	data := generateReplicationStatsDisplay(node.target.SinceStart, 0, true)
 	prependEntry(data, "Target", shortARN(node.targetName))
 	return data
 }
@@ -729,6 +735,7 @@ func (node *ReplicationLastDayNode) GetChild(name string) (MetricNode, error) {
 		return &ReplicationLastDayTotalNode{
 			targetName: node.targetName,
 			total:      total,
+			windowSecs: segmentedWindowSecs(node.segmented),
 			parent:     node,
 			path:       node.path + "/" + name,
 		}, nil
@@ -766,6 +773,7 @@ func (node *ReplicationLastDayNode) GetPath() string       { return node.path }
 type ReplicationLastDayTotalNode struct {
 	targetName string
 	total      madmin.ReplicationStats
+	windowSecs float64 // wall-clock seconds total covers
 	parent     MetricNode
 	path       string
 }
@@ -783,7 +791,7 @@ func (node *ReplicationLastDayTotalNode) GetChildren() []MetricChild {
 }
 
 func (node *ReplicationLastDayTotalNode) GetLeafData() map[string]string {
-	data := generateReplicationStatsDisplay(node.total, true)
+	data := generateReplicationStatsDisplay(node.total, node.windowSecs, true)
 	prependEntry(data, "Target", shortARN(node.targetName))
 	return data
 }
@@ -825,7 +833,7 @@ func (node *ReplicationTimeSegmentNode) GetChildren() []MetricChild {
 }
 
 func (node *ReplicationTimeSegmentNode) GetLeafData() map[string]string {
-	data := generateReplicationStatsDisplay(node.segment, false)
+	data := generateReplicationStatsDisplay(node.segment, float64(node.interval), false)
 	endTime := node.segmentTime.Add(time.Duration(node.interval) * time.Second)
 	prependEntry(data, "Time Range", fmt.Sprintf("%s → %s",
 		node.segmentTime.Local().Format("15:04:05"),
@@ -966,6 +974,7 @@ func (node *ReplicationLastDayAggregatedNode) GetChild(name string) (MetricNode,
 		return &ReplicationLastDayTotalNode{
 			targetName: "all targets",
 			total:      total,
+			windowSecs: segmentedWindowSecs(seg),
 			parent:     node,
 			path:       node.path + "/Total",
 		}, nil

--- a/mnav/rpc.go
+++ b/mnav/rpc.go
@@ -710,72 +710,6 @@ func (node *RPCLastDayHandlerNode) GetChild(name string) (MetricNode, error) {
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }
 
-// RPCConnectionsNode shows RPC connection statistics and health
-type RPCConnectionsNode struct {
-	rpc    *madmin.RPCMetrics
-	parent MetricNode
-	path   string
-}
-
-func (node *RPCConnectionsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *RPCConnectionsNode) ShouldPauseRefresh() bool { return false }
-
-func (node *RPCConnectionsNode) GetChildren() []MetricChild {
-	if node.rpc == nil {
-		return []MetricChild{}
-	}
-	children := make([]MetricChild, 0, 1)
-	// Connection summary
-	children = append(children, MetricChild{
-		Name:        "summary",
-		Description: fmt.Sprintf("Connection health overview (Connected: %d, Disconnected: %d)", node.rpc.Connected, node.rpc.Disconnected),
-	})
-
-	return children
-}
-
-func (node *RPCConnectionsNode) GetLeafData() map[string]string {
-	if node.rpc == nil {
-		return map[string]string{"Status": "No RPC connection data available"}
-	}
-
-	data := make(map[string]string)
-
-	data["Total Nodes"] = fmt.Sprintf("%d", node.rpc.Nodes)
-	data["Connected"] = fmt.Sprintf("%d", node.rpc.Connected)
-	data["Disconnected"] = fmt.Sprintf("%d", node.rpc.Disconnected)
-
-	if node.rpc.Nodes > 0 {
-		connectionRate := float64(node.rpc.Connected) / float64(node.rpc.Nodes) * 100
-		data["Connection Rate"] = fmt.Sprintf("%.1f%%", connectionRate)
-	}
-
-	data["Last Updated"] = node.rpc.CollectedAt.Format("2006-01-02 15:04:05")
-
-	return data
-}
-
-func (node *RPCConnectionsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRPC }
-func (node *RPCConnectionsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *RPCConnectionsNode) GetParent() MetricNode              { return node.parent }
-func (node *RPCConnectionsNode) GetPath() string                    { return node.path }
-
-func (node *RPCConnectionsNode) GetChild(name string) (MetricNode, error) {
-	switch name {
-	case "summary":
-		return &RPCConnectionSummaryNode{
-			rpc:    node.rpc,
-			parent: node,
-			path:   node.path + "/" + name,
-		}, nil
-	default:
-		return nil, fmt.Errorf("connection child not found: %s", name)
-	}
-}
-
 // RPCConnectionSummaryNode shows connection summary details
 type RPCConnectionSummaryNode struct {
 	rpc    *madmin.RPCMetrics
@@ -1209,32 +1143,6 @@ func (node *RPCCallerNode) GetParent() MetricNode              { return node.par
 func (node *RPCCallerNode) GetPath() string                    { return node.path }
 func (node *RPCCallerNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children available for caller")
-}
-
-// RPCHandlerNode shows detailed statistics for a specific RPC handler
-type RPCHandlerNode struct {
-	stats  madmin.RPCStats
-	parent MetricNode
-	path   string
-}
-
-func (node *RPCHandlerNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *RPCHandlerNode) ShouldPauseRefresh() bool   { return true }
-func (node *RPCHandlerNode) GetChildren() []MetricChild { return []MetricChild{} }
-
-func (node *RPCHandlerNode) GetLeafData() map[string]string {
-	return generateRPCStatsDisplay(node.stats, 1, false, nil)
-}
-
-func (node *RPCHandlerNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRPC }
-func (node *RPCHandlerNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *RPCHandlerNode) GetParent() MetricNode              { return node.parent }
-func (node *RPCHandlerNode) GetPath() string                    { return node.path }
-func (node *RPCHandlerNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("no children available for RPC handler")
 }
 
 // RPCHandlerTotalNode shows total statistics for a handler over a time range

--- a/mnav/rpc.go
+++ b/mnav/rpc.go
@@ -710,59 +710,6 @@ func (node *RPCLastDayHandlerNode) GetChild(name string) (MetricNode, error) {
 	return nil, fmt.Errorf("time segment not found: %s", name)
 }
 
-// RPCConnectionSummaryNode shows connection summary details
-type RPCConnectionSummaryNode struct {
-	rpc    *madmin.RPCMetrics
-	parent MetricNode
-	path   string
-}
-
-func (node *RPCConnectionSummaryNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func (node *RPCConnectionSummaryNode) ShouldPauseRefresh() bool   { return false }
-func (node *RPCConnectionSummaryNode) GetChildren() []MetricChild { return []MetricChild{} }
-
-func (node *RPCConnectionSummaryNode) GetLeafData() map[string]string {
-	if node.rpc == nil {
-		return map[string]string{"Status": "No RPC connection data available"}
-	}
-
-	data := make(map[string]string)
-
-	data["Cluster Nodes"] = fmt.Sprintf("%d nodes configured", node.rpc.Nodes)
-	data["Connected Nodes"] = fmt.Sprintf("%d online", node.rpc.Connected)
-	if node.rpc.Disconnected > 0 {
-		data["Disconnected Nodes"] = fmt.Sprintf("%d offline", node.rpc.Disconnected)
-	}
-
-	if node.rpc.Nodes > 0 {
-		data["Connections"] = fmt.Sprintf("%.1f per node", float64(node.rpc.Connected)/float64(node.rpc.Nodes))
-	}
-
-	// Add activity summary
-	totalActivity := int64(0)
-	for _, stats := range node.rpc.LastMinute {
-		totalActivity += stats.Requests
-	}
-	if totalActivity > 0 {
-		data["Recent Activity"] = fmt.Sprintf("%s requests (last minute)", humanize.Comma(totalActivity))
-	} else {
-		data["Recent Activity"] = "No recent RPC activity"
-	}
-
-	return data
-}
-
-func (node *RPCConnectionSummaryNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRPC }
-func (node *RPCConnectionSummaryNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *RPCConnectionSummaryNode) GetParent() MetricNode              { return node.parent }
-func (node *RPCConnectionSummaryNode) GetPath() string                    { return node.path }
-func (node *RPCConnectionSummaryNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("no children available for connection summary")
-}
-
 // RPCByDestinationNode groups RPC statistics by destination
 type RPCByDestinationNode struct {
 	rpc    *madmin.RPCMetrics

--- a/mnav/runtime.go
+++ b/mnav/runtime.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2015-2026 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -19,22 +19,302 @@ package mnav
 
 import (
 	"fmt"
+	"math"
+	"runtime/metrics"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v4"
 )
 
-// formatBytes formats bytes in human readable format
-func formatRuntimeBytes(bytes uint64) string {
-	return humanize.Bytes(bytes)
+// Runtime metric names read in more than one place. The rest are named where they
+// are rendered.
+//
+// The set a node reports is whatever its own Go version exposes, so every read
+// here is optional and a missing name renders nothing rather than a zero. The
+// scheduler's goroutine-state breakdown and the finalizer counters, for one,
+// arrived in Go 1.25 and simply appear once the servers carry them.
+const (
+	mGoroutines  = "/sched/goroutines:goroutines"
+	mGomaxprocs  = "/sched/gomaxprocs:threads"
+	mCPUTotal    = "/cpu/classes/total:cpu-seconds"
+	mCPUUser     = "/cpu/classes/user:cpu-seconds"
+	mCPUGC       = "/cpu/classes/gc/total:cpu-seconds"
+	mGCCycles    = "/gc/cycles/total:gc-cycles"
+	mHeapInUse   = "/memory/classes/heap/objects:bytes"
+	mHeapObjects = "/gc/heap/objects:objects"
+	mAllocBytes  = "/gc/heap/allocs:bytes"
+	mMemTotal    = "/memory/classes/total:bytes"
+	mMutexWait   = "/sync/mutex/wait/total:seconds"
+)
+
+// goVals is one sample of the Go runtime metrics.
+//
+// Every value on the wire is summed across the nodes that reported it, gauges
+// included: a 17-node cluster reports its goroutine count as the fleet total, so
+// "961,763 goroutines" is 56,574 per process. nodes is what turns any of them
+// back into a per-process figure, and nothing here reads a map directly.
+type goVals struct {
+	uints  map[string]uint64
+	floats map[string]float64
+	nodes  int
+	// up is the reported process uptime and how many nodes reported one. Zero
+	// nodes means nobody did and it has to be derived.
+	up      time.Duration
+	upNodes int
 }
 
-// formatRuntimeNumber formats large numbers with thousand separators
-func formatRuntimeNumber(n uint64) string {
-	return humanize.Comma(int64(n))
+func runtimeVals(r *madmin.RuntimeMetrics) goVals {
+	v := goVals{uints: r.UintMetrics, floats: r.FloatMetrics, nodes: max(r.N, 1)}
+	if r.UptimeNodes > 0 {
+		v.up = time.Duration(r.UptimeSecs / float64(r.UptimeNodes) * float64(time.Second))
+		v.upNodes = r.UptimeNodes
+	}
+	return v
+}
+
+func segmentVals(s madmin.RuntimeSegment) goVals {
+	return goVals{uints: s.UintMetrics, floats: s.FloatMetrics, nodes: max(s.N, 1)}
+}
+
+// get reads a value from whichever map holds it, so a caller can name a metric
+// without tracking whether the runtime types it as an integer or a float.
+func (v goVals) get(key string) (float64, bool) {
+	if n, ok := v.uints[key]; ok {
+		return float64(n), true
+	}
+	f, ok := v.floats[key]
+	return f, ok
+}
+
+// node is get divided back down to one process.
+func (v goVals) node(key string) (float64, bool) {
+	f, ok := v.get(key)
+	return f / float64(v.nodes), ok
+}
+
+// uptime is the window every rate over these cumulative counters divides by.
+//
+// Reported when the nodes carry one. Otherwise derived:
+// /cpu/classes/total:cpu-seconds accrues one second per thread per second of wall
+// clock since the process started, so dividing it by GOMAXPROCS gives that wall
+// clock back -- both summed over the same nodes, so the quotient needs no node
+// count. The derivation breaks where GOMAXPROCS changed mid-flight, which Go 1.25
+// does on its own when a container's CPU limit moves; the reported value does not.
+//
+// Either way it is a mean: a node restarted ten minutes ago pulls the figure down
+// instead of showing up on its own, which is why every rate taken from it is
+// labelled per node rather than presented as a fleet fact.
+func (v goVals) uptime() (d time.Duration, reported, ok bool) {
+	if v.upNodes > 0 && v.up > 0 {
+		return v.up, true, true
+	}
+	cpu, okCPU := v.get(mCPUTotal)
+	procs, okProcs := v.get(mGomaxprocs)
+	if !okCPU || !okProcs || procs <= 0 || cpu <= 0 {
+		return 0, false, false
+	}
+	return time.Duration(cpu / procs * float64(time.Second)), false, true
+}
+
+// uptimeRow states the uptime and where it came from: a derived figure is an
+// inference from the CPU accounting, and a reported one that only some of the
+// fleet answered is a mean over those nodes, not over the cluster.
+func (v goVals) uptimeRow() (string, bool) {
+	d, reported, ok := v.uptime()
+	if !ok {
+		return "", false
+	}
+	switch {
+	case !reported:
+		return coverDuration(d) + " (derived, mean per node)", true
+	case v.upNodes < v.nodes:
+		return fmt.Sprintf("%s (mean of %d of %d nodes)", coverDuration(d), v.upNodes, v.nodes), true
+	case v.nodes > 1:
+		return coverDuration(d) + " (mean per node)", true
+	}
+	return coverDuration(d), true
+}
+
+// runtimeRows builds leaf data in display order. The leaf renderer sorts on the
+// key, so the position has to be part of it.
+//
+// Every add is conditional on the metric being present, because which ones are
+// depends on the servers' Go version: a section states what it would like to show
+// and quietly omits what this cluster cannot report.
+type runtimeRows struct {
+	data map[string]string
+	n    int
+}
+
+func newRuntimeRows() *runtimeRows {
+	return &runtimeRows{data: make(map[string]string)}
+}
+
+func (r *runtimeRows) add(label, value string) {
+	r.data[fmt.Sprintf("%02d:%s", r.n, label)] = value
+	r.n++
+}
+
+func (r *runtimeRows) addIf(label, value string, ok bool) {
+	if ok {
+		r.add(label, value)
+	}
+}
+
+// total states a summed value as the cluster figure with the per-node mean behind
+// it. A single node has no mean worth repeating.
+func (r *runtimeRows) total(v goVals, label, key string, render func(float64) string) {
+	sum, ok := v.get(key)
+	if !ok {
+		return
+	}
+	if v.nodes <= 1 {
+		r.add(label, render(sum))
+		return
+	}
+	r.add(label, fmt.Sprintf("%s (%s/node)", render(sum), render(sum/float64(v.nodes))))
+}
+
+// perNode states only the per-node value, for a setting rather than a
+// measurement: GOGC summed over a cluster reads as nonsense, and no reader
+// expects a knob to be a fleet total. It is still a mean, so nodes configured
+// differently average into something neither of them is set to.
+func (r *runtimeRows) perNode(v goVals, label, key string, render func(float64) string) {
+	value, ok := v.node(key)
+	if !ok {
+		return
+	}
+	r.add(label, render(value))
+}
+
+// counter is total with the per-node rate over the process uptime appended, which
+// is the only rate available for a value cumulative since start.
+func (r *runtimeRows) counter(v goVals, label, key string, up time.Duration, render func(float64) string, unit string) {
+	sum, ok := v.get(key)
+	if !ok {
+		return
+	}
+	value := render(sum)
+	perNode := sum / float64(v.nodes)
+	if v.nodes > 1 {
+		value += fmt.Sprintf(" (%s/node)", render(perNode))
+	}
+	if up > 0 && perNode > 0 {
+		value += ", " + fmtRate(perNode/up.Seconds(), render, unit)
+	}
+	r.add(label, value)
+}
+
+// share renders one part of a whole: the cluster total, the per-node mean every
+// other row in the section carries, and the split that is the point of the
+// breakdown. The share alone would be an answer to a question nobody asked twice.
+func (r *runtimeRows) share(v goVals, label, key string, whole float64, render func(float64) string) {
+	part, ok := v.get(key)
+	if !ok {
+		return
+	}
+	r.add(label, render(part)+qualify(v.nodes, part, whole, render))
+}
+
+// cpuShare renders a CPU class against the CPU time available since start.
+//
+// The classes are cumulative and so is their total, by the same clock, so the
+// share is mean utilisation over the process lifetime -- the closest thing to a
+// rate these counters can give without a window.
+func (r *runtimeRows) cpuShare(v goVals, label, key string) {
+	part, ok := v.get(key)
+	total, okTotal := v.get(mCPUTotal)
+	if !ok {
+		return
+	}
+	if !okTotal {
+		total = 0
+	}
+	r.add(label, fmtSecs(part)+" CPU-time"+qualify(v.nodes, part, total, fmtSecs))
+}
+
+// hist renders a histogram row, skipping one the reporting Go version omits.
+func (r *runtimeRows) hist(m *madmin.RuntimeMetrics, label, key string, nodes int) {
+	h, ok := m.HistMetrics[key]
+	if !ok {
+		return
+	}
+	line, ok := histLine(h, nodes)
+	r.addIf(label, line, ok)
+}
+
+// histLine summarizes a runtime histogram: how many samples, their mean, and the
+// tail that a mean hides.
+//
+// Buckets carry the distribution only, so the mean is midpoint-weighted and the
+// percentiles are bucket edges -- upper bounds, except in the open-ended top
+// bucket, where only a lower bound exists.
+func histLine(h metrics.Float64Histogram, nodes int) (string, bool) {
+	if len(h.Counts) == 0 || len(h.Buckets) != len(h.Counts)+1 {
+		return "", false
+	}
+	var count uint64
+	var weighted float64
+	for i, c := range h.Counts {
+		if c == 0 {
+			continue
+		}
+		count += c
+		lo, hi := h.Buckets[i], h.Buckets[i+1]
+		// The outermost buckets are unbounded; the finite edge is the only
+		// estimate either of them offers.
+		if math.IsInf(lo, -1) {
+			lo = hi
+		}
+		if math.IsInf(hi, 1) {
+			hi = lo
+		}
+		weighted += (lo + hi) / 2 * float64(c)
+	}
+	if count == 0 {
+		return "", false
+	}
+	out := fmtCount(float64(count))
+	if nodes > 1 {
+		out += fmt.Sprintf(" (%s/node)", fmtCount(float64(count)/float64(nodes)))
+	}
+	out += ", avg " + fmtSecs(weighted/float64(count))
+	for _, q := range []struct {
+		label string
+		p     float64
+	}{{"p50", 0.5}, {"p99", 0.99}} {
+		edge, bounded, ok := histQuantile(h, count, q.p)
+		switch {
+		case !ok:
+		case bounded:
+			out += fmt.Sprintf(", %s %s", q.label, fmtSecs(edge))
+		default:
+			out += fmt.Sprintf(", %s >%s", q.label, fmtSecs(edge))
+		}
+	}
+	return out, true
+}
+
+// histQuantile returns the bucket edge the qth sample falls in. bounded is false
+// in the open-ended top bucket, where the edge is a lower bound.
+func histQuantile(h metrics.Float64Histogram, count uint64, q float64) (edge float64, bounded, ok bool) {
+	want := uint64(float64(count) * q)
+	var seen uint64
+	for i, c := range h.Counts {
+		if c == 0 {
+			continue
+		}
+		seen += c
+		if seen >= want {
+			if hi := h.Buckets[i+1]; !math.IsInf(hi, 1) {
+				return hi, true, true
+			}
+			return h.Buckets[i], false, true
+		}
+	}
+	return 0, false, false
 }
 
 // RuntimeMetricsNavigator provides navigation for Go Runtime metrics
@@ -57,51 +337,48 @@ func (node *RuntimeMetricsNavigator) GetChildren() []MetricChild {
 	if node.runtime == nil {
 		return []MetricChild{}
 	}
-	children := make([]MetricChild, 0, 6)
-	children = append(children,
-		MetricChild{Name: "gc", Description: "Garbage collection metrics and heap statistics"},
-		MetricChild{Name: "memory", Description: "Memory management and allocation metrics"},
-		MetricChild{Name: "scheduler", Description: "Go scheduler and goroutine metrics"},
-		MetricChild{Name: "cpu_classes", Description: "CPU time breakdown by runtime activities"},
-		MetricChild{Name: "sync", Description: "Synchronization and locking metrics"},
-		MetricChild{Name: "last_day", Description: "Last 24h runtime statistics"},
-	)
-	return children
+	return []MetricChild{
+		{Name: "gc", Description: "Collector cycles, heap occupancy, allocation rate and pauses"},
+		{Name: "memory", Description: "Process footprint split by what the runtime holds it for"},
+		{Name: "scheduler", Description: "Goroutines by state, threads, run-queue latency and stop-the-world"},
+		{Name: "cpu_classes", Description: "Where CPU time went, as a share of what was available"},
+		{Name: "sync", Description: "Time goroutines spent blocked on locks"},
+		{Name: "last_hour", Description: "Runtime levels and rates over the last hour, by time segment"},
+		{Name: "last_day", Description: "Runtime levels and rates over the last day, by time segment"},
+	}
 }
 
 func (node *RuntimeMetricsNavigator) GetLeafData() map[string]string {
 	if node.runtime == nil {
 		return map[string]string{"Status": "Runtime metrics not available"}
 	}
+	v := runtimeVals(node.runtime)
+	up, _, _ := v.uptime()
 
-	data := map[string]string{
-		"Metric Categories": strconv.Itoa(len(node.GetChildren())),
-		"Uint64 Metrics":    strconv.Itoa(len(node.runtime.UintMetrics)),
-		"Float64 Metrics":   strconv.Itoa(len(node.runtime.FloatMetrics)),
-		"Histogram Metrics": strconv.Itoa(len(node.runtime.HistMetrics)),
-		"Total Metrics":     strconv.Itoa(len(node.runtime.UintMetrics) + len(node.runtime.FloatMetrics) + len(node.runtime.HistMetrics)),
+	r := newRuntimeRows()
+	r.add("Nodes", formatNodeCount(v.nodes, 1))
+	if row, ok := v.uptimeRow(); ok {
+		r.add("Uptime", row)
 	}
-
-	// Add high-level summary metrics if available
-	if goroutines, ok := node.runtime.UintMetrics["/sched/goroutines:goroutines"]; ok {
-		data["Active Goroutines"] = formatRuntimeNumber(goroutines)
-	}
-
-	if heapObjects, ok := node.runtime.UintMetrics["/gc/heap/objects:objects"]; ok {
-		data["Heap Objects"] = formatRuntimeNumber(heapObjects)
-	}
-
-	if heapBytes, ok := node.runtime.UintMetrics["/memory/classes/heap/objects:bytes"]; ok {
-		data["Heap Size"] = formatRuntimeBytes(heapBytes)
-	}
-
-	return data
+	r.total(v, "Goroutines", mGoroutines, fmtCount)
+	r.total(v, "Runnable", "/sched/goroutines/runnable:goroutines", fmtCount)
+	r.total(v, "Threads", "/sched/threads/total:threads", fmtCount)
+	r.total(v, "GOMAXPROCS", mGomaxprocs, fmtCount)
+	r.total(v, "Heap In Use", mHeapInUse, fmtBytes)
+	r.total(v, "Heap Objects", mHeapObjects, fmtCount)
+	r.counter(v, "GC Cycles", mGCCycles, up, fmtCount, "cycles")
+	r.cpuShare(v, "User CPU", mCPUUser)
+	r.total(v, "Mutex Wait", mMutexWait, fmtSecs)
+	return r.data
 }
 
 func (node *RuntimeMetricsNavigator) GetMetricType() madmin.MetricType {
 	return madmin.MetricsRuntime
 }
 
+// GetMetricFlags requests no historic window: this node refreshes continuously,
+// and asking for them here would pull the hour and the day on every tick to
+// render nothing that uses them. They are fetched on navigating into one.
 func (node *RuntimeMetricsNavigator) GetMetricFlags() madmin.MetricFlags {
 	return 0
 }
@@ -122,511 +399,546 @@ func (node *RuntimeMetricsNavigator) GetChild(name string) (MetricNode, error) {
 	if node.runtime == nil {
 		return nil, fmt.Errorf("no runtime data available")
 	}
-
 	switch name {
-	case "gc":
-		return NewGCMetricsNode(node.runtime, node, fmt.Sprintf("%s/gc", node.path)), nil
-	case "memory":
-		return NewMemoryMetricsNode(node.runtime, node, fmt.Sprintf("%s/memory", node.path)), nil
-	case "scheduler":
-		return NewSchedulerMetricsNode(node.runtime, node, fmt.Sprintf("%s/scheduler", node.path)), nil
-	case "cpu_classes":
-		return NewCPUClassesMetricsNode(node.runtime, node, fmt.Sprintf("%s/cpu_classes", node.path)), nil
-	case "sync":
-		return NewSyncMetricsNode(node.runtime, node, fmt.Sprintf("%s/sync", node.path)), nil
+	case "gc", "memory", "scheduler", "cpu_classes", "sync":
+		return &runtimeSectionNode{
+			runtime: node.runtime, kind: name,
+			parent: node, path: fmt.Sprintf("%s/%s", node.path, name),
+		}, nil
+	case "last_hour":
+		return &runtimeWindowNode{
+			seg: node.runtime.LastHour, flags: madmin.MetricsHourStats, window: "hour",
+			parent: node, path: fmt.Sprintf("%s/last_hour", node.path),
+		}, nil
 	case "last_day":
-		return NewRuntimeLastDayNode(node.runtime.LastDay, node, fmt.Sprintf("%s/last_day", node.path)), nil
-	default:
-		return nil, fmt.Errorf("child not found: %s", name)
+		return &runtimeWindowNode{
+			seg: node.runtime.LastDay, flags: madmin.MetricsDayStats, window: "day",
+			parent: node, path: fmt.Sprintf("%s/last_day", node.path),
+		}, nil
 	}
+	return nil, fmt.Errorf("child not found: %s", name)
 }
 
-// GCMetricsNode handles navigation for garbage collection metrics
-type GCMetricsNode struct {
+// runtimeSectionNode is one themed page of the current sample. The sections differ
+// only in which metrics they render, so they share a node and switch on kind.
+type runtimeSectionNode struct {
 	runtime *madmin.RuntimeMetrics
+	kind    string
 	parent  MetricNode
 	path    string
 }
 
-func (node *GCMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func NewGCMetricsNode(runtime *madmin.RuntimeMetrics, parent MetricNode, path string) *GCMetricsNode {
-	return &GCMetricsNode{runtime: runtime, parent: parent, path: path}
-}
-
-func (node *GCMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{}
-}
-
-func (node *GCMetricsNode) GetLeafData() map[string]string {
-	if node.runtime == nil {
-		return map[string]string{"Status": "GC metrics not available"}
-	}
-
-	data := map[string]string{}
-
-	// GC Overview
-	if cycles, ok := node.runtime.UintMetrics["/gc/cycles/total:gc-cycles"]; ok {
-		data["GC Overview"] = fmt.Sprintf("%s total GC cycles completed", formatRuntimeNumber(cycles))
-	}
-
-	// Heap Statistics
-	if heapObjects, ok := node.runtime.UintMetrics["/gc/heap/objects:objects"]; ok {
-		data["Heap Objects"] = fmt.Sprintf("%s objects currently allocated", formatRuntimeNumber(heapObjects))
-	}
-
-	if heapGoal, ok := node.runtime.UintMetrics["/gc/heap/goal:bytes"]; ok {
-		data["Heap Goal"] = fmt.Sprintf("%s target heap size", formatRuntimeBytes(heapGoal))
-	}
-
-	if totalAllocs, ok := node.runtime.UintMetrics["/gc/heap/allocs:objects"]; ok {
-		data["Total Allocations"] = fmt.Sprintf("%s objects allocated lifetime", formatRuntimeNumber(totalAllocs))
-	}
-
-	if totalFrees, ok := node.runtime.UintMetrics["/gc/heap/frees:objects"]; ok {
-		data["Total Deallocations"] = fmt.Sprintf("%s objects freed lifetime", formatRuntimeNumber(totalFrees))
-	}
-
-	// GC Performance
-	if gcPauseHist, ok := node.runtime.HistMetrics["/gc/pauses:seconds"]; ok {
-		totalCount := uint64(0)
-		totalSum := float64(0)
-
-		// Calculate total count from all buckets
-		for _, count := range gcPauseHist.Counts {
-			totalCount += count
-		}
-
-		// Calculate weighted sum using bucket midpoints
-		for i, count := range gcPauseHist.Counts {
-			if i < len(gcPauseHist.Buckets)-1 && count > 0 {
-				bucketMidpoint := (gcPauseHist.Buckets[i] + gcPauseHist.Buckets[i+1]) / 2
-				totalSum += bucketMidpoint * float64(count)
-			}
-		}
-
-		data["GC Pause Analysis"] = fmt.Sprintf("%d pause measurements recorded", totalCount)
-		if totalCount > 0 {
-			// Convert to milliseconds for better readability
-			avgPauseMs := (totalSum / float64(totalCount)) * 1000
-			data["Average Pause"] = fmt.Sprintf("%.2fms per GC cycle", avgPauseMs)
-			data["Total Pause Time"] = fmt.Sprintf("%.2fms cumulative", totalSum*1000)
-		}
-	}
-
-	// Scan work
-	if scanWork, ok := node.runtime.UintMetrics["/gc/scan/heap:bytes"]; ok {
-		data["Heap Scan Work"] = fmt.Sprintf("%s scanned during GC", formatRuntimeBytes(scanWork))
-	}
-
-	if scanStack, ok := node.runtime.UintMetrics["/gc/scan/stack:bytes"]; ok {
-		data["Stack Scan Work"] = fmt.Sprintf("%s stack memory scanned", formatRuntimeBytes(scanStack))
-	}
-
-	return data
-}
-
-func (node *GCMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *GCMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *GCMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *GCMetricsNode) GetPath() string                    { return node.path }
-func (node *GCMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *GCMetricsNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("GC metrics node has no children")
-}
-
-// MemoryMetricsNode handles navigation for memory management metrics
-type MemoryMetricsNode struct {
-	runtime *madmin.RuntimeMetrics
-	parent  MetricNode
-	path    string
-}
-
-func (node *MemoryMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func NewMemoryMetricsNode(runtime *madmin.RuntimeMetrics, parent MetricNode, path string) *MemoryMetricsNode {
-	return &MemoryMetricsNode{runtime: runtime, parent: parent, path: path}
-}
-
-func (node *MemoryMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{}
-}
-
-func (node *MemoryMetricsNode) GetLeafData() map[string]string {
-	if node.runtime == nil {
-		return map[string]string{"Status": "Memory metrics not available"}
-	}
-
-	data := map[string]string{}
-
-	// Memory Classes Overview
-	data["Memory Classes"] = "Go runtime memory breakdown by usage"
-
-	// Heap memory
-	if heapObjects, ok := node.runtime.UintMetrics["/memory/classes/heap/objects:bytes"]; ok {
-		data["Heap Objects"] = fmt.Sprintf("%s allocated to Go objects", formatRuntimeBytes(heapObjects))
-	}
-
-	if heapUnused, ok := node.runtime.UintMetrics["/memory/classes/heap/unused:bytes"]; ok {
-		data["Heap Unused"] = fmt.Sprintf("%s heap space available for allocation", formatRuntimeBytes(heapUnused))
-	}
-
-	if heapReleased, ok := node.runtime.UintMetrics["/memory/classes/heap/released:bytes"]; ok {
-		data["Heap Released"] = fmt.Sprintf("%s returned to OS but not yet reused", formatRuntimeBytes(heapReleased))
-	}
-
-	if heapFree, ok := node.runtime.UintMetrics["/memory/classes/heap/free:bytes"]; ok {
-		data["Heap Free"] = fmt.Sprintf("%s unallocated heap memory", formatRuntimeBytes(heapFree))
-	}
-
-	// Stack memory
-	if heapStacks, ok := node.runtime.UintMetrics["/memory/classes/heap/stacks:bytes"]; ok {
-		data["Stack Memory"] = fmt.Sprintf("%s allocated to goroutine stacks", formatRuntimeBytes(heapStacks))
-	}
-
-	// Runtime structures
-	if metadata, ok := node.runtime.UintMetrics["/memory/classes/metadata/mcache/free:bytes"]; ok {
-		data["MCache Free"] = fmt.Sprintf("%s free mcache memory", formatRuntimeBytes(metadata))
-	}
-
-	if mcacheInuse, ok := node.runtime.UintMetrics["/memory/classes/metadata/mcache/inuse:bytes"]; ok {
-		data["MCache InUse"] = fmt.Sprintf("%s active mcache memory", formatRuntimeBytes(mcacheInuse))
-	}
-
-	if mspanFree, ok := node.runtime.UintMetrics["/memory/classes/metadata/mspan/free:bytes"]; ok {
-		data["MSpan Free"] = fmt.Sprintf("%s free mspan memory", formatRuntimeBytes(mspanFree))
-	}
-
-	if mspanInuse, ok := node.runtime.UintMetrics["/memory/classes/metadata/mspan/inuse:bytes"]; ok {
-		data["MSpan InUse"] = fmt.Sprintf("%s active mspan memory", formatRuntimeBytes(mspanInuse))
-	}
-
-	// Other memory classes
-	if otherSystem, ok := node.runtime.UintMetrics["/memory/classes/os-stacks:bytes"]; ok {
-		data["OS Stacks"] = fmt.Sprintf("%s OS thread stacks", formatRuntimeBytes(otherSystem))
-	}
-
-	if profBuf, ok := node.runtime.UintMetrics["/memory/classes/profiling/buckets:bytes"]; ok {
-		data["Profiling Memory"] = fmt.Sprintf("%s profiling bucket memory", formatRuntimeBytes(profBuf))
-	}
-
-	return data
-}
-
-func (node *MemoryMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *MemoryMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *MemoryMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *MemoryMetricsNode) GetPath() string                    { return node.path }
-func (node *MemoryMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *MemoryMetricsNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("memory metrics node has no children")
-}
-
-// SchedulerMetricsNode handles navigation for Go scheduler metrics
-type SchedulerMetricsNode struct {
-	runtime *madmin.RuntimeMetrics
-	parent  MetricNode
-	path    string
-}
-
-func (node *SchedulerMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func NewSchedulerMetricsNode(runtime *madmin.RuntimeMetrics, parent MetricNode, path string) *SchedulerMetricsNode {
-	return &SchedulerMetricsNode{runtime: runtime, parent: parent, path: path}
-}
-
-func (node *SchedulerMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{}
-}
-
-func (node *SchedulerMetricsNode) GetLeafData() map[string]string {
-	if node.runtime == nil {
-		return map[string]string{"Status": "Scheduler metrics not available"}
-	}
-
-	data := map[string]string{}
-
-	// Goroutine Statistics
-	if goroutines, ok := node.runtime.UintMetrics["/sched/goroutines:goroutines"]; ok {
-		data["Goroutine Statistics"] = fmt.Sprintf("%s active goroutines", formatRuntimeNumber(goroutines))
-	}
-
-	// Scheduling Latencies
-	if schedLatency, ok := node.runtime.HistMetrics["/sched/latencies:seconds"]; ok {
-		totalCount := uint64(0)
-		totalSum := float64(0)
-
-		// Calculate total count from all buckets
-		for _, count := range schedLatency.Counts {
-			totalCount += count
-		}
-
-		// Calculate weighted sum using bucket midpoints
-		for i, count := range schedLatency.Counts {
-			if i < len(schedLatency.Buckets)-1 && count > 0 {
-				bucketMidpoint := (schedLatency.Buckets[i] + schedLatency.Buckets[i+1]) / 2
-				totalSum += bucketMidpoint * float64(count)
-			}
-		}
-
-		data["Scheduling Performance"] = fmt.Sprintf("%d scheduling measurements", totalCount)
-		if totalCount > 0 {
-			avgLatencyMs := (totalSum / float64(totalCount)) * 1000
-			data["Average Scheduling Latency"] = fmt.Sprintf("%.2fms per goroutine schedule", avgLatencyMs)
-			data["Total Scheduling Time"] = fmt.Sprintf("%.2fms cumulative", totalSum*1000)
-		}
-	}
-
-	// Gomaxprocs
-	if gomaxprocs, ok := node.runtime.UintMetrics["/sched/gomaxprocs:threads"]; ok {
-		data["Maximum Threads"] = fmt.Sprintf("%s maximum OS threads (GOMAXPROCS)", formatRuntimeNumber(gomaxprocs))
-	}
-
-	return data
-}
-
-func (node *SchedulerMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *SchedulerMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *SchedulerMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *SchedulerMetricsNode) GetPath() string                    { return node.path }
-func (node *SchedulerMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *SchedulerMetricsNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("scheduler metrics node has no children")
-}
-
-// CPUClassesMetricsNode handles navigation for CPU time class metrics
-type CPUClassesMetricsNode struct {
-	runtime *madmin.RuntimeMetrics
-	parent  MetricNode
-	path    string
-}
-
-func (node *CPUClassesMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func NewCPUClassesMetricsNode(runtime *madmin.RuntimeMetrics, parent MetricNode, path string) *CPUClassesMetricsNode {
-	return &CPUClassesMetricsNode{runtime: runtime, parent: parent, path: path}
-}
-
-func (node *CPUClassesMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{}
-}
-
-func (node *CPUClassesMetricsNode) GetLeafData() map[string]string {
-	if node.runtime == nil {
-		return map[string]string{"Status": "CPU class metrics not available"}
-	}
-
-	data := map[string]string{}
-
-	data["00:CPU time breakdown"] = "Time spent by runtime in different activities"
-
-	// GC activities
-	if gcAssist, ok := node.runtime.FloatMetrics["/cpu/classes/gc/mark/assist:cpu-seconds"]; ok {
-		data["GC Mark Assist"] = fmt.Sprintf("%.2fs assisting GC marking", gcAssist)
-	}
-
-	if gcDedicated, ok := node.runtime.FloatMetrics["/cpu/classes/gc/mark/dedicated:cpu-seconds"]; ok {
-		data["GC Mark Dedicated"] = fmt.Sprintf("%.2fs dedicated GC marking", gcDedicated)
-	}
-
-	if gcFractional, ok := node.runtime.FloatMetrics["/cpu/classes/gc/mark/fractional:cpu-seconds"]; ok {
-		data["GC Mark Fractional"] = fmt.Sprintf("%.2fs fractional GC marking", gcFractional)
-	}
-
-	if gcTotal, ok := node.runtime.FloatMetrics["/cpu/classes/gc/total:cpu-seconds"]; ok {
-		data["GC Total Time"] = fmt.Sprintf("%.2fs total garbage collection", gcTotal)
-	}
-
-	// Scavenging
-	if scavenge, ok := node.runtime.FloatMetrics["/cpu/classes/scavenge:cpu-seconds"]; ok {
-		data["Memory Scavenge"] = fmt.Sprintf("%.2fs memory scavenging", scavenge)
-	}
-
-	// User time
-	if userTime, ok := node.runtime.FloatMetrics["/cpu/classes/user:cpu-seconds"]; ok {
-		data["User Code"] = fmt.Sprintf("%.2fs executing user Go code", userTime)
-	}
-
-	// Idle time
-	if idleTime, ok := node.runtime.FloatMetrics["/cpu/classes/idle:cpu-seconds"]; ok {
-		data["Idle Time"] = fmt.Sprintf("%.2fs runtime idle", idleTime)
-	}
-
-	return data
-}
-
-func (node *CPUClassesMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *CPUClassesMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *CPUClassesMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *CPUClassesMetricsNode) GetPath() string                    { return node.path }
-func (node *CPUClassesMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *CPUClassesMetricsNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("CPU classes metrics node has no children")
-}
-
-// SyncMetricsNode handles navigation for synchronization metrics
-type SyncMetricsNode struct {
-	runtime *madmin.RuntimeMetrics
-	parent  MetricNode
-	path    string
-}
-
-func (node *SyncMetricsNode) GetOpts() madmin.MetricsOptions {
-	return getNodeOpts(node)
-}
-
-func NewSyncMetricsNode(runtime *madmin.RuntimeMetrics, parent MetricNode, path string) *SyncMetricsNode {
-	return &SyncMetricsNode{runtime: runtime, parent: parent, path: path}
-}
-
-func (node *SyncMetricsNode) GetChildren() []MetricChild {
-	return []MetricChild{}
-}
-
-func (node *SyncMetricsNode) GetLeafData() map[string]string {
-	if node.runtime == nil {
-		return map[string]string{"Status": "Synchronization metrics not available"}
-	}
-
-	data := map[string]string{}
-
-	// Mutex wait time
-	if mutexWait, ok := node.runtime.FloatMetrics["/sync/mutex/wait/total:seconds"]; ok {
-		data["00:Sync Overhead"] = fmt.Sprintf("%.2fs total mutex wait time", mutexWait)
-	}
-
-	// Check for any other sync-related metrics that might be available
-	syncMetricCount := 0
-	for key := range node.runtime.FloatMetrics {
-		if strings.HasPrefix(key, "/sync/") {
-			syncMetricCount++
-		}
-	}
-	for key := range node.runtime.UintMetrics {
-		if strings.HasPrefix(key, "/sync/") {
-			syncMetricCount++
-		}
-	}
-
-	if syncMetricCount > 0 {
-		data["Available Sync Metrics"] = fmt.Sprintf("%d synchronization metrics tracked", syncMetricCount)
-	} else {
-		data["Status"] = "No synchronization metrics available in current Go version"
-	}
-
-	return data
-}
-
-func (node *SyncMetricsNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *SyncMetricsNode) GetMetricFlags() madmin.MetricFlags { return 0 }
-func (node *SyncMetricsNode) GetParent() MetricNode              { return node.parent }
-func (node *SyncMetricsNode) GetPath() string                    { return node.path }
-func (node *SyncMetricsNode) ShouldPauseRefresh() bool {
-	return false
-}
-
-func (node *SyncMetricsNode) GetChild(_ string) (MetricNode, error) {
-	return nil, fmt.Errorf("sync metrics node has no children")
-}
-
-// RuntimeLastDayNode shows last 24h runtime statistics
-type RuntimeLastDayNode struct {
-	segmented *madmin.SegmentedRuntimeMetrics
-	parent    MetricNode
-	path      string
-}
-
-func NewRuntimeLastDayNode(segmented *madmin.SegmentedRuntimeMetrics, parent MetricNode, path string) *RuntimeLastDayNode {
-	return &RuntimeLastDayNode{segmented: segmented, parent: parent, path: path}
-}
-
-func (node *RuntimeLastDayNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
-func (node *RuntimeLastDayNode) GetPath() string                    { return node.path }
-func (node *RuntimeLastDayNode) GetParent() MetricNode              { return node.parent }
-func (node *RuntimeLastDayNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
-func (node *RuntimeLastDayNode) GetMetricFlags() madmin.MetricFlags { return madmin.MetricsDayStats }
-func (node *RuntimeLastDayNode) ShouldPauseRefresh() bool           { return true }
-func (node *RuntimeLastDayNode) GetChildren() []MetricChild         { return nil }
-
-func (node *RuntimeLastDayNode) GetChild(_ string) (MetricNode, error) {
+func (node *runtimeSectionNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *runtimeSectionNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
+func (node *runtimeSectionNode) GetMetricFlags() madmin.MetricFlags { return 0 }
+func (node *runtimeSectionNode) GetParent() MetricNode              { return node.parent }
+func (node *runtimeSectionNode) GetPath() string                    { return node.path }
+func (node *runtimeSectionNode) ShouldPauseRefresh() bool           { return false }
+func (node *runtimeSectionNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *runtimeSectionNode) GetChild(_ string) (MetricNode, error) {
 	return nil, fmt.Errorf("no children")
 }
 
-func (node *RuntimeLastDayNode) GetLeafData() map[string]string {
-	if node.segmented == nil || len(node.segmented.Segments) == 0 {
-		return nil
+func (node *runtimeSectionNode) GetLeafData() map[string]string {
+	if node.runtime == nil {
+		return map[string]string{"Status": "Runtime metrics not available"}
 	}
-	data := make(map[string]string)
-	idx := 0
-	var prevGCCycles uint64
-	// Forward pass to compute GC deltas per segment
-	gcDeltas := make([]uint64, len(node.segmented.Segments))
-	for i := range node.segmented.Segments {
-		seg := node.segmented.Segments[i]
-		if seg.N == 0 {
+	v := runtimeVals(node.runtime)
+	r := newRuntimeRows()
+	r.add("Nodes", formatNodeCount(v.nodes, 1))
+	switch node.kind {
+	case "gc":
+		node.gcRows(v, r)
+	case "memory":
+		node.memoryRows(v, r)
+	case "scheduler":
+		node.schedulerRows(v, r)
+	case "cpu_classes":
+		node.cpuRows(v, r)
+	case "sync":
+		node.syncRows(v, r)
+	}
+	// Only the node count made it, so this Go version reports nothing this
+	// section knows how to render.
+	if r.n == 1 {
+		return map[string]string{"Status": "no " + node.kind + " metrics in this sample"}
+	}
+	return r.data
+}
+
+func (node *runtimeSectionNode) gcRows(v goVals, r *runtimeRows) {
+	up, _, _ := v.uptime()
+	r.counter(v, "Cycles", mGCCycles, up, fmtCount, "cycles")
+	if forced, ok := v.get("/gc/cycles/forced:gc-cycles"); ok && forced > 0 {
+		r.add("Forced Cycles", fmtCount(forced))
+	}
+	r.total(v, "Heap Live", "/gc/heap/live:bytes", fmtBytes)
+	r.total(v, "Heap In Use", mHeapInUse, fmtBytes)
+	r.total(v, "Heap Objects", mHeapObjects, fmtCount)
+	r.total(v, "Heap Goal", "/gc/heap/goal:bytes", fmtBytes)
+	// GOGC and GOMEMLIMIT are settings, not measurements, so only the per-node
+	// value means anything.
+	r.perNode(v, "GOGC", "/gc/gogc:percent", func(f float64) string {
+		return fmt.Sprintf("%.0f%%", f)
+	})
+	if limit, ok := v.node("/gc/gomemlimit:bytes"); ok && limit < math.MaxInt64 {
+		r.add("GOMEMLIMIT", fmtBytes(limit))
+	}
+	r.counter(v, "Allocated", mAllocBytes, up, fmtBytes, "")
+	r.counter(v, "Allocated Objects", "/gc/heap/allocs:objects", up, fmtCount, "obj")
+	r.counter(v, "Freed", "/gc/heap/frees:bytes", up, fmtBytes, "")
+	r.total(v, "Scan Work", "/gc/scan/total:bytes", fmtBytes)
+	r.hist(node.runtime, "Pauses", "/gc/pauses:seconds", v.nodes)
+	r.cpuShare(v, "GC CPU", mCPUGC)
+	// A queue that outruns the runs is a leak in the making; both pairs arrived
+	// with Go 1.24/1.25 and are absent on older servers.
+	for _, q := range []struct{ label, queued, done string }{
+		{"Finalizers", "/gc/finalizers/queued:finalizers", "/gc/finalizers/executed:finalizers"},
+		{"Cleanups", "/gc/cleanups/queued:cleanups", "/gc/cleanups/executed:cleanups"},
+	} {
+		queued, ok := v.get(q.queued)
+		done, okDone := v.get(q.done)
+		if !ok || !okDone || queued == 0 {
 			continue
 		}
-		if v, ok := seg.UintMetrics["/gc/cycles/total:gc-cycles"]; ok {
-			avg := v / uint64(seg.N)
-			if prevGCCycles > 0 && avg >= prevGCCycles {
-				gcDeltas[i] = avg - prevGCCycles
+		r.add(q.label, fmt.Sprintf("%s queued, %s run, %s pending",
+			fmtCount(queued), fmtCount(done), fmtCount(queued-done)))
+	}
+}
+
+func (node *runtimeSectionNode) memoryRows(v goVals, r *runtimeRows) {
+	whole, _ := v.get(mMemTotal)
+	r.total(v, "Total", mMemTotal, fmtBytes)
+	// Ordered by what the reader is after -- live data, then heap the allocator
+	// holds but is not using, then the runtime's own overhead -- rather than by
+	// metric name.
+	for _, row := range []struct{ label, key string }{
+		{"Heap In Use", mHeapInUse},
+		{"Heap Unused", "/memory/classes/heap/unused:bytes"},
+		{"Heap Free", "/memory/classes/heap/free:bytes"},
+		{"Heap Released", "/memory/classes/heap/released:bytes"},
+		{"Goroutine Stacks", "/memory/classes/heap/stacks:bytes"},
+		{"OS Stacks", "/memory/classes/os-stacks:bytes"},
+		{"MSpan", "/memory/classes/metadata/mspan/inuse:bytes"},
+		{"MCache", "/memory/classes/metadata/mcache/inuse:bytes"},
+		{"Metadata Other", "/memory/classes/metadata/other:bytes"},
+		{"Profiling", "/memory/classes/profiling/buckets:bytes"},
+		{"Other", "/memory/classes/other:bytes"},
+	} {
+		r.share(v, row.label, row.key, whole, fmtBytes)
+	}
+}
+
+func (node *runtimeSectionNode) schedulerRows(v goVals, r *runtimeRows) {
+	up, _, _ := v.uptime()
+	r.total(v, "Goroutines", mGoroutines, fmtCount)
+	// The state split is what says whether a large count is a problem: waiting
+	// goroutines are parked and cost only memory, runnable ones are queued
+	// behind a thread. Go 1.25 and later only.
+	for _, row := range []struct{ label, key string }{
+		{"↳ Running", "/sched/goroutines/running:goroutines"},
+		{"↳ Runnable", "/sched/goroutines/runnable:goroutines"},
+		{"↳ Waiting", "/sched/goroutines/waiting:goroutines"},
+		{"↳ Not In Go", "/sched/goroutines/not-in-go:goroutines"},
+	} {
+		r.total(v, row.label, row.key, fmtCount)
+	}
+	r.counter(v, "Created", "/sched/goroutines-created:goroutines", up, fmtCount, "goroutines")
+	r.total(v, "OS Threads", "/sched/threads/total:threads", fmtCount)
+	r.total(v, "GOMAXPROCS", mGomaxprocs, fmtCount)
+	// The ratio is what says whether the run queues are deep: 30k goroutines on
+	// 32 threads is a very different machine from 30k on 512.
+	if goroutines, ok := v.get(mGoroutines); ok {
+		if procs, okProcs := v.get(mGomaxprocs); okProcs && procs > 0 {
+			r.add("Per Thread", fmt.Sprintf("%.1f goroutines", goroutines/procs))
+		}
+	}
+	r.hist(node.runtime, "Run Queue Wait", "/sched/latencies:seconds", v.nodes)
+	// Stopping is how long it took to bring the world to a halt; total also
+	// covers the work done while it was stopped.
+	for _, row := range []struct{ label, key string }{
+		{"STW Stopping (GC)", "/sched/pauses/stopping/gc:seconds"},
+		{"STW Total (GC)", "/sched/pauses/total/gc:seconds"},
+		{"STW Stopping (other)", "/sched/pauses/stopping/other:seconds"},
+		{"STW Total (other)", "/sched/pauses/total/other:seconds"},
+	} {
+		r.hist(node.runtime, row.label, row.key, v.nodes)
+	}
+	r.counter(v, "Cgo Calls", "/cgo/go-to-c-calls:calls", up, fmtCount, "calls")
+}
+
+func (node *runtimeSectionNode) cpuRows(v goVals, r *runtimeRows) {
+	if row, ok := v.uptimeRow(); ok {
+		r.add("Since Start", row)
+	}
+	r.total(v, "Available", mCPUTotal, fmtSecs)
+	// Each class as a share of what was available, which is the utilisation an
+	// operator is after; the cumulative seconds alone only say how long the
+	// process has been up.
+	for _, row := range []struct{ label, key string }{
+		{"User", mCPUUser},
+		{"Idle", "/cpu/classes/idle:cpu-seconds"},
+		{"GC Total", mCPUGC},
+		{"↳ Mark Dedicated", "/cpu/classes/gc/mark/dedicated:cpu-seconds"},
+		{"↳ Mark Assist", "/cpu/classes/gc/mark/assist:cpu-seconds"},
+		{"↳ Mark Idle", "/cpu/classes/gc/mark/idle:cpu-seconds"},
+		{"↳ Pause", "/cpu/classes/gc/pause:cpu-seconds"},
+		{"Scavenge", "/cpu/classes/scavenge/total:cpu-seconds"},
+		{"↳ Assist", "/cpu/classes/scavenge/assist:cpu-seconds"},
+		{"↳ Background", "/cpu/classes/scavenge/background:cpu-seconds"},
+	} {
+		r.cpuShare(v, row.label, row.key)
+	}
+}
+
+func (node *runtimeSectionNode) syncRows(v goVals, r *runtimeRows) {
+	wait, ok := v.get(mMutexWait)
+	if !ok {
+		return
+	}
+	r.total(v, "Mutex Wait", mMutexWait, fmtSecs)
+	// Goroutine-seconds lost per second of wall clock: below 1 the contention
+	// costs less than one goroutine's worth of time, above it there is a queue.
+	if up, _, okUp := v.uptime(); okUp && up > 0 {
+		blocked := fmtRate(wait/float64(v.nodes)/up.Seconds(), func(f float64) string {
+			return strconv.FormatFloat(f, 'f', 2, 64)
+		}, "goroutine-s")
+		r.add("Blocked Rate", blocked+" per node")
+	}
+}
+
+// runtimeWindowRow is a value worth a row in a window. A gauge reads as a level;
+// a counter is cumulative on the wire and only means anything once differenced
+// against the previous segment. brief marks the few that fit a one-line summary.
+type runtimeWindowRow struct {
+	label   string
+	key     string
+	counter bool
+	brief   bool
+	unit    string
+	render  func(float64) string
+}
+
+var runtimeWindowRows = []runtimeWindowRow{
+	{"Goroutines", mGoroutines, false, true, "", fmtCount},
+	{"Heap In Use", mHeapInUse, false, true, "", fmtBytes},
+	{"Heap Objects", mHeapObjects, false, false, "", fmtCount},
+	{"Memory Total", mMemTotal, false, false, "", fmtBytes},
+	{"GC Cycles", mGCCycles, true, true, "cycles", fmtCount},
+	{"Allocated", mAllocBytes, true, true, "", fmtBytes},
+	{"GC CPU", mCPUGC, true, false, "", fmtSecs},
+	{"User CPU", mCPUUser, true, false, "", fmtSecs},
+	{"Mutex Wait", mMutexWait, true, true, "", fmtSecs},
+}
+
+// segDelta is how far a counter advanced into one segment, and over how much wall
+// clock. The two are separate because a segment nobody reported widens the span
+// the next increase covers without widening the segment.
+type segDelta struct {
+	value float64
+	secs  int
+}
+
+// windowStat is one row aggregated over a whole window: the range a gauge moved
+// through, or the total a counter advanced by and the span that took.
+type windowStat struct {
+	min, max, sum, delta float64
+	samples, deltaSecs   int
+}
+
+// runtimeWindow is a window prepared for display: each segment's per-node
+// increase of every counter row, and the whole-window aggregate of every row.
+//
+// Counters arrive cumulative since process start, so a window is only a rate once
+// differenced. A drop means a node restarted inside the window, or that the set
+// of nodes reporting changed and moved the per-node mean; neither can be
+// recovered from the sample, so that segment is left without a rate rather than
+// shown a negative one.
+type runtimeWindow struct {
+	seg    *madmin.SegmentedRuntimeMetrics
+	deltas []map[string]segDelta
+	stats  map[string]windowStat
+}
+
+func newRuntimeWindow(seg *madmin.SegmentedRuntimeMetrics) *runtimeWindow {
+	w := &runtimeWindow{
+		seg:    seg,
+		deltas: make([]map[string]segDelta, len(seg.Segments)),
+		stats:  make(map[string]windowStat, len(runtimeWindowRows)),
+	}
+	type sample struct {
+		value float64
+		index int
+	}
+	prev := make(map[string]sample, len(runtimeWindowRows))
+	for i := range seg.Segments {
+		if seg.Segments[i].N == 0 {
+			continue
+		}
+		v := segmentVals(seg.Segments[i])
+		w.deltas[i] = make(map[string]segDelta, len(runtimeWindowRows))
+		for _, row := range runtimeWindowRows {
+			cur, ok := v.node(row.key)
+			if !ok {
+				continue
 			}
-			prevGCCycles = avg
+			s := w.stats[row.key]
+			if s.samples == 0 || cur < s.min {
+				s.min = cur
+			}
+			if cur > s.max {
+				s.max = cur
+			}
+			s.sum += cur
+			s.samples++
+			if row.counter {
+				// The span is measured from the segment that last reported,
+				// not from the one before this in the slice: a gap of three
+				// quarter hours means the increase took forty-five minutes.
+				if before, seen := prev[row.key]; seen && cur >= before.value {
+					d := segDelta{cur - before.value, (i - before.index) * seg.Interval}
+					w.deltas[i][row.key] = d
+					s.delta += d.value
+					s.deltaSecs += d.secs
+				}
+				prev[row.key] = sample{cur, i}
+			}
+			w.stats[row.key] = s
 		}
 	}
+	return w
+}
 
-	for i := len(node.segmented.Segments) - 1; i >= 0; i-- {
-		seg := node.segmented.Segments[i]
-		if seg.N == 0 {
+// reported is how many segments carry a sample and how many nodes reported across
+// them, so a node count can be divided back out of the sum.
+func (w *runtimeWindow) reported() (segments, nodes int) {
+	for i := range w.seg.Segments {
+		if n := w.seg.Segments[i].N; n > 0 {
+			segments++
+			nodes += n
+		}
+	}
+	return segments, nodes
+}
+
+// wholeSecs is the span the window covers.
+func (w *runtimeWindow) wholeSecs() int {
+	return w.seg.Interval * len(w.seg.Segments)
+}
+
+// summarize renders one row over the whole window: the range a gauge moved
+// through, or how far a counter advanced and how fast.
+func (w *runtimeWindow) summarize(row runtimeWindowRow) (string, bool) {
+	s, ok := w.stats[row.key]
+	if !ok || s.samples == 0 {
+		return "", false
+	}
+	if row.counter {
+		if s.delta <= 0 {
+			return "", false
+		}
+		out := "+" + row.render(s.delta) + "/node over the window"
+		// Over the span the increases were actually observed across, which is
+		// short of the window when the oldest segments went unreported.
+		if s.deltaSecs > 0 {
+			out += ", " + fmtRate(s.delta/float64(s.deltaSecs), row.render, row.unit)
+		}
+		return out, true
+	}
+	out := row.render(s.sum/float64(s.samples)) + "/node avg"
+	if s.min != s.max {
+		out += fmt.Sprintf(" (min %s, max %s)", row.render(s.min), row.render(s.max))
+	}
+	return out, true
+}
+
+// windowRows is the aggregate view of the whole span, shared by the window node's
+// own leaf and its _ALL child.
+func (w *runtimeWindow) windowRows(r *runtimeRows) {
+	r.add("Coverage", windowCoverage(w.seg.FirstTime, w.wholeSecs()))
+	segments, nodes := w.reported()
+	r.add("Segments", fmt.Sprintf("%d of %d reported", segments, len(w.seg.Segments)))
+	if segments == 0 {
+		return
+	}
+	r.add("Nodes", formatNodeCount(nodes, segments))
+	for _, row := range runtimeWindowRows {
+		line, ok := w.summarize(row)
+		r.addIf(row.label, line, ok)
+	}
+}
+
+// describeRuntimeSegment renders one segment on a single line: the levels an
+// operator scans down the column for, and the counters only where they moved.
+func describeRuntimeSegment(w *runtimeWindow, i int) string {
+	v := segmentVals(w.seg.Segments[i])
+	var parts []string
+	for _, row := range runtimeWindowRows {
+		if !row.brief {
 			continue
 		}
-		idx++
-		startTime := node.segmented.FirstTime.Add(time.Duration(i*node.segmented.Interval) * time.Second)
-		endTime := startTime.Add(time.Duration(node.segmented.Interval) * time.Second)
-		name := segmentRowKey(idx, startTime, endTime)
-		n := uint64(seg.N)
-
-		var parts []string
-		parts = append(parts, startTime.Local().Format("15:04"))
-		if v, ok := seg.UintMetrics["/sched/goroutines:goroutines"]; ok {
-			parts = append(parts, fmt.Sprintf("Goroutines: %d", v/n))
+		if row.counter {
+			if d, ok := w.deltas[i][row.key]; ok && d.value > 0 {
+				parts = append(parts, row.label+" +"+row.render(d.value))
+			}
+			continue
 		}
-		if v, ok := seg.UintMetrics["/memory/classes/heap/objects:bytes"]; ok {
-			parts = append(parts, fmt.Sprintf("HeapInuse: %s", formatRuntimeBytes(v/n)))
+		if value, ok := v.node(row.key); ok {
+			parts = append(parts, row.label+" "+row.render(value))
 		}
-		if gcDeltas[i] > 0 {
-			parts = append(parts, fmt.Sprintf("GC: +%d", gcDeltas[i]))
-		}
-		if v, ok := seg.FloatMetrics["/cpu/classes/gc/total:cpu-seconds"]; ok {
-			parts = append(parts, fmt.Sprintf("GC CPU: %.1fs", v/float64(n)))
-		}
-		if v, ok := seg.FloatMetrics["/sync/mutex/wait/total:seconds"]; ok && v > 0 {
-			parts = append(parts, fmt.Sprintf("Mutex wait: %.2fs", v/float64(n)))
-		}
-		if len(parts) == 1 {
-			parts = append(parts, fmt.Sprintf("%d metrics", len(seg.UintMetrics)+len(seg.FloatMetrics)))
-		}
-		data[name] = strings.Join(parts, ", ")
 	}
-	return data
+	if len(parts) == 0 {
+		return formatNodeCount(w.seg.Segments[i].N, 1) + ", no runtime values recorded"
+	}
+	return strings.Join(parts, ", ") + " per node"
+}
+
+// runtimeWindowNode is one persisted runtime window -- the hour or the day -- as a
+// row per time segment plus one navigable child per segment, and an _ALL entry
+// that ranges the gauges and totals the counters over the whole span.
+type runtimeWindowNode struct {
+	seg    *madmin.SegmentedRuntimeMetrics
+	flags  madmin.MetricFlags
+	window string
+	parent MetricNode
+	path   string
+}
+
+func (node *runtimeWindowNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *runtimeWindowNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
+func (node *runtimeWindowNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *runtimeWindowNode) GetParent() MetricNode              { return node.parent }
+func (node *runtimeWindowNode) GetPath() string                    { return node.path }
+func (node *runtimeWindowNode) ShouldPauseRefresh() bool           { return true }
+
+// hasSegments reports whether the window can be placed on a timeline at all. An
+// interval of zero would stamp every segment with the same time.
+func (node *runtimeWindowNode) hasSegments() bool {
+	return node.seg != nil && node.seg.Interval > 0 && len(node.seg.Segments) > 0
+}
+
+func (node *runtimeWindowNode) GetChildren() []MetricChild {
+	if !node.hasSegments() {
+		return []MetricChild{}
+	}
+	w := newRuntimeWindow(node.seg)
+	children := []MetricChild{{
+		Name: "_ALL",
+		Description: "Every segment in the window combined. " +
+			windowCoverage(node.seg.FirstTime, w.wholeSecs()),
+	}}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	withDate := windowCrossesDay(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	// Newest first, as every other family lists a window: the reader is here to
+	// see what just happened, not to read a day from the beginning.
+	for i := len(node.seg.Segments) - 1; i >= 0; i-- {
+		if node.seg.Segments[i].N == 0 {
+			continue
+		}
+		start := segmentStart(node.seg.FirstTime, node.seg.Interval, i)
+		name := segmentKey(start)
+		if owners[name] != i {
+			continue
+		}
+		children = append(children, MetricChild{
+			Name:        name,
+			Description: segmentDescTime(start, withDate) + ", " + describeRuntimeSegment(w, i),
+		})
+	}
+	return children
+}
+
+func (node *runtimeWindowNode) GetChild(name string) (MetricNode, error) {
+	if !node.hasSegments() {
+		return nil, fmt.Errorf("no last-%s runtime segments available", node.window)
+	}
+	leaf := func(index int) MetricNode {
+		return &runtimeSegmentNode{
+			win: newRuntimeWindow(node.seg), index: index, flags: node.flags,
+			parent: node, path: node.path + "/" + name,
+		}
+	}
+	if name == "_ALL" {
+		return leaf(-1), nil
+	}
+	owners := segmentSecOwners(node.seg.FirstTime, node.seg.Interval, len(node.seg.Segments))
+	if i, ok := owners[name]; ok {
+		return leaf(i), nil
+	}
+	return nil, fmt.Errorf("time segment not found: %s", name)
+}
+
+func (node *runtimeWindowNode) GetLeafData() map[string]string {
+	if status := windowStatus(node.seg, node.window); status != "" {
+		return map[string]string{"Status": status}
+	}
+	// The window aggregate only. Each segment states its own levels and rates in
+	// the description of the child that opens it, so repeating them here as rows
+	// pushed the totals off the top of a day's worth of them.
+	r := newRuntimeRows()
+	newRuntimeWindow(node.seg).windowRows(r)
+	return r.data
+}
+
+// runtimeSegmentNode is one segment of a window, or the whole window when index
+// is negative.
+type runtimeSegmentNode struct {
+	win    *runtimeWindow
+	index  int
+	flags  madmin.MetricFlags
+	parent MetricNode
+	path   string
+}
+
+func (node *runtimeSegmentNode) GetOpts() madmin.MetricsOptions     { return getNodeOpts(node) }
+func (node *runtimeSegmentNode) GetMetricType() madmin.MetricType   { return madmin.MetricsRuntime }
+func (node *runtimeSegmentNode) GetMetricFlags() madmin.MetricFlags { return node.flags }
+func (node *runtimeSegmentNode) GetParent() MetricNode              { return node.parent }
+func (node *runtimeSegmentNode) GetPath() string                    { return node.path }
+func (node *runtimeSegmentNode) ShouldPauseRefresh() bool           { return true }
+func (node *runtimeSegmentNode) GetChildren() []MetricChild         { return []MetricChild{} }
+
+func (node *runtimeSegmentNode) GetChild(_ string) (MetricNode, error) {
+	return nil, fmt.Errorf("no children")
+}
+
+func (node *runtimeSegmentNode) GetLeafData() map[string]string {
+	w := node.win
+	r := newRuntimeRows()
+	if node.index < 0 {
+		w.windowRows(r)
+		return r.data
+	}
+	seg := w.seg.Segments[node.index]
+	if seg.N == 0 {
+		return map[string]string{"Status": "no node reported this time segment"}
+	}
+	v := segmentVals(seg)
+	interval := w.seg.Interval
+	r.add("Time Segment", windowCoverage(segmentStart(w.seg.FirstTime, interval, node.index), interval))
+	r.add("Nodes", formatNodeCount(seg.N, 1))
+	for _, row := range runtimeWindowRows {
+		before := r.n
+		r.total(v, row.label, row.key, row.render)
+		if r.n == before {
+			continue
+		}
+		// A counter's level is the process lifetime's; what happened inside the
+		// segment is the increase over the one before it.
+		d, moved := w.deltas[node.index][row.key]
+		if !moved || d.value <= 0 {
+			continue
+		}
+		key := fmt.Sprintf("%02d:%s", before, row.label)
+		value := r.data[key] + fmt.Sprintf(", +%s/node", row.render(d.value))
+		if d.secs > 0 {
+			value += " (" + fmtRate(d.value/float64(d.secs), row.render, row.unit) + ")"
+			if d.secs > interval {
+				value += " since " + segmentKey(segmentStart(w.seg.FirstTime, interval, node.index-d.secs/interval))
+			}
+		}
+		r.data[key] = value
+	}
+	return r.data
 }

--- a/mnav/runtime.go
+++ b/mnav/runtime.go
@@ -215,7 +215,7 @@ func (r *runtimeRows) share(v goVals, label, key string, whole float64, render f
 	if !ok {
 		return
 	}
-	r.add(label, render(part)+qualify(v.nodes, part, whole, render))
+	r.add(label, render(part)+qualify(v.nodes, "node", part, whole, render))
 }
 
 // cpuShare renders a CPU class against the CPU time available since start.
@@ -232,7 +232,7 @@ func (r *runtimeRows) cpuShare(v goVals, label, key string) {
 	if !okTotal {
 		total = 0
 	}
-	r.add(label, fmtSecs(part)+" CPU-time"+qualify(v.nodes, part, total, fmtSecs))
+	r.add(label, fmtSecs(part)+" CPU-time"+qualify(v.nodes, "node", part, total, fmtSecs))
 }
 
 // hist renders a histogram row, skipping one the reporting Go version omits.

--- a/mnav/runtime.go
+++ b/mnav/runtime.go
@@ -107,7 +107,11 @@ func (v goVals) node(key string) (float64, bool) {
 // instead of showing up on its own, which is why every rate taken from it is
 // labelled per node rather than presented as a fleet fact.
 func (v goVals) uptime() (d time.Duration, reported, ok bool) {
-	if v.upNodes > 0 && v.up > 0 {
+	// Only when every node reporting a counter also reported an uptime. Mid
+	// rollout the maps still hold all N nodes' counters while the uptime covers
+	// the upgraded subset, and rating one against the other inflates the result
+	// by however much longer the old nodes have been up.
+	if v.upNodes >= v.nodes && v.up > 0 {
 		return v.up, true, true
 	}
 	cpu, okCPU := v.get(mCPUTotal)
@@ -127,14 +131,15 @@ func (v goVals) uptimeRow() (string, bool) {
 		return "", false
 	}
 	switch {
-	case !reported:
-		return coverDuration(d) + " (derived, mean per node)", true
-	case v.upNodes < v.nodes:
-		return fmt.Sprintf("%s (mean of %d of %d nodes)", coverDuration(d), v.upNodes, v.nodes), true
-	case v.nodes > 1:
+	case reported && v.nodes > 1:
 		return coverDuration(d) + " (mean per node)", true
+	case reported:
+		return coverDuration(d), true
+	case v.upNodes > 0:
+		return fmt.Sprintf("%s (derived; %d of %d nodes report one)",
+			coverDuration(d), v.upNodes, v.nodes), true
 	}
-	return coverDuration(d), true
+	return coverDuration(d) + " (derived, mean per node)", true
 }
 
 // runtimeRows builds leaf data in display order. The leaf renderer sorts on the
@@ -262,13 +267,16 @@ func histLine(h metrics.Float64Histogram, nodes int) (string, bool) {
 			continue
 		}
 		count += c
-		lo, hi := h.Buckets[i], h.Buckets[i+1]
-		// The outermost buckets are unbounded; the finite edge is the only
-		// estimate either of them offers.
-		if math.IsInf(lo, -1) {
+		lo, loOK := histEdge(h.Buckets[i])
+		hi, hiOK := histEdge(h.Buckets[i+1])
+		// An unbounded outer edge has no value to average; the finite side is
+		// the only estimate the bucket offers.
+		switch {
+		case !loOK && !hiOK:
+			continue
+		case !loOK:
 			lo = hi
-		}
-		if math.IsInf(hi, 1) {
+		case !hiOK:
 			hi = lo
 		}
 		weighted += (lo + hi) / 2 * float64(c)
@@ -297,10 +305,26 @@ func histLine(h metrics.Float64Histogram, nodes int) (string, bool) {
 	return out, true
 }
 
+// histEdge reports a bucket boundary and whether it is bounded.
+//
+// The wire carries no infinities: the producer substitutes -math.MaxFloat64 and
+// math.MaxFloat64 for the runtime's open outer edges because JSON cannot encode
+// Inf. Testing for Inf here therefore never fires, and averaging in a sentinel
+// overflows the duration it is rendered as.
+func histEdge(v float64) (float64, bool) {
+	if math.IsInf(v, 0) || v <= -math.MaxFloat64 || v >= math.MaxFloat64 {
+		return 0, false
+	}
+	return v, true
+}
+
 // histQuantile returns the bucket edge the qth sample falls in. bounded is false
-// in the open-ended top bucket, where the edge is a lower bound.
+// in the open outer bucket, where the edge is a lower bound.
 func histQuantile(h metrics.Float64Histogram, count uint64, q float64) (edge float64, bounded, ok bool) {
-	want := uint64(float64(count) * q)
+	// Ceiling rank: flooring puts p99 of two samples at rank 1, which answers
+	// with the first bucket instead of the second sample.
+	want := uint64(math.Ceil(float64(count) * q))
+	want = min(max(want, 1), count)
 	var seen uint64
 	for i, c := range h.Counts {
 		if c == 0 {
@@ -308,10 +332,11 @@ func histQuantile(h metrics.Float64Histogram, count uint64, q float64) (edge flo
 		}
 		seen += c
 		if seen >= want {
-			if hi := h.Buckets[i+1]; !math.IsInf(hi, 1) {
+			if hi, ok := histEdge(h.Buckets[i+1]); ok {
 				return hi, true, true
 			}
-			return h.Buckets[i], false, true
+			lo, ok := histEdge(h.Buckets[i])
+			return lo, false, ok
 		}
 	}
 	return 0, false, false
@@ -609,8 +634,12 @@ func (node *runtimeSectionNode) syncRows(v goVals, r *runtimeRows) {
 }
 
 // runtimeWindowRow is a value worth a row in a window. A gauge reads as a level;
-// a counter is cumulative on the wire and only means anything once differenced
-// against the previous segment. brief marks the few that fit a one-line summary.
+// a counter arrives already differenced -- the producer stores each segment's own
+// increase -- so it is summed, never differenced again. brief marks the few that
+// fit a one-line summary.
+//
+// Only what the producer actually puts in a RuntimeSegment; the live sample's
+// wider metric set is not in the window.
 type runtimeWindowRow struct {
 	label   string
 	key     string
@@ -623,67 +652,54 @@ type runtimeWindowRow struct {
 var runtimeWindowRows = []runtimeWindowRow{
 	{"Goroutines", mGoroutines, false, true, "", fmtCount},
 	{"Heap In Use", mHeapInUse, false, true, "", fmtBytes},
-	{"Heap Objects", mHeapObjects, false, false, "", fmtCount},
-	{"Memory Total", mMemTotal, false, false, "", fmtBytes},
+	{"Goroutine Stacks", "/memory/classes/heap/stacks:bytes", false, false, "", fmtBytes},
 	{"GC Cycles", mGCCycles, true, true, "cycles", fmtCount},
-	{"Allocated", mAllocBytes, true, true, "", fmtBytes},
-	{"GC CPU", mCPUGC, true, false, "", fmtSecs},
-	{"User CPU", mCPUUser, true, false, "", fmtSecs},
-	{"Mutex Wait", mMutexWait, true, true, "", fmtSecs},
-}
-
-// segDelta is how far a counter advanced into one segment, and over how much wall
-// clock. The two are separate because a segment nobody reported widens the span
-// the next increase covers without widening the segment.
-type segDelta struct {
-	value float64
-	secs  int
+	// Counted, not timed: the producer stores how many pauses the segment saw,
+	// under the histogram's own name.
+	{"GC Pauses", "/gc/pauses:seconds", true, true, "pauses", fmtCount},
 }
 
 // windowStat is one row aggregated over a whole window: the range a gauge moved
-// through, or the total a counter advanced by and the span that took.
+// through, or the total a counter advanced by.
 type windowStat struct {
 	min, max, sum, delta float64
-	samples, deltaSecs   int
+	samples, segments    int
 }
 
-// runtimeWindow is a window prepared for display: each segment's per-node
-// increase of every counter row, and the whole-window aggregate of every row.
+// runtimeWindow is a window prepared for display: the whole-window aggregate of
+// every row.
 //
-// Counters arrive cumulative since process start, so a window is only a rate once
-// differenced. A drop means a node restarted inside the window, or that the set
-// of nodes reporting changed and moved the per-node mean; neither can be
-// recovered from the sample, so that segment is left without a rate rather than
-// shown a negative one.
+// A counter is already a per-segment delta on the wire -- the producer stores
+// each segment's own increase -- so the window total is their sum. Differencing
+// adjacent segments again would measure the change in the rate rather than the
+// activity, and would read three equal segments as no activity at all.
 type runtimeWindow struct {
-	seg    *madmin.SegmentedRuntimeMetrics
-	deltas []map[string]segDelta
-	stats  map[string]windowStat
+	seg   *madmin.SegmentedRuntimeMetrics
+	stats map[string]windowStat
 }
 
 func newRuntimeWindow(seg *madmin.SegmentedRuntimeMetrics) *runtimeWindow {
 	w := &runtimeWindow{
-		seg:    seg,
-		deltas: make([]map[string]segDelta, len(seg.Segments)),
-		stats:  make(map[string]windowStat, len(runtimeWindowRows)),
+		seg:   seg,
+		stats: make(map[string]windowStat, len(runtimeWindowRows)),
 	}
-	type sample struct {
-		value float64
-		index int
-	}
-	prev := make(map[string]sample, len(runtimeWindowRows))
 	for i := range seg.Segments {
 		if seg.Segments[i].N == 0 {
 			continue
 		}
 		v := segmentVals(seg.Segments[i])
-		w.deltas[i] = make(map[string]segDelta, len(runtimeWindowRows))
 		for _, row := range runtimeWindowRows {
 			cur, ok := v.node(row.key)
 			if !ok {
 				continue
 			}
 			s := w.stats[row.key]
+			if row.counter {
+				s.delta += cur
+				s.segments++
+				w.stats[row.key] = s
+				continue
+			}
 			if s.samples == 0 || cur < s.min {
 				s.min = cur
 			}
@@ -692,18 +708,6 @@ func newRuntimeWindow(seg *madmin.SegmentedRuntimeMetrics) *runtimeWindow {
 			}
 			s.sum += cur
 			s.samples++
-			if row.counter {
-				// The span is measured from the segment that last reported,
-				// not from the one before this in the slice: a gap of three
-				// quarter hours means the increase took forty-five minutes.
-				if before, seen := prev[row.key]; seen && cur >= before.value {
-					d := segDelta{cur - before.value, (i - before.index) * seg.Interval}
-					w.deltas[i][row.key] = d
-					s.delta += d.value
-					s.deltaSecs += d.secs
-				}
-				prev[row.key] = sample{cur, i}
-			}
 			w.stats[row.key] = s
 		}
 	}
@@ -731,7 +735,7 @@ func (w *runtimeWindow) wholeSecs() int {
 // through, or how far a counter advanced and how fast.
 func (w *runtimeWindow) summarize(row runtimeWindowRow) (string, bool) {
 	s, ok := w.stats[row.key]
-	if !ok || s.samples == 0 {
+	if !ok {
 		return "", false
 	}
 	if row.counter {
@@ -739,12 +743,15 @@ func (w *runtimeWindow) summarize(row runtimeWindowRow) (string, bool) {
 			return "", false
 		}
 		out := "+" + row.render(s.delta) + "/node over the window"
-		// Over the span the increases were actually observed across, which is
-		// short of the window when the oldest segments went unreported.
-		if s.deltaSecs > 0 {
-			out += ", " + fmtRate(s.delta/float64(s.deltaSecs), row.render, row.unit)
+		// Over the segments that reported, not the window, so a gap does not
+		// dilute the rate.
+		if secs := s.segments * w.seg.Interval; secs > 0 {
+			out += ", " + fmtRate(s.delta/float64(secs), row.render, row.unit)
 		}
 		return out, true
+	}
+	if s.samples == 0 {
+		return "", false
 	}
 	out := row.render(s.sum/float64(s.samples)) + "/node avg"
 	if s.min != s.max {
@@ -778,15 +785,17 @@ func describeRuntimeSegment(w *runtimeWindow, i int) string {
 		if !row.brief {
 			continue
 		}
+		value, ok := v.node(row.key)
+		if !ok {
+			continue
+		}
 		if row.counter {
-			if d, ok := w.deltas[i][row.key]; ok && d.value > 0 {
-				parts = append(parts, row.label+" +"+row.render(d.value))
+			if value > 0 {
+				parts = append(parts, row.label+" +"+row.render(value))
 			}
 			continue
 		}
-		if value, ok := v.node(row.key); ok {
-			parts = append(parts, row.label+" "+row.render(value))
-		}
+		parts = append(parts, row.label+" "+row.render(value))
 	}
 	if len(parts) == 0 {
 		return formatNodeCount(w.seg.Segments[i].N, 1) + ", no runtime values recorded"
@@ -919,26 +928,21 @@ func (node *runtimeSegmentNode) GetLeafData() map[string]string {
 	r.add("Time Segment", windowCoverage(segmentStart(w.seg.FirstTime, interval, node.index), interval))
 	r.add("Nodes", formatNodeCount(seg.N, 1))
 	for _, row := range runtimeWindowRows {
-		before := r.n
-		r.total(v, row.label, row.key, row.render)
-		if r.n == before {
+		perNode, ok := v.node(row.key)
+		if !ok {
 			continue
 		}
-		// A counter's level is the process lifetime's; what happened inside the
-		// segment is the increase over the one before it.
-		d, moved := w.deltas[node.index][row.key]
-		if !moved || d.value <= 0 {
+		if !row.counter {
+			r.total(v, row.label, row.key, row.render)
 			continue
 		}
-		key := fmt.Sprintf("%02d:%s", before, row.label)
-		value := r.data[key] + fmt.Sprintf(", +%s/node", row.render(d.value))
-		if d.secs > 0 {
-			value += " (" + fmtRate(d.value/float64(d.secs), row.render, row.unit) + ")"
-			if d.secs > interval {
-				value += " since " + segmentKey(segmentStart(w.seg.FirstTime, interval, node.index-d.secs/interval))
-			}
+		// Already this segment's own increase, so it is stated as such rather
+		// than as a level.
+		value := "+" + row.render(perNode) + "/node"
+		if interval > 0 {
+			value += " (" + fmtRate(perNode/float64(interval), row.render, row.unit) + ")"
 		}
-		r.data[key] = value
+		r.add(row.label, value)
 	}
 	return r.data
 }

--- a/mnav/runtime_test.go
+++ b/mnav/runtime_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package mnav
+
+import (
+	"reflect"
+	"runtime/metrics"
+	"strings"
+	"testing"
+
+	"github.com/minio/madmin-go/v4"
+)
+
+// goNav builds a navigator over one merged runtime sample. Values are given
+// per node and summed here, the way the wire carries them.
+func goNav(nodes int, uints map[string]uint64, floats map[string]float64) MetricNavigator {
+	r := &madmin.RuntimeMetrics{
+		N:            nodes,
+		UintMetrics:  make(map[string]uint64, len(uints)),
+		FloatMetrics: make(map[string]float64, len(floats)),
+	}
+	for k, v := range uints {
+		r.UintMetrics[k] = v * uint64(nodes)
+	}
+	for k, v := range floats {
+		r.FloatMetrics[k] = v * float64(nodes)
+	}
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Go: r},
+	})
+}
+
+// Every runtime value on the wire is a sum across the nodes that reported, gauges
+// included, so the fleet figure alone answers no question an operator has:
+// "Active Goroutines 961,763" on a 17-node cluster is 56,574 per process.
+func TestRuntimeValuesCarryPerNodeMean(t *testing.T) {
+	const nodes = 17
+	nav := goNav(nodes, map[string]uint64{
+		mGoroutines:  56_574,
+		mGomaxprocs:  64,
+		mHeapInUse:   2 << 30,
+		mHeapObjects: 1_000_000,
+		mGCCycles:    500,
+	}, map[string]float64{
+		// 64 threads busy for an hour: the uptime every rate below derives from.
+		mCPUTotal: 3600 * 64,
+		mCPUUser:  3600 * 64 * 0.25,
+	})
+
+	root, err := nav.Navigate("go")
+	if err != nil {
+		t.Fatalf("navigate go: %v", err)
+	}
+	data := root.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"Nodes", "17 node(s)"},
+		{"Goroutines", "961,758 (56,574/node)"},
+		{"GOMAXPROCS", "1,088 (64/node)"},
+		{"Heap In Use", "36 GB (2.1 GB/node)"},
+		{"Uptime", "1h (derived, mean per node)"},
+		// A counter is worth a rate, and the only window it has is the uptime.
+		// Under one per second it is stated per minute: 500 collections in an
+		// hour is 8.3 a minute, not "0.139 cycles/s".
+		{"GC Cycles", "8,500 (500/node), 8.3 cycles/min"},
+		{"User CPU", "272h0m0s CPU-time (16h0m0s/node, 25.0%)"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+
+	// The counts of how many metric names the sample happened to carry said
+	// nothing about the cluster and crowded out what did.
+	for _, gone := range []string{"Uint64 Metrics", "Float64 Metrics", "Histogram Metrics", "Total Metrics", "Metric Categories"} {
+		if got := leafValue(data, gone); got != "" {
+			t.Errorf("%s = %q, want it dropped", gone, got)
+		}
+	}
+}
+
+// A reported uptime beats the one derived from the CPU accounting, and says so.
+// Until the servers carry the field nothing reports one, so the derived value has
+// to keep working -- and a partial rollout must divide by the nodes that answered
+// rather than by the cluster, or the mean drops with the share still silent.
+func TestRuntimeUptimePrefersReported(t *testing.T) {
+	uptimeOf := func(reportedBy int, secs float64) string {
+		nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+			Aggregated: madmin.Metrics{Go: &madmin.RuntimeMetrics{
+				N:           10,
+				UptimeSecs:  secs,
+				UptimeNodes: reportedBy,
+				UintMetrics: map[string]uint64{mGomaxprocs: 8 * 10},
+				// The derivation would say two hours.
+				FloatMetrics: map[string]float64{mCPUTotal: 7200 * 8 * 10},
+			}},
+		})
+		node, err := nav.Navigate("go")
+		if err != nil {
+			t.Fatalf("navigate go: %v", err)
+		}
+		return leafValue(node.GetLeafData(), "Uptime")
+	}
+	for _, tc := range []struct {
+		name       string
+		reportedBy int
+		secs       float64
+		want       string
+	}{
+		{"nobody reports one", 0, 0, "2h (derived, mean per node)"},
+		{"whole fleet reports", 10, 3600 * 10, "1h (mean per node)"},
+		{"half the fleet reports", 4, 3600 * 4, "1h (mean of 4 of 10 nodes)"},
+	} {
+		if got := uptimeOf(tc.reportedBy, tc.secs); got != tc.want {
+			t.Errorf("%s: Uptime = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// A single-node sample has no mean to add, and repeating the value would be pure
+// noise.
+func TestRuntimeSingleNodeHasNoMean(t *testing.T) {
+	nav := goNav(1, map[string]uint64{mGoroutines: 400}, nil)
+	root, err := nav.Navigate("go")
+	if err != nil {
+		t.Fatalf("navigate go: %v", err)
+	}
+	if got, want := leafValue(root.GetLeafData(), "Goroutines"), "400"; got != want {
+		t.Errorf("Goroutines = %q, want %q", got, want)
+	}
+}
+
+// The CPU classes are cumulative since start, so a share of the CPU time that was
+// available is the only rate they can give -- and the sub-percent ones must not
+// all round to the same "0.00%".
+func TestRuntimeCPUClassesAreShares(t *testing.T) {
+	nav := goNav(4, map[string]uint64{mGomaxprocs: 8}, map[string]float64{
+		mCPUTotal:                       1000,
+		mCPUUser:                        250,
+		"/cpu/classes/idle:cpu-seconds": 749,
+		mCPUGC:                          1,
+		"/cpu/classes/gc/mark/dedicated:cpu-seconds": 0.05,
+	})
+	node, err := nav.Navigate("go/cpu_classes")
+	if err != nil {
+		t.Fatalf("navigate cpu_classes: %v", err)
+	}
+	data := node.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"User", "16m40s CPU-time (4m10s/node, 25.0%)"},
+		{"Idle", "49m56s CPU-time (12m29s/node, 74.9%)"},
+		{"GC Total", "4s CPU-time (1s/node, 0.10%)"},
+		{"↳ Mark Dedicated", "200ms CPU-time (50ms/node, <0.01%)"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+}
+
+// A breakdown states the split, but the per-node mean is what the rest of the
+// section carries and what an operator compares against one process. Showing only
+// the share drops the magnitude the reader came for.
+func TestRuntimeMemoryClassesCarryBothMeanAndShare(t *testing.T) {
+	nav := goNav(8, map[string]uint64{
+		mMemTotal:                         1000 << 20,
+		mHeapInUse:                        700 << 20,
+		"/memory/classes/heap/free:bytes": 300 << 20,
+	}, nil)
+	node, err := nav.Navigate("go/memory")
+	if err != nil {
+		t.Fatalf("navigate memory: %v", err)
+	}
+	data := node.GetLeafData()
+	for _, want := range []struct{ label, value string }{
+		{"Total", "8.4 GB (1.0 GB/node)"},
+		{"Heap In Use", "5.9 GB (734 MB/node, 70.0%)"},
+		{"Heap Free", "2.5 GB (315 MB/node, 30.0%)"},
+	} {
+		if got := leafValue(data, want.label); got != want.value {
+			t.Errorf("%s = %q, want %q", want.label, got, want.value)
+		}
+	}
+}
+
+// Half of a real cluster's GC pauses landed under 64ns, which the shared
+// duration helper floors to "0s" -- a percentile that reads as "instant" for
+// every histogram is worse than none.
+func TestRuntimeHistogramKeepsNanoseconds(t *testing.T) {
+	h := metrics.Float64Histogram{
+		Buckets: []float64{0, 64e-9, 128e-9, 1e-3, 4e-3},
+		Counts:  []uint64{530, 100, 40, 2},
+	}
+	line, ok := histLine(h, 6)
+	if !ok {
+		t.Fatal("histLine returned no summary")
+	}
+	for _, want := range []string{"672 (112/node)", "p50 64ns", "p99 1ms"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("histLine = %q, want it to contain %q", line, want)
+		}
+	}
+}
+
+// runtimeWindow builds a day window whose gauges move and whose counters climb,
+// so both halves of the segment view have something to render.
+func runtimeWindowNav(t *testing.T) MetricNavigator {
+	t.Helper()
+	const nodes = 3
+	segs := make([]madmin.RuntimeSegment, 4)
+	for i := range segs {
+		segs[i] = madmin.RuntimeSegment{
+			N: nodes,
+			UintMetrics: map[string]uint64{
+				mGoroutines: uint64(500+i*100) * nodes,
+				mHeapInUse:  uint64(1<<30) * nodes,
+				mGCCycles:   uint64(1000+i*10) * nodes,
+				mAllocBytes: uint64(i+1) * (1 << 30) * nodes,
+			},
+		}
+	}
+	return NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Go: &madmin.RuntimeMetrics{
+			N: nodes,
+			LastDay: &madmin.SegmentedRuntimeMetrics{
+				Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+			},
+		}},
+	})
+}
+
+// The window used to be a flat wall of rows with no total and nothing to open.
+// It now lists an _ALL summary and a navigable child per segment, and the
+// counters -- cumulative since process start on the wire -- are differenced into
+// rates rather than shown as their lifetime level.
+func TestRuntimeWindowNavigation(t *testing.T) {
+	nav := runtimeWindowNav(t)
+
+	day, err := nav.Navigate("go/last_day")
+	if err != nil {
+		t.Fatalf("navigate last_day: %v", err)
+	}
+	// Newest first, behind _ALL, the way every family lists a window.
+	names := childNames(day.GetChildren())
+	want := []string{"_ALL", "10:45Z", "10:30Z", "10:15Z", "10:00Z"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("children = %v, want %v", names, want)
+	}
+	// Each child says what happened in its segment, so the window page is the
+	// aggregate and nothing else -- a day of segment rows buried the totals.
+	if got := childDesc(day.GetChildren(), "10:30Z"); !strings.Contains(got, "GC Cycles +10") {
+		t.Errorf("segment description = %q, want the segment's own movement in it", got)
+	}
+	for key := range day.GetLeafData() {
+		if strings.Contains(key, "Z") && !strings.Contains(key, "Coverage") {
+			t.Errorf("window leaf carries per-segment row %q, want the aggregate only", key)
+		}
+	}
+
+	// _ALL ranges the gauges and totals the counters: three steps of ten cycles
+	// across four samples. The rate is over the 45 minutes those three increases
+	// were observed across, not the hour the window spans -- the first sample only
+	// establishes a baseline, and nothing is attributable to it.
+	all, err := nav.Navigate("go/last_day/_ALL")
+	if err != nil {
+		t.Fatalf("navigate _ALL: %v", err)
+	}
+	data := all.GetLeafData()
+	for _, w := range []struct{ label, value string }{
+		{"Segments", "4 of 4 reported"},
+		{"Nodes", "3 node(s)"},
+		{"Goroutines", "650/node avg (min 500, max 800)"},
+		{"Heap In Use", "1.1 GB/node avg"},
+		{"GC Cycles", "+30/node over the window, 0.7 cycles/min"},
+		{"Allocated", "+3.2 GB/node over the window, 1.2 MB/s"},
+	} {
+		if got := leafValue(data, w.label); got != w.value {
+			t.Errorf("_ALL %s = %q, want %q", w.label, got, w.value)
+		}
+	}
+
+	// A segment states the level and what moved inside it, at the segment's own
+	// 15-minute rate.
+	seg, err := nav.Navigate("go/last_day/10:30Z")
+	if err != nil {
+		t.Fatalf("navigate segment: %v", err)
+	}
+	data = seg.GetLeafData()
+	for _, w := range []struct{ label, value string }{
+		{"Nodes", "3 node(s)"},
+		{"Goroutines", "2,100 (700/node)"},
+		{"GC Cycles", "3,060 (1,020/node), +10/node (0.7 cycles/min)"},
+	} {
+		if got := leafValue(data, w.label); got != w.value {
+			t.Errorf("segment %s = %q, want %q", w.label, got, w.value)
+		}
+	}
+	if got := leafValue(data, "Time Segment"); !strings.HasPrefix(got, "Covering 15m") {
+		t.Errorf("Time Segment = %q, want it to cover 15m", got)
+	}
+}
+
+// A node that restarted inside the window resets its cumulative counters, and the
+// per-node mean drops with it. There is no way to recover the missing span from
+// the sample, so that segment carries no rate rather than a negative one.
+func TestRuntimeWindowSkipsCounterResets(t *testing.T) {
+	const nodes = 2
+	cycles := []uint64{1000, 1010, 4, 14}
+	segs := make([]madmin.RuntimeSegment, len(cycles))
+	for i, c := range cycles {
+		segs[i] = madmin.RuntimeSegment{
+			N:           nodes,
+			UintMetrics: map[string]uint64{mGCCycles: c * nodes},
+		}
+	}
+	w := newRuntimeWindow(&madmin.SegmentedRuntimeMetrics{
+		Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+	})
+	if got, ok := w.deltas[2][mGCCycles]; ok {
+		t.Errorf("reset segment carries delta %v, want none", got)
+	}
+	// The span the surviving delta covers is measured from the segment that
+	// last reported, so a gap does not inflate the rate derived from it.
+	if got, want := w.deltas[3][mGCCycles].secs, 900; got != want {
+		t.Errorf("delta span = %v, want %v", got, want)
+	}
+	if got, want := w.deltas[3][mGCCycles].value, 10.0; got != want {
+		t.Errorf("delta after the reset = %v, want %v", got, want)
+	}
+	// The window total is the sum of the deltas it could trust, not last minus
+	// first -- which would be negative here.
+	if got, want := w.stats[mGCCycles].delta, 20.0; got != want {
+		t.Errorf("window delta = %v, want %v", got, want)
+	}
+}
+
+// A window that was never requested and one that is still filling are opposite
+// answers, and neither is a measured zero.
+func TestRuntimeWindowStates(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Go: &madmin.RuntimeMetrics{
+			N:       1,
+			LastDay: &madmin.SegmentedRuntimeMetrics{Interval: 900},
+		}},
+	})
+	for _, tc := range []struct{ path, want string }{
+		{"go/last_hour", "not collected"},
+		{"go/last_day", "no data yet"},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := node.GetLeafData()["Status"]; !strings.Contains(got, tc.want) {
+			t.Errorf("%s status = %q, want it to contain %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// The window nodes ask for their own history; the root does not, so a continuous
+// refresh does not pull the hour and the day on every tick.
+func TestRuntimeWindowFlags(t *testing.T) {
+	nav := runtimeWindowNav(t)
+	for _, tc := range []struct {
+		path string
+		want madmin.MetricFlags
+	}{
+		{"go", 0},
+		{"go/gc", 0},
+		{"go/last_day", madmin.MetricsDayStats},
+		{"go/last_day/_ALL", madmin.MetricsDayStats},
+		{"go/last_day/10:00Z", madmin.MetricsDayStats},
+		{"go/last_hour", madmin.MetricsHourStats},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := node.GetMetricFlags(); got != tc.want {
+			t.Errorf("%s flags = %v, want %v", tc.path, got, tc.want)
+		}
+		if got := node.GetOpts().Type; got&madmin.MetricsRuntime == 0 {
+			t.Errorf("%s opts type = %v, want MetricsRuntime", tc.path, got)
+		}
+	}
+}
+
+// childDesc is the description listed for one child, or "" when it is absent.
+func childDesc(children []MetricChild, name string) string {
+	for _, c := range children {
+		if c.Name == name {
+			return c.Description
+		}
+	}
+	return ""
+}

--- a/mnav/runtime_test.go
+++ b/mnav/runtime_test.go
@@ -18,6 +18,7 @@
 package mnav
 
 import (
+	"math"
 	"reflect"
 	"runtime/metrics"
 	"strings"
@@ -95,8 +96,12 @@ func TestRuntimeValuesCarryPerNodeMean(t *testing.T) {
 
 // A reported uptime beats the one derived from the CPU accounting, and says so.
 // Until the servers carry the field nothing reports one, so the derived value has
-// to keep working -- and a partial rollout must divide by the nodes that answered
-// rather than by the cluster, or the mean drops with the share still silent.
+// to keep working.
+//
+// A partial rollout falls back to the derived value: the metric maps still hold
+// every node's counters while the reported uptime covers only the upgraded ones,
+// and rating all-node counters against a subset's uptime inflates them by however
+// much longer the rest have been up.
 func TestRuntimeUptimePrefersReported(t *testing.T) {
 	uptimeOf := func(reportedBy int, secs float64) string {
 		nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
@@ -123,7 +128,7 @@ func TestRuntimeUptimePrefersReported(t *testing.T) {
 	}{
 		{"nobody reports one", 0, 0, "2h (derived, mean per node)"},
 		{"whole fleet reports", 10, 3600 * 10, "1h (mean per node)"},
-		{"half the fleet reports", 4, 3600 * 4, "1h (mean of 4 of 10 nodes)"},
+		{"half the fleet reports", 4, 3600 * 4, "2h (derived; 4 of 10 nodes report one)"},
 	} {
 		if got := uptimeOf(tc.reportedBy, tc.secs); got != tc.want {
 			t.Errorf("%s: Uptime = %q, want %q", tc.name, got, tc.want)
@@ -228,8 +233,9 @@ func runtimeWindowNav(t *testing.T) MetricNavigator {
 			UintMetrics: map[string]uint64{
 				mGoroutines: uint64(500+i*100) * nodes,
 				mHeapInUse:  uint64(1<<30) * nodes,
-				mGCCycles:   uint64(1000+i*10) * nodes,
-				mAllocBytes: uint64(i+1) * (1 << 30) * nodes,
+				// Already this segment's own increase, the way the producer
+				// stores it.
+				mGCCycles: 10 * nodes,
 			},
 		}
 	}
@@ -271,10 +277,8 @@ func TestRuntimeWindowNavigation(t *testing.T) {
 		}
 	}
 
-	// _ALL ranges the gauges and totals the counters: three steps of ten cycles
-	// across four samples. The rate is over the 45 minutes those three increases
-	// were observed across, not the hour the window spans -- the first sample only
-	// establishes a baseline, and nothing is attributable to it.
+	// _ALL ranges the gauges and sums the counters: four segments of ten cycles
+	// are forty, over the hour they were measured across.
 	all, err := nav.Navigate("go/last_day/_ALL")
 	if err != nil {
 		t.Fatalf("navigate _ALL: %v", err)
@@ -285,8 +289,7 @@ func TestRuntimeWindowNavigation(t *testing.T) {
 		{"Nodes", "3 node(s)"},
 		{"Goroutines", "650/node avg (min 500, max 800)"},
 		{"Heap In Use", "1.1 GB/node avg"},
-		{"GC Cycles", "+30/node over the window, 0.7 cycles/min"},
-		{"Allocated", "+3.2 GB/node over the window, 1.2 MB/s"},
+		{"GC Cycles", "+40/node over the window, 0.7 cycles/min"},
 	} {
 		if got := leafValue(data, w.label); got != w.value {
 			t.Errorf("_ALL %s = %q, want %q", w.label, got, w.value)
@@ -303,7 +306,7 @@ func TestRuntimeWindowNavigation(t *testing.T) {
 	for _, w := range []struct{ label, value string }{
 		{"Nodes", "3 node(s)"},
 		{"Goroutines", "2,100 (700/node)"},
-		{"GC Cycles", "3,060 (1,020/node), +10/node (0.7 cycles/min)"},
+		{"GC Cycles", "+10/node (0.7 cycles/min)"},
 	} {
 		if got := leafValue(data, w.label); got != w.value {
 			t.Errorf("segment %s = %q, want %q", w.label, got, w.value)
@@ -314,37 +317,74 @@ func TestRuntimeWindowNavigation(t *testing.T) {
 	}
 }
 
-// A node that restarted inside the window resets its cumulative counters, and the
-// per-node mean drops with it. There is no way to recover the missing span from
-// the sample, so that segment carries no rate rather than a negative one.
-func TestRuntimeWindowSkipsCounterResets(t *testing.T) {
+// The producer stores each segment's own increase, so a window sums them.
+// Differencing adjacent segments again measures the change in the rate instead
+// of the activity: three equal segments would come back as no activity at all,
+// and [10, 12, 8] would report +2 and discard the last eight as a reset.
+func TestRuntimeWindowSumsSegmentDeltas(t *testing.T) {
 	const nodes = 2
-	cycles := []uint64{1000, 1010, 4, 14}
-	segs := make([]madmin.RuntimeSegment, len(cycles))
-	for i, c := range cycles {
-		segs[i] = madmin.RuntimeSegment{
-			N:           nodes,
-			UintMetrics: map[string]uint64{mGCCycles: c * nodes},
+	for _, tc := range []struct {
+		name   string
+		cycles []uint64
+		want   float64
+	}{
+		{"steady", []uint64{10, 10, 10}, 30},
+		{"varying", []uint64{10, 12, 8}, 30},
+	} {
+		segs := make([]madmin.RuntimeSegment, len(tc.cycles))
+		for i, c := range tc.cycles {
+			segs[i] = madmin.RuntimeSegment{
+				N: nodes, UintMetrics: map[string]uint64{mGCCycles: c * nodes},
+			}
+		}
+		w := newRuntimeWindow(&madmin.SegmentedRuntimeMetrics{
+			Interval: 900, FirstTime: dupFirstTime, Segments: segs,
+		})
+		if got := w.stats[mGCCycles].delta; got != tc.want {
+			t.Errorf("%s: window total = %v, want %v", tc.name, got, tc.want)
 		}
 	}
-	w := newRuntimeWindow(&madmin.SegmentedRuntimeMetrics{
-		Interval: 900, FirstTime: dupFirstTime, Segments: segs,
-	})
-	if got, ok := w.deltas[2][mGCCycles]; ok {
-		t.Errorf("reset segment carries delta %v, want none", got)
+}
+
+// The wire carries no infinities -- the producer swaps the runtime's open outer
+// edges for +/-math.MaxFloat64, since JSON cannot encode Inf -- so a populated
+// outer bucket used to average a sentinel into the mean and overflow the duration
+// it renders as.
+func TestRuntimeHistogramHandlesFiniteSentinels(t *testing.T) {
+	h := metrics.Float64Histogram{
+		Buckets: []float64{-math.MaxFloat64, 0, 1e-3, math.MaxFloat64},
+		Counts:  []uint64{1, 96, 3},
 	}
-	// The span the surviving delta covers is measured from the segment that
-	// last reported, so a gap does not inflate the rate derived from it.
-	if got, want := w.deltas[3][mGCCycles].secs, 900; got != want {
-		t.Errorf("delta span = %v, want %v", got, want)
+	line, ok := histLine(h, 1)
+	if !ok {
+		t.Fatal("histLine returned no summary")
 	}
-	if got, want := w.deltas[3][mGCCycles].value, 10.0; got != want {
-		t.Errorf("delta after the reset = %v, want %v", got, want)
+	if strings.Contains(line, "e+") || strings.Contains(line, "2562047h") {
+		t.Errorf("histLine = %q, want the sentinel left out of the mean", line)
 	}
-	// The window total is the sum of the deltas it could trust, not last minus
-	// first -- which would be negative here.
-	if got, want := w.stats[mGCCycles].delta, 20.0; got != want {
-		t.Errorf("window delta = %v, want %v", got, want)
+	// The top bucket is open, so its edge is only a lower bound.
+	if !strings.Contains(line, "p99 >1ms") {
+		t.Errorf("histLine = %q, want p99 reported as a lower bound", line)
+	}
+}
+
+// Flooring the rank puts p99 of two samples at rank 1, answering with the first
+// bucket rather than the second sample.
+func TestRuntimeHistogramPercentileRankCeils(t *testing.T) {
+	h := metrics.Float64Histogram{
+		Buckets: []float64{0, 1e-6, 1e-3},
+		Counts:  []uint64{1, 1},
+	}
+	edge, bounded, ok := histQuantile(h, 2, 0.99)
+	if !ok || !bounded {
+		t.Fatalf("histQuantile ok=%v bounded=%v, want a bounded edge", ok, bounded)
+	}
+	if edge != 1e-3 {
+		t.Errorf("p99 edge = %v, want %v: the second sample's bucket", edge, 1e-3)
+	}
+	// p50 of two samples is the first.
+	if edge, _, _ := histQuantile(h, 2, 0.5); edge != 1e-6 {
+		t.Errorf("p50 edge = %v, want %v", edge, 1e-6)
 	}
 }
 
@@ -407,4 +447,53 @@ func childDesc(children []MetricChild, name string) string {
 		}
 	}
 	return ""
+}
+
+// The three sections that no test reached: their derived rows -- the queue
+// backlogs, the goroutines-per-thread ratio and the blocked rate -- exist only
+// here, so nothing else would catch them going wrong.
+func TestRuntimeSectionsRenderDerivedRows(t *testing.T) {
+	const nodes = 4
+	nav := goNav(nodes, map[string]uint64{
+		mGomaxprocs:                             32,
+		mGoroutines:                             640,
+		mGCCycles:                               500,
+		mHeapInUse:                              2 << 30,
+		mHeapObjects:                            1_000_000,
+		"/gc/heap/goal:bytes":                   3 << 30,
+		"/gc/gogc:percent":                      100,
+		"/gc/finalizers/queued:finalizers":      900,
+		"/gc/finalizers/executed:finalizers":    875,
+		"/sched/threads/total:threads":          40,
+		"/sched/goroutines/runnable:goroutines": 12,
+		"/cgo/go-to-c-calls:calls":              360_000,
+	}, map[string]float64{
+		mCPUTotal:  3600 * 32,
+		mCPUUser:   3600 * 32 * 0.25,
+		mCPUGC:     3600 * 32 * 0.01,
+		mMutexWait: 36,
+	})
+
+	for _, tc := range []struct{ path, label, want string }{
+		{"go/gc", "Cycles", "2,000 (500/node), 8.3 cycles/min"},
+		{"go/gc", "GOGC", "100%"},
+		// Queued minus run is the backlog; a queue outrunning its runs is a
+		// leak in the making.
+		{"go/gc", "Finalizers", "3,600 queued, 3,500 run, 100 pending"},
+		{"go/scheduler", "Goroutines", "2,560 (640/node)"},
+		{"go/scheduler", "↳ Runnable", "48 (12/node)"},
+		{"go/scheduler", "OS Threads", "160 (40/node)"},
+		{"go/scheduler", "Per Thread", "20.0 goroutines"},
+		{"go/scheduler", "Cgo Calls", "1,440,000 (360,000/node), 100 calls/s"},
+		{"go/sync", "Mutex Wait", "2m24s (36s/node)"},
+		{"go/sync", "Blocked Rate", "0.60 goroutine-s/min per node"},
+	} {
+		node, err := nav.Navigate(tc.path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", tc.path, err)
+		}
+		if got := leafValue(node.GetLeafData(), tc.label); got != tc.want {
+			t.Errorf("%s %s = %q, want %q", tc.path, tc.label, got, tc.want)
+		}
+	}
 }

--- a/mnav/segments.go
+++ b/mnav/segments.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v4"
 )
 
@@ -217,4 +219,126 @@ func formatNodeCount(n, segments int) string {
 		return fmt.Sprintf("%d node(s)", int(avg))
 	}
 	return fmt.Sprintf("%.1f node(s) avg", avg)
+}
+
+// windowSecs returns the wall-clock seconds a stat covers, for use as the
+// denominator of a rate.
+//
+// A WallTimeSecs field is accumulated from every source folded in: each node,
+// operation and time segment merged contributes its own window, so a minute of
+// twenty operations on sixteen nodes carries 19200 seconds. Reading that raw
+// reports a rate hundreds of times below the real one, so it is only usable when
+// the number of merged sources is known.
+//
+// known is that window when the view fixes it (60 for a last minute, the interval
+// times the segment count for a day). Zero means it does not, and the node count
+// is divided out instead -- exact only where nodes were the sole axis merged,
+// which is the case for since-start totals.
+func windowSecs(known, wallTimeSecs float64, nodes int) float64 {
+	if known > 0 {
+		return known
+	}
+	if nodes <= 0 {
+		return 0
+	}
+	return wallTimeSecs / float64(nodes)
+}
+
+// segmentedWindowSecs is the wall-clock span a segmented series covers, the known
+// window for anything folded out of it.
+func segmentedWindowSecs[T any, PT segPtr[T]](s *madmin.Segmented[T, PT]) float64 {
+	if s == nil {
+		return 0
+	}
+	return float64(s.Interval * len(s.Segments))
+}
+
+func fmtBytes(v float64) string { return humanize.Bytes(uint64(max(v, 0))) }
+func fmtCount(v float64) string { return humanize.Comma(int64(v)) }
+
+// fmtSecs renders a float count of seconds at a precision its magnitude justifies.
+//
+// Scheduler and GC pauses run into the tens of nanoseconds -- half of one
+// cluster's GC pauses landed under 64ns -- which roundDuration, sized for lock
+// waits, floors to "0s". Below a microsecond the nanoseconds are the measurement.
+func fmtSecs(v float64) string {
+	d := time.Duration(v * float64(time.Second))
+	if d.Abs() < time.Microsecond {
+		return d.String()
+	}
+	return roundDuration(d).String()
+}
+
+// fmtRate renders a per-node rate with the row's own renderer, so a byte counter
+// reads as "4.6 MB/s".
+//
+// Below one per second it switches to the minute, which is where the slow
+// counters live: a collector running every 54 seconds is "1.1 cycles/min", not
+// "0.0187 cycles/s". It stops there rather than reaching for the hour, because
+// the shortest thing a rate is taken over here is a 15-minute segment and an
+// hourly figure would extrapolate past the measurement.
+func fmtRate(perSec float64, render func(float64) string, unit string) string {
+	value, per := perSec, "/s"
+	if perSec > 0 && perSec < 1 {
+		value, per = perSec*60, "/min"
+	}
+	out := render(value)
+	// A count renderer floors, so a scaled rate of 1.9 would print as "1", and a
+	// slower one as "0". Bare digits is what tells that renderer apart from the
+	// ones carrying a unit, which never need the correction.
+	if value < 10 && isBareCount(out) {
+		out = strconv.FormatFloat(value, 'f', 1, 64)
+	}
+	if unit != "" {
+		out += " " + unit
+	}
+	return out + per
+}
+
+// isBareCount reports a rendering that is only digits and thousand separators,
+// and so has no unit to lose if it is reformatted.
+func isBareCount(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r != ',' && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// fmtPct renders a share. Two digits below ten percent, because the GC classes run
+// to hundredths of a percent of a busy process and "0.0%" would round several
+// distinct rows to the same nothing.
+func fmtPct(part, whole float64) string {
+	switch p := part / whole * 100; {
+	case p >= 10:
+		return fmt.Sprintf("%.1f%%", p)
+	case p >= 0.01:
+		return fmt.Sprintf("%.2f%%", p)
+	case p > 0:
+		// Scientific notation for a percentage reads worse than the answer it
+		// encodes, and the absolute value is on the same row for comparison.
+		return "<0.01%"
+	}
+	return "0%"
+}
+
+// qualify is the parenthesised tail a value carries: its per-node mean, and its
+// share of a whole where there is one. Either may be absent -- a single node has
+// no mean worth repeating -- and with neither the value stands alone.
+func qualify(nodes int, part, whole float64, render func(float64) string) string {
+	var parts []string
+	if nodes > 1 {
+		parts = append(parts, render(part/float64(nodes))+"/node")
+	}
+	if whole > 0 {
+		parts = append(parts, fmtPct(part, whole))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
 }

--- a/mnav/segments.go
+++ b/mnav/segments.go
@@ -326,13 +326,18 @@ func fmtPct(part, whole float64) string {
 	return "0%"
 }
 
-// qualify is the parenthesised tail a value carries: its per-node mean, and its
-// share of a whole where there is one. Either may be absent -- a single node has
-// no mean worth repeating -- and with neither the value stands alone.
-func qualify(nodes int, part, whole float64, render func(float64) string) string {
+// qualify is the parenthesised tail a value carries: its mean over the things
+// that reported it, and its share of a whole where there is one. Either may be
+// absent -- a single reporter has no mean worth repeating -- and with neither the
+// value stands alone.
+//
+// unit names what reporters counts, because the families do not agree: memory and
+// the Go runtime divide by nodes, while the process family divides by processes
+// and says so, since a host may run more than one.
+func qualify(reporters int, unit string, part, whole float64, render func(float64) string) string {
 	var parts []string
-	if nodes > 1 {
-		parts = append(parts, render(part/float64(nodes))+"/node")
+	if reporters > 1 {
+		parts = append(parts, render(part/float64(reporters))+"/"+unit)
 	}
 	if whole > 0 {
 		parts = append(parts, fmtPct(part, whole))

--- a/mnav/segments_test.go
+++ b/mnav/segments_test.go
@@ -127,7 +127,9 @@ func TestDuplicateSegmentKeysAcrossFamilies(t *testing.T) {
 			key: "Started", want: "11",
 		},
 		{
-			// Named by the instant a segment ends, so its keys sit one interval on.
+			// Keyed by the segment start, like every family above it. It used to
+			// name a segment by the instant it ended, putting its keys one
+			// interval on from everyone else's for the same slot.
 			name: "process",
 			node: func() MetricNode {
 				w := dupWindow[madmin.ProcessSegment, *madmin.ProcessSegment](
@@ -135,7 +137,7 @@ func TestDuplicateSegmentKeysAcrossFamilies(t *testing.T) {
 				)
 				return NewProcessLastDayNode(&w, nil, "process/last_day")
 			}(),
-			dup: "10:15Z", key: "CPU Usage", want: "11.00% average",
+			key: "CPU", want: "11.00% per process",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -368,6 +370,172 @@ func TestAPITimeSegmentLeafReportsNodeCount(t *testing.T) {
 	}
 	if got, want := leafValue(node.GetLeafData(), "Responding Nodes"), "3 nodes"; got != want {
 		t.Errorf("Responding Nodes = %q, want %q", got, want)
+	}
+}
+
+// A rate needs the window its stats cover, and WallTimeSecs is not that window:
+// Merge sums it from every source folded in, so a minute of 20 operations on 16
+// nodes carries 19200 seconds. Dividing by it read a 100k-request minute as
+// "5.2 req/sec", while the api overview page above it read the same minute
+// correctly.
+func TestAPILastMinuteRateUsesTheMinute(t *testing.T) {
+	const nodes, endpoints = 16, 20
+	api := &madmin.APIMetrics{
+		Nodes:         nodes,
+		LastMinuteAPI: make(map[string]madmin.APIStats, endpoints),
+	}
+	for i := range endpoints {
+		api.LastMinuteAPI[fmt.Sprintf("s3.Op%02d", i)] = madmin.APIStats{
+			Nodes: nodes, Requests: 5000, WallTimeSecs: 60 * nodes, RequestTimeSecs: 500,
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{API: api},
+	})
+
+	// 100,000 requests in a minute.
+	total, err := nav.Navigate("api/last_minute")
+	if err != nil {
+		t.Fatalf("navigate last_minute: %v", err)
+	}
+	if got, want := leafValue(total.GetLeafData(), "Request Rate"), "1666.7 req/sec"; got != want {
+		t.Errorf("last_minute Request Rate = %q, want %q: dividing by the summed wall time (%d s) gives %.1f",
+			got, want, 60*nodes*endpoints, 100000.0/float64(60*nodes*endpoints))
+	}
+
+	// The overview page one level up derives the same minute from the request
+	// count alone; the two must not disagree.
+	overview, err := nav.Navigate("api")
+	if err != nil {
+		t.Fatalf("navigate api: %v", err)
+	}
+	if got := leafValue(overview.GetLeafData(), "Request Rate"); !strings.Contains(got, "1666.7 req/sec") {
+		t.Errorf("api overview Request Rate = %q, want it to contain 1666.7 req/sec", got)
+	}
+
+	// A single endpoint covers the same minute, not 16 nodes' worth of it.
+	ep, err := nav.Navigate("api/last_minute/s3.Op00")
+	if err != nil {
+		t.Fatalf("navigate endpoint: %v", err)
+	}
+	if got, want := leafValue(ep.GetLeafData(), "Request Rate"), "83.3 req/sec"; got != want {
+		t.Errorf("endpoint Request Rate = %q, want %q", got, want)
+	}
+}
+
+// The same defect one level down, where only the node axis is folded: a quarter
+// hour of one endpoint on 17 nodes carries 15300 wall seconds, reading 1832
+// requests as "0.1 req/sec" while the segment listing said 122.1 req/min --
+// 2.0 req/sec -- for the very same numbers.
+func TestAPILastDayRateUsesSegmentWindow(t *testing.T) {
+	const nodes, segments = 17, 2
+	segs := make([]madmin.APIStats, segments)
+	for i := range segs {
+		segs[i] = madmin.APIStats{
+			Nodes: nodes, Requests: 1832, WallTimeSecs: 900 * nodes, RequestTimeSecs: 2512,
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{API: &madmin.APIMetrics{
+			Nodes: nodes,
+			LastDayAPI: map[string]madmin.SegmentedAPIMetrics{
+				"s3.HeadBucket": {Interval: 900, FirstTime: dupFirstTime, Segments: segs},
+			},
+		}},
+	})
+
+	// One segment covers 900 s; the folds below cover both, 1800 s for twice the
+	// requests, so every one of them lands on the same rate.
+	for _, path := range []string{
+		"api/last_day/s3.HeadBucket/" + dupKey,
+		"api/last_day/s3.HeadBucket/Total",
+		"api/last_day/s3.HeadBucket",
+		"api/last_day/_by_time/" + dupKey + "/_ALL",
+		"api/last_day",
+	} {
+		node, err := nav.Navigate(path)
+		if err != nil {
+			t.Fatalf("navigate %s: %v", path, err)
+		}
+		if got, want := leafValue(node.GetLeafData(), "Request Rate"), "2.0 req/sec"; got != want {
+			t.Errorf("%s: Request Rate = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// Since-start is the one API view with no window of its own, so the node count is
+// what gets divided back out: 3 nodes up for an hour carry 10800 wall seconds.
+func TestAPISinceStartRateDividesNodesOut(t *testing.T) {
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{API: &madmin.APIMetrics{
+			Nodes: 3,
+			SinceStart: madmin.APIStats{
+				Nodes: 3, Requests: 36000, WallTimeSecs: 3600 * 3, RequestTimeSecs: 3600,
+			},
+		}},
+	})
+	node, err := nav.Navigate("api/since_start")
+	if err != nil {
+		t.Fatalf("navigate since_start: %v", err)
+	}
+	if got, want := leafValue(node.GetLeafData(), "Request Rate"), "10.0 req/sec"; got != want {
+		t.Errorf("Request Rate = %q, want %q", got, want)
+	}
+}
+
+// Replication divides by the same field, and folds along the target axis on top
+// of the node one: two targets on 3 nodes turn an hour into 21600 seconds, which
+// reported a sixth of the real throughput and a six-hour duration.
+func TestReplicationRateUsesKnownWindow(t *testing.T) {
+	const nodes, targets = 3, 2
+	start := dupFirstTime
+	end := start.Add(time.Hour)
+	day := make([]madmin.ReplicationStats, 96)
+	for i := range day {
+		day[i] = madmin.ReplicationStats{
+			Nodes: nodes, Events: 100, Bytes: 900_000_000, WallTimeSecs: 900 * nodes,
+		}
+	}
+	rm := &madmin.ReplicationMetrics{
+		Nodes:   nodes,
+		Targets: make(map[string]madmin.ReplicationTargetStats, targets),
+	}
+	for i := range targets {
+		rm.Targets[fmt.Sprintf("peer%d:bucket", i)] = madmin.ReplicationTargetStats{
+			Nodes: nodes,
+			LastHour: madmin.ReplicationStats{
+				Nodes: nodes, StartTime: &start, EndTime: &end,
+				Events: 1000, Bytes: 1_800_000_000, WallTimeSecs: 3600 * nodes,
+			},
+			LastDay: &madmin.SegmentedReplicationStats{
+				Interval: 900, FirstTime: dupFirstTime, Segments: day,
+			},
+		}
+	}
+	nav := NewRealtimeMetricsNavigator(&madmin.RealtimeMetrics{
+		Aggregated: madmin.Metrics{Replication: rm},
+	})
+
+	// 3.6 GB over the hour, across both targets.
+	hour, err := nav.Navigate("replication/last_hour")
+	if err != nil {
+		t.Fatalf("navigate last_hour: %v", err)
+	}
+	data := hour.GetLeafData()
+	if got, want := leafValue(data, "Throughput"), "1.0 MB/s"; got != want {
+		t.Errorf("Throughput = %q, want %q: the summed wall time is %d s", got, want, 3600*nodes*targets)
+	}
+	if got, want := leafValue(data, "Duration"), "3600.0 seconds"; got != want {
+		t.Errorf("Duration = %q, want %q", got, want)
+	}
+
+	// A folded day covers its segments: 86.4 GB over 96 quarter hours, per target.
+	total, err := nav.Navigate("replication/peer0:bucket/last_day/Total")
+	if err != nil {
+		t.Fatalf("navigate last_day/Total: %v", err)
+	}
+	if got, want := leafValue(total.GetLeafData(), "Throughput"), "1.0 MB/s"; got != want {
+		t.Errorf("last_day Total Throughput = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Ensure there are per node averages for process/cpu/mem stats.

Fix various minor inconsistencies in request averages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added last-hour and last-day navigation for runtime and memory metrics.
  * Added per-segment and `_ALL` aggregate views for process, memory, and runtime statistics.
  * Runtime displays now include uptime metrics and clearer per-node summaries.

* **Bug Fixes**
  * Improved API, replication, process, and runtime rate calculations using actual reporting windows.
  * Improved per-node averages, percentage shares, cumulative counter handling, and histogram formatting.
  * Corrected time-segment labels, navigation consistency, and duration and memory formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->